### PR TITLE
Fix "NameError: name 'sys' is not defined" when icu was not installed

### DIFF
--- a/pythainlp/romanization/pyicu.py
+++ b/pythainlp/romanization/pyicu.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-import sys
 from __future__ import absolute_import,unicode_literals
+import sys
 try:
 	import icu
 except ImportError:

--- a/pythainlp/romanization/pyicu.py
+++ b/pythainlp/romanization/pyicu.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import sys
 from __future__ import absolute_import,unicode_literals
 try:
 	import icu

--- a/pythainlp/tokenize/pyicu.py
+++ b/pythainlp/tokenize/pyicu.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import sys
 from __future__ import absolute_import,print_function,unicode_literals
 from six.moves import zip
 try:

--- a/pythainlp/tokenize/pyicu.py
+++ b/pythainlp/tokenize/pyicu.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-import sys
 from __future__ import absolute_import,print_function,unicode_literals
+import sys
 from six.moves import zip
 try:
 	import icu


### PR DESCRIPTION
Almost as title says, would be required 'import sys' before 'import icu'