### PR TITLE
เพิ่มการ clean สระภาษาไทยครับ

### DIFF
--- a/example/vowel_clean.py
+++ b/example/vowel_clean.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from pythainlp.vowel_clean import vowel_clean, vowel_list_clean
+print(vowel_clean('คืืนควาาามสุุุข'))
+print(vowel_list_clean(['คืืน', 'ควาาาม', 'สุุุข']))

--- a/pythainlp/__init__.py
+++ b/pythainlp/__init__.py
@@ -21,3 +21,4 @@ from pythainlp.MetaSound import MetaSound
 from pythainlp.soundex import LK82,Udom83
 from pythainlp.util import ngrams,bigrams,trigram
 from pythainlp.keywords import find_keyword
+from pythainlp.vowel_clean import vowel_clean, vowel_list_clean

--- a/pythainlp/test/__init__.py
+++ b/pythainlp/test/__init__.py
@@ -18,6 +18,7 @@ from collections import namedtuple
 from pythainlp.collation import collation
 from pythainlp.util import normalize
 from pythainlp.summarize import summarize_text
+from pythainlp.vowel_clean import vowel_clean, vowel_list_clean
 class TestUM(unittest.TestCase):
 	"""
 	ระบบทดสอบการทำงานของโค้ดของ PyThaiNLP 1.6
@@ -104,5 +105,10 @@ class TestUM(unittest.TestCase):
 		self.assertEqual(pos_tag(word_tokenize("คุณกำลังประชุม"),engine='old'),[('คุณ', 'PPRS'), ('กำลัง', 'XVBM'), ('ประชุม', 'VACT')])
 		if sys.version_info >= (3,4):
 			self.assertEqual(str(type(pos_tag(word_tokenize("ผมรักคุณ"),engine='artagger'))),"<class 'list'>")
+	def test_vowel_clean(self):
+		self.assertEqual(vowel_list_clean(["เเม่"]), ["แม่"])
+		self.assertEqual(vowel_list_clean(["สี่เหลี่่่่่ยม"]), ["สี่เหลี่ยม"])
+		self.assertEqual(vowel_clean("สี่เหลี่่่่่ยม"), "สี่เหลี่ยม")
+		self.assertEqual(vowel_clean("มาาาาหาาาาแม่หน่อย"), "มาหาแม่หน่อย")
 if __name__ == '__main__':
     unittest.main()

--- a/pythainlp/vowel_clean/__init__.py
+++ b/pythainlp/vowel_clean/__init__.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+def vowel_list_clean(segmenteds):
+    '''
+    ใช้ clean สระ หลังการ tokenize\n
+    vowel_list_clean(segmenteds)
+    - segmenteds คือ list ของคำ
+    '''
+    output = []
+    for segmented in segmenteds:
+        segmented = vowel_replace(segmented)
+        segmented = vowel_clean(segmented)
+        output.append(segmented)
+    return output
+
+def vowel_clean(text):
+    '''
+    ใช้ clean สระ ก่อนการ tokenize\n
+    vowel_clean(text)
+    - text คือ string
+    '''
+    text = vowel_replace(text)
+    text_cleaned = ''
+    previous_chr = ''
+    for chr in text:
+        if not chr >= 'ฯ' and chr <= '์':
+            text_cleaned = text_cleaned + chr
+            previous_chr = chr
+            continue
+        if chr == previous_chr:
+            continue
+        text_cleaned = text_cleaned + chr
+        previous_chr = chr
+    return text_cleaned
+
+def vowel_replace(text):
+    '''
+    ใช้ replace สระบางตัว เช่น สระเอ 2 ตัว ให้เป็นสระแอ\n
+    vowel_replace(text)\n
+    - text คือ string ที่ต้องการ replace สระ
+    '''
+    vowel_for_replaces = [['เเ', 'แ']]
+    for mark in vowel_for_replaces:
+        text = text.replace(mark[0], mark[1])
+    return text

--- a/pythainlp/vowel_clean/__init__.py
+++ b/pythainlp/vowel_clean/__init__.py
@@ -23,12 +23,12 @@ def vowel_clean(text):
     previous_chr = ''
     for chr in text:
         if not chr >= 'ฯ' and chr <= '์':
-            text_cleaned = text_cleaned + chr
+            text_cleaned = '{}{}'.format(text_cleaned, chr)
             previous_chr = chr
             continue
         if chr == previous_chr:
             continue
-        text_cleaned = text_cleaned + chr
+        text_cleaned = '{}{}'.format(text_cleaned, chr)
         previous_chr = chr
     return text_cleaned
 


### PR DESCRIPTION
จากที่ทำ NLP สำหรับ Chatbot พบว่ามีปัญหากับการตัดคำที่มีสระหรือวรรณยุกต์เกินมา เช่น ดีีจ้าาา ซึ่งตัดได้ ["ดีีจ้าาา"] ทำให้ยากต่อการนำไปใช้ต่อ ดังนั้น ผมจึงทำ feature นี้มาเพื่อแก้ปัญหาดังกล่าว

โดย แบ่งเป็น 2 function ให้เลือกใช้ ดังนี้
1. vowel_clean ใช้สำหรับ clean สระก่อนการ tokenize เพราะ tokenizer บางตัวตัดคำโดยใช้ Dictionary
2. vowel_list_clean ใช้สำหรับ clean สระหลังจากผ่านการ tokenize มาแล้ว 

ผิดพลาดประการใดต้องขอคำแนะนำด้วยครับ