### PR TITLE
.gitignore to ignore Jupyter notebook checkpoints and macOS generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,15 @@ coverage.xml
 
 # PyBuilder
 target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# macOS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,3 @@ target/
 .Spotlight-V100
 .Trashes
 
-


### PR DESCRIPTION
Ignore files like .ipynb_checkpoints, .DS_Store, and .Spotlight*