### PR TITLE
more description about Thai consonants, letters, characters

### DIFF
--- a/docs/pythainlp-dev-thai.md
+++ b/docs/pythainlp-dev-thai.md
@@ -506,7 +506,7 @@ print(wordnet.synset("spy.n.01").lemma_names("tha"))
 #### พยัญชนะในภาษาไทย
 
 ```python
-from pythainlp import thai_alphabets
+from pythainlp import thai_consonants
 ```
 
 จะได้ str ที่มีพยัญชนะในภาษาไทยทั้งหมด

--- a/pythainlp/__init__.py
+++ b/pythainlp/__init__.py
@@ -2,7 +2,7 @@
 
 __version__ = 1.8
 
-thai_alphabets = "กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรลวศษสหฬอฮ"  # 44 chars
+thai_consonants = "กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรลวศษสหฬอฮ"  # 44 chars
 thai_vowels = "ฤฦะ\u0e31าำ\u0e34\u0e35\u0e36\u0e37\u0e38\u0e39เแโใไ\u0e45\u0e47"  # 19
 thai_tonemarks = "\u0e48\u0e49\u0e4a\u0e4b"  # 4
 
@@ -10,7 +10,8 @@ thai_tonemarks = "\u0e48\u0e49\u0e4a\u0e4b"  # 4
 # These signs can be part of a word
 thai_signs = "ฯๆ\u0e3a\u0e4c\u0e4d\u0e4e"  # 6 chars
 
-thai_letters = "".join([thai_alphabets, thai_vowels, thai_tonemarks, thai_signs])  # 73
+# Any Thai character that can be part of a word
+thai_letters = "".join([thai_consonants, thai_vowels, thai_tonemarks, thai_signs])  # 73
 
 # Thai Characters Fongman, Angkhankhu, Khomut
 # These characters are section markers
@@ -19,6 +20,7 @@ thai_punctuations = "\u0e4f\u0e5a\u0e5b"  # 3 chars
 thai_digits = "๐๑๒๓๔๕๖๗๘๙"  # 10
 thai_symbols = "฿"
 
+# All Thai characters that presented in Unicode
 thai_characters = "".join([thai_letters, thai_punctuations, thai_digits, thai_symbols])
 
 

--- a/pythainlp/tokenize/etcc.py
+++ b/pythainlp/tokenize/etcc.py
@@ -11,12 +11,12 @@ etcc(คำ)
 
 import re
 
-from pythainlp import thai_alphabets
+from pythainlp import thai_consonants
 
 _UV = ["็", "ี", "ื", "ิ"]
 _UV1 = ["ั", "ี"]
 _LV = ["ุ", "ู"]
-_C = "[" + thai_alphabets + "]"
+_C = "[" + thai_consonants + "]"
 _UV2 = "[" + "".join(["ั", "ื"]) + "]"
 
 


### PR DESCRIPTION
- rename from ```thai_alphabets``` to ```thai_consonants``` to be more accurate
- add more description about Thai consonants, letters, and characters 
- minor adjustment with no logic change