### PR TITLE
Remove "ulmfit" engine option in word_tokenize()

### DIFF
--- a/pythainlp/tokenize/__init__.py
+++ b/pythainlp/tokenize/__init__.py
@@ -32,7 +32,6 @@ def word_tokenize(
         * longest - dictionary-based, Longest Matching
         * deepcut - wrapper for deepcut, language-model-based https://github.com/rkcosmos/deepcut
         * icu - wrapper for ICU (International Components for Unicode, using PyICU), dictionary-based
-        * ulmfit - for thai2fit
         * a custom_dict can be provided for newmm, longest, and deepcut
 
     **Example**
@@ -67,10 +66,6 @@ def word_tokenize(
             segments = segment(text, custom_dict)
         else:
             segments = segment(text)
-    elif engine == "ulmfit":  # ulmfit has its own specific dictionary
-        from .newmm import segment
-
-        segments = segment(text, custom_dict=FROZEN_DICT_TRIE)
     elif engine == "icu":
         from .pyicu import segment
 

--- a/pythainlp/ulmfit/__init__.py
+++ b/pythainlp/ulmfit/__init__.py
@@ -5,21 +5,19 @@ https://github.com/cstorm125/thai2fit/
 """
 import collections
 import re
-
 from typing import List
 
 import emoji
 import numpy as np
 import torch
-
 from fastai.text import TK_REP, BaseTokenizer
 from fastai.text.transform import (
     fix_html,
+    replace_all_caps,
     rm_useless_spaces,
     spec_add_spaces,
-    replace_all_caps,
 )
-from pythainlp import word_tokenize
+from pythainlp import FROZEN_DICT_TRIE, Tokenizer
 from pythainlp.corpus import download, get_corpus_path
 from pythainlp.util import normalize as normalize_char_order
 
@@ -37,6 +35,7 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 _MODEL_NAME_LSTM = "wiki_lm_lstm"
 _ITOS_NAME_LSTM = "wiki_itos_lstm"
 
+_pythainlp_tokenizer = Tokenizer(custom_dict=FROZEN_DICT_TRIE, engine="newmm")
 
 # Download pretrained models
 def _get_path(fname: str) -> str:
@@ -69,7 +68,7 @@ class ThaiTokenizer(BaseTokenizer):
         :param str text: text to tokenize
         :return: tokenized text
         """
-        return word_tokenize(text, engine="ulmfit")
+        return _pythainlp_tokenizer.word_tokenize(text)
 
     def add_special_cases(self, toks):
         pass

--- a/pythainlp/ulmfit/__init__.py
+++ b/pythainlp/ulmfit/__init__.py
@@ -17,8 +17,8 @@ from fastai.text.transform import (
     rm_useless_spaces,
     spec_add_spaces,
 )
-from pythainlp import FROZEN_DICT_TRIE, Tokenizer
 from pythainlp.corpus import download, get_corpus_path
+from pythainlp.tokenize import FROZEN_DICT_TRIE, Tokenizer
 from pythainlp.util import normalize as normalize_char_order
 
 __all__ = [

--- a/pythainlp/word_vector/__init__.py
+++ b/pythainlp/word_vector/__init__.py
@@ -8,11 +8,14 @@ from typing import List
 
 import numpy as np
 from gensim.models import KeyedVectors
+from pythainlp import FROZEN_DICT_TRIE, Tokenizer
 from pythainlp.corpus import download as download_data
 from pythainlp.corpus import get_corpus_path
 from pythainlp.tokenize import word_tokenize
 
 WV_DIM = 300
+
+_pythainlp_tokenizer = Tokenizer(custom_dict=FROZEN_DICT_TRIE, engine="newmm")
 
 
 def _download() -> str:
@@ -82,7 +85,8 @@ def sentence_vectorizer(text: str, use_mean: bool = True):
 
     :return: sentence vector of given input text
     """
-    words = word_tokenize(text, engine="ulmfit")
+    words = _pythainlp_tokenizer.word_tokenize(text)
+
     vec = np.zeros((1, WV_DIM))
 
     for word in words:

--- a/pythainlp/word_vector/__init__.py
+++ b/pythainlp/word_vector/__init__.py
@@ -8,10 +8,9 @@ from typing import List
 
 import numpy as np
 from gensim.models import KeyedVectors
-from pythainlp import FROZEN_DICT_TRIE, Tokenizer
 from pythainlp.corpus import download as download_data
 from pythainlp.corpus import get_corpus_path
-from pythainlp.tokenize import word_tokenize
+from pythainlp.tokenize import FROZEN_DICT_TRIE, Tokenizer
 
 WV_DIM = 300
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -31,7 +31,7 @@ from pythainlp.summarize import summarize
 from pythainlp.tag import perceptron, pos_tag, pos_tag_sents, unigram
 from pythainlp.tag.locations import tag_provinces
 from pythainlp.tag.named_entity import ThaiNameTagger
-from pythainlp.tokenize import DEFAULT_DICT_TRIE, FROZEN_DICT_TRIE, Tokenizer
+from pythainlp.tokenize import DEFAULT_DICT_TRIE, Tokenizer
 from pythainlp.tokenize import deepcut as tokenize_deepcut
 from pythainlp.tokenize import (
     dict_trie,
@@ -328,7 +328,6 @@ class TestUM(unittest.TestCase):
         self.assertIsNotNone(word_tokenize("หมอนทองตากลมหูว์MBK39", engine="newmm"))
         self.assertIsNotNone(word_tokenize("หมอนทองตากลมหูว์MBK39", engine="mm"))
         self.assertIsNotNone(word_tokenize("หมอนทองตากลมหูว์MBK39", engine="longest"))
-        self.assertIsNotNone(word_tokenize("หมอนทองตากลมหูว์MBK39", engine="ulmfit"))
         self.assertIsNotNone(word_tokenize("หมอนทองตากลมหูว์MBK39", engine="icu"))
         self.assertIsNotNone(word_tokenize("หมอนทองตากลมหูว์MBK39", engine="deepcut"))
         self.assertIsNotNone(word_tokenize("หมอนทองตากลมหูว์MBK39", engine="XX"))
@@ -337,21 +336,15 @@ class TestUM(unittest.TestCase):
         self.assertIsNotNone(dict_trie(("ทดสอบ", "สร้าง", "Trie")))
         self.assertIsNotNone(dict_trie(["ทดสอบ", "สร้าง", "Trie"]))
         self.assertIsNotNone(dict_trie(thai_words()))
-        self.assertIsNotNone(dict_trie(FROZEN_DICT_TRIE))
+        self.assertIsNotNone(dict_trie(DEFAULT_DICT_TRIE))
         self.assertIsNotNone(
             dict_trie(os.path.join(_CORPUS_PATH, _THAI_WORDS_FILENAME))
         )
 
         self.assertIsNotNone(word_tokenize("รถไฟฟ้าBTS", custom_dict=DEFAULT_DICT_TRIE))
-        self.assertIsNotNone(
-            word_tokenize("ทดสอบ", engine="deepcut", custom_dict=FROZEN_DICT_TRIE)
-        )
-        self.assertIsNotNone(
-            word_tokenize("ทดสอบ", engine="XX", custom_dict=FROZEN_DICT_TRIE)
-        )
 
     def test_Tokenizer(self):
-        t_test = Tokenizer(FROZEN_DICT_TRIE)
+        t_test = Tokenizer(DEFAULT_DICT_TRIE)
         self.assertEqual(t_test.word_tokenize(""), [])
         t_test.set_tokenize_engine("longest")
         self.assertEqual(t_test.word_tokenize(None), [])

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -366,6 +366,9 @@ class TestUM(unittest.TestCase):
         self.assertIsNotNone(tokenize_deepcut.segment("ทดสอบ", DEFAULT_DICT_TRIE))
         self.assertIsNotNone(tokenize_deepcut.segment("ทดสอบ", ["ทด", "สอบ"]))
         self.assertIsNotNone(word_tokenize("ทดสอบ", engine="deepcut"))
+        self.assertIsNotNone(
+            word_tokenize("ทดสอบ", engine="deepcut", custom_dict=DEFAULT_DICT_TRIE)
+        )
 
     def test_word_tokenize_longest(self):
         self.assertEqual(longest.segment(None), [])


### PR DESCRIPTION
"ulmfit" engine option is supposed to be used internally.
Remove to avoid confusion.

See #222 for more discussion.