### PR TITLE
add option of setting data dir with an enviromental variable

### DIFF
--- a/pythainlp/tools/__init__.py
+++ b/pythainlp/tools/__init__.py
@@ -22,8 +22,8 @@ def get_pythainlp_data_path() -> str:
     """
     Return full path where PyThaiNLP keeps its (downloaded) data
     """
-    path = os.environ('PYTHAINLP_DATA_DIR',
-                      os.path.join("~", PYTHAINLP_DATA_DIR))
+    path = os.getenv('PYTHAINLP_DATA_DIR',
+                     os.path.join("~", PYTHAINLP_DATA_DIR))
     path = os.path.expanduser(path)
     if not os.path.exists(path):
         os.makedirs(path)

--- a/pythainlp/tools/__init__.py
+++ b/pythainlp/tools/__init__.py
@@ -23,7 +23,8 @@ def get_pythainlp_data_path() -> str:
     Return full path where PyThaiNLP keeps its (downloaded) data
     """
     path = os.environ('PYTHAINLP_DATA_DIR',
-                      os.path.join(os.path.expanduser("~"), PYTHAINLP_DATA_DIR))
+                      os.path.join("~", PYTHAINLP_DATA_DIR))
+    path = os.path.expanduser(path)
     if not os.path.exists(path):
         os.makedirs(path)
     return path

--- a/pythainlp/tools/__init__.py
+++ b/pythainlp/tools/__init__.py
@@ -22,7 +22,8 @@ def get_pythainlp_data_path() -> str:
     """
     Return full path where PyThaiNLP keeps its (downloaded) data
     """
-    path = os.path.join(os.path.expanduser("~"), PYTHAINLP_DATA_DIR)
+    path = os.environ('PYTHAINLP_DATA_DIR',
+                      os.path.join(os.path.expanduser("~"), PYTHAINLP_DATA_DIR))
     if not os.path.exists(path):
         os.makedirs(path)
     return path


### PR DESCRIPTION
Instead of hard-coding `PYTHAINLP_DATA_DIR`, this allows one to change the dir with an environmental variable.