### PR TITLE
Add ssg

### DIFF
--- a/pythainlp/tokenize/__init__.py
+++ b/pythainlp/tokenize/__init__.py
@@ -137,6 +137,7 @@ def subword_tokenize(text: str, engine: str = "tcc") -> List[str]:
 
     **Options for engine**
         * tcc (default) -  Thai Character Cluster (Theeramunkong et al. 2000)
+        * ssg - CRF syllable segmenter for Thai.
         * etcc - Enhanced Thai Character Cluster (Inrut et al. 2001) [In development]
     """
     if not text or not isinstance(text, str):
@@ -144,27 +145,37 @@ def subword_tokenize(text: str, engine: str = "tcc") -> List[str]:
 
     if engine == "etcc":
         from .etcc import segment
+    elif engine == "ssg":
+        from .ssg import segment
     else:  # default
         from .tcc import segment
 
     return segment(text)
 
 
-def syllable_tokenize(text: str) -> List[str]:
+def syllable_tokenize(text: str, engine: str = "default") -> List[str]:
     """
     :param str text: input string to be tokenized
+    :param str engine: syllable tokenizer
     :return: list of syllables
+
+    **Options for engine**
+        * default
+        * ssg - CRF syllable segmenter for Thai.
     """
 
     if not text or not isinstance(text, str):
         return []
 
     tokens = []
-    if text:
+    if engine == "default":
         words = word_tokenize(text)
         trie = dict_trie(dict_source=thai_syllables())
         for word in words:
             tokens.extend(word_tokenize(text=word, custom_dict=trie))
+    else:
+        from .ssg import segment
+        tokens = segment(text)
 
     return tokens
 

--- a/pythainlp/tokenize/ssg.py
+++ b/pythainlp/tokenize/ssg.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+from typing import List
+import ssg
+def segment(text: str) -> List[str]:
+    return ssg.syllable_tokenize(text)

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ extras = {
     "deepcut": ["deepcut", "keras", "tensorflow"],
     "icu": ["pyicu"],
     "ipa": ["epitran"],
+    "ssg": ["ssg"],
     "ml": ["fastai>=1.0.38", "keras", "numpy", "torch"],
     "ner": ["sklearn-crfsuite"],
     "thai2fit": ["emoji", "gensim", "numpy"],
@@ -29,6 +30,7 @@ extras = {
         "sklearn-crfsuite",
         "tensorflow",
         "torch",
+        "ssg",
     ],
 }
 

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -202,6 +202,10 @@ class TestTokenizePackage(unittest.TestCase):
             syllable_tokenize("สวัสดีชาวโลก"),
             ["สวัส", "ดี", "ชาว", "โลก"]
         )
+        self.assertEqual(
+            syllable_tokenize("แมวกินปลา", engine="ssg"),
+            ['แมว', 'กิน', 'ปลา']
+        )
 
     def test_tcc(self):
         self.assertEqual(tcc.segment(None), [])


### PR DESCRIPTION
From #237, `ssg` is CRF syllable segmenter for Thai.

GitHub : https://github.com/ponrawee/ssg

## Usage

```python
from pythainlp.tokenize import syllable_tokenize, subword_tokenize
syllable_tokenize("แมวเดินเล่นกับคน", engine="ssg")
subword_tokenize("แมวเดินเล่นกับคน", engine="ssg")
```