### PR TITLE
Automatically build/deploy documentation

### DIFF
--- a/appveyor.docs.yml
+++ b/appveyor.docs.yml
@@ -17,16 +17,17 @@ only_commits:
   message: /(build and deploy docs)/    
 
 build_script: 
-  - cd docs
+  - cd ./docs
   - sudo make html
   - echo "Done building HTML files for the branch -- $APPVEYOR_REPO_BRANCH"
-  - echo "Start cleaning the directory /tutorials"
+  - echo "Start cleaning the directory /docs/$APPVEYOR_REPO_BRANCH"
   - sudo bash ./clean_directory.sh $FTP_USER $FTP_PASSWORD $FTP_HOST $APPVEYOR_REPO_BRANCH
-  - echo "Uploading files to `thainlp.org/pythainlp/docs/$APPVEYOR_REPO_BRANCH"
+  - echo "Start Uploading files to `thainlp.org/pythainlp/docs/$APPVEYOR_REPO_BRANCH"
   - cd ./_build/html
-  - find . -type f -name "*" -print -exec curl --ftp-create-dir --ipv4 -T {} ftp://${FTP_USER}:${FTP_PASSWORD}@${FTP_HOST}/public_html/pythainlp/docs/${APPVEYOR_REPO_BRANCH}/{} \;
+  - echo "cd to ./build/html"
+  - find . -type f -name "*" -print -exec curl --ftp-create-dir --ipv4 -T {} ftp://${FTP_USER}:${FTP_PASSWORD}@${FTP_HOST}/public_html/pythainlp/docs/$APPVEYOR_REPO_BRANCH/{} \;
   - echo "Done uploading"
-  - echo "Done uploading files to -- thainlp.orgpythainlp/docs/${APPVEYOR_REPO_BRANCH}"
+  - echo "Done uploading files to -- thainlp.orgpythainlp/docs/$APPVEYOR_REPO_BRANCH"
 
 artifacts:
   - path: ./build/html

--- a/appveyor.docs.yml
+++ b/appveyor.docs.yml
@@ -17,6 +17,7 @@ only_commits:
   message: /(build and deloy docs)/    
 
 build_script: 
+  - cd docs
   - sudo make html
   - echo "Done building HTML files for the branch -- ${APPVEYOR_REPO_BRANCH}"
   - echo "Start cleaning the directory /tutorials"

--- a/appveyor.docs.yml
+++ b/appveyor.docs.yml
@@ -22,7 +22,7 @@ build_script:
   - echo "Done building HTML files for the branch -- $APPVEYOR_REPO_BRANCH"
   - echo "Start cleaning the directory /docs/$APPVEYOR_REPO_BRANCH"
   - sudo bash ./clean_directory.sh $FTP_USER $FTP_PASSWORD $FTP_HOST $APPVEYOR_REPO_BRANCH
-  - echo "Start Uploading files to `thainlp.org/pythainlp/docs/$APPVEYOR_REPO_BRANCH"
+  - echo "Start Uploading files to thainlp.org/pythainlp/docs/$APPVEYOR_REPO_BRANCH"
   - cd ./_build/html
   - echo "cd to ./build/html"
   - find . -type f -name "*" -print -exec curl --ftp-create-dir --ipv4 -T {} ftp://${FTP_USER}:${FTP_PASSWORD}@${FTP_HOST}/public_html/pythainlp/docs/$APPVEYOR_REPO_BRANCH/{} \;

--- a/appveyor.docs.yml
+++ b/appveyor.docs.yml
@@ -34,5 +34,5 @@ build_script:
   - echo "Done uploading files to -- thainlp.orgpythainlp/docs/$APPVEYOR_REPO_BRANCH"
 
 artifacts:
-  - path: ./build/html
+  - path: ./_build/html
     name: document

--- a/appveyor.docs.yml
+++ b/appveyor.docs.yml
@@ -1,5 +1,9 @@
 image: ubuntu1604
 
+branchs:
+  only:
+    - /2.*/
+    - dev
 skip_commits:
   message: /\(skip ci docs\)/     # Skip a new build if message contains '(skip ci docs)'
 

--- a/appveyor.docs.yml
+++ b/appveyor.docs.yml
@@ -19,11 +19,11 @@ only_commits:
 build_script: 
   - cd docs
   - sudo make html
-  - echo "Done building HTML files for the branch -- ${APPVEYOR_REPO_BRANCH}"
+  - echo "Done building HTML files for the branch -- $APPVEYOR_REPO_BRANCH"
   - echo "Start cleaning the directory /tutorials"
   - sudo bash ./clean_directory.sh $FTP_USER $FTP_PASSWORD $FTP_HOST $APPVEYOR_REPO_BRANCH
-  - echo "Uploading files to `thainlp.org/pythainlp/docs<version>`"
-  - cd ./build/html
+  - echo "Uploading files to `thainlp.org/pythainlp/docs/$APPVEYOR_REPO_BRANCH"
+  - cd ./_build/html
   - find . -type f -name "*" -print -exec curl --ftp-create-dir --ipv4 -T {} ftp://${FTP_USER}:${FTP_PASSWORD}@${FTP_HOST}/public_html/pythainlp/docs/${APPVEYOR_REPO_BRANCH}/{} \;
   - echo "Done uploading"
   - echo "Done uploading files to -- thainlp.orgpythainlp/docs/${APPVEYOR_REPO_BRANCH}"

--- a/appveyor.docs.yml
+++ b/appveyor.docs.yml
@@ -7,56 +7,16 @@ install:
   - sudo apt-get update && sudo apt-get install -y pandoc python3
   - sudo apt-get install -y python3-sphinx
   - sudo pip install -r requirements.txt
-  
-# configuration for staging mode
-# only build documents and upload HTML files to Appveyor's storage
--
-  only_commits:
-    message: /\(build docs\)/    
-  
-  configuration: Staging
 
-  build_script: 
-    - sudo make html
 
-    - echo "Done building HTML files for the branch -- ${APPVEYOR_REPO_BRANCH}"
-    - echo "Start cleaning the directory /tutorials"
-    - sudo bash ./clean_directory.sh $FTP_USER $FTP_PASSWORD $FTP_HOST $APPVEYOR_REPO_BRANCH
-    - echo "Uploading files to `thainlp.org/pythainlp/docs<version>`"
-    - cd ./build/html
-    - find . -type f -name "*" -print -exec curl --ftp-create-dir --ipv4 -T {} ftp://${FTP_USER}:${FTP_PASSWORD}@${FTP_HOST}/public_html/pythainlp/docs/${APPVEYOR_REPO_BRANCH}/{} \;
-    - echo "Done uploading"
-    - echo "Done uploading files to -- thainlp.orgpythainlp/docs/${APPVEYOR_REPO_BRANCH}"
-  
-  artifacts:
-    - path: ./build/html
-      name: document
-
-# configuration for deploy mode 
+# configuration for deploy mode, commit message with /(build and deloy docs)/
 # 1. build documents and upload HTML files to Appveyor's storage
 # 2. upload to thainlp.org/pythainlp/docs/<brnach_bane>
 
--
-  only_commits:
-    message: /\(build and deloy docs\)/    
-  
-  configuration: Staging
-  
-  build_script: 
-    - sudo make html
+only_commits:
+  message: /\(build and deloy docs\)/    
 
-    - echo "Done building HTML files for the branch -- ${APPVEYOR_REPO_BRANCH}"
-    - echo "Start cleaning the directory /tutorials"
-    - sudo bash ./clean_directory.sh $FTP_USER $FTP_PASSWORD $FTP_HOST $APPVEYOR_REPO_BRANCH
-    - echo "Uploading files to `thainlp.org/pythainlp/docs<version>`"
-    - cd ./build/html
-    - find . -type f -name "*" -print -exec curl --ftp-create-dir --ipv4 -T {} ftp://${FTP_USER}:${FTP_PASSWORD}@${FTP_HOST}/public_html/pythainlp/docs/${APPVEYOR_REPO_BRANCH}/{} \;
-    - echo "Done uploading"
-    - echo "Done uploading files to -- thainlp.orgpythainlp/docs/${APPVEYOR_REPO_BRANCH}"
-  
-  artifacts:
-    - path: ./build/html
-      name: document
+configuration: Deploy
 
 build_script: 
   - sudo make html
@@ -73,3 +33,19 @@ build_script:
 artifacts:
   - path: ./build/html
     name: document
+
+build_script: 
+- sudo make html
+
+- echo "Done building HTML files for the branch -- ${APPVEYOR_REPO_BRANCH}"
+- echo "Start cleaning the directory /tutorials"
+- sudo bash ./clean_directory.sh $FTP_USER $FTP_PASSWORD $FTP_HOST $APPVEYOR_REPO_BRANCH
+- echo "Uploading files to `thainlp.org/pythainlp/docs<version>`"
+- cd ./build/html
+- find . -type f -name "*" -print -exec curl --ftp-create-dir --ipv4 -T {} ftp://${FTP_USER}:${FTP_PASSWORD}@${FTP_HOST}/public_html/pythainlp/docs/${APPVEYOR_REPO_BRANCH}/{} \;
+- echo "Done uploading"
+- echo "Done uploading files to -- thainlp.orgpythainlp/docs/${APPVEYOR_REPO_BRANCH}"
+
+artifacts:
+- path: ./build/html
+  name: document

--- a/appveyor.docs.yml
+++ b/appveyor.docs.yml
@@ -14,7 +14,7 @@ install:
 # 2. upload to thainlp.org/pythainlp/docs/<brnach_bane>
 
 only_commits:
-  message: /(build and deloy docs)/    
+  message: /(build and deploy docs)/    
 
 build_script: 
   - cd docs

--- a/appveyor.docs.yml
+++ b/appveyor.docs.yml
@@ -1,0 +1,75 @@
+image: ubuntu1604
+
+skip_commits:
+  message: /\(skip ci docs\)/     # Skip a new build if message contains '(skip ci docs)'
+
+install:
+  - sudo apt-get update && sudo apt-get install -y pandoc python3
+  - sudo apt-get install -y python3-sphinx
+  - sudo pip install -r requirements.txt
+  
+# configuration for staging mode
+# only build documents and upload HTML files to Appveyor's storage
+-
+  only_commits:
+    message: /\(build docs\)/    
+  
+  configuration: Staging
+
+  build_script: 
+    - sudo make html
+
+    - echo "Done building HTML files for the branch -- ${APPVEYOR_REPO_BRANCH}"
+    - echo "Start cleaning the directory /tutorials"
+    - sudo bash ./clean_directory.sh $FTP_USER $FTP_PASSWORD $FTP_HOST $APPVEYOR_REPO_BRANCH
+    - echo "Uploading files to `thainlp.org/pythainlp/docs<version>`"
+    - cd ./build/html
+    - find . -type f -name "*" -print -exec curl --ftp-create-dir --ipv4 -T {} ftp://${FTP_USER}:${FTP_PASSWORD}@${FTP_HOST}/public_html/pythainlp/docs/${APPVEYOR_REPO_BRANCH}/{} \;
+    - echo "Done uploading"
+    - echo "Done uploading files to -- thainlp.orgpythainlp/docs/${APPVEYOR_REPO_BRANCH}"
+  
+  artifacts:
+    - path: ./build/html
+      name: document
+
+# configuration for deploy mode 
+# 1. build documents and upload HTML files to Appveyor's storage
+# 2. upload to thainlp.org/pythainlp/docs/<brnach_bane>
+
+-
+  only_commits:
+    message: /\(build and deloy docs\)/    
+  
+  configuration: Staging
+  
+  build_script: 
+    - sudo make html
+
+    - echo "Done building HTML files for the branch -- ${APPVEYOR_REPO_BRANCH}"
+    - echo "Start cleaning the directory /tutorials"
+    - sudo bash ./clean_directory.sh $FTP_USER $FTP_PASSWORD $FTP_HOST $APPVEYOR_REPO_BRANCH
+    - echo "Uploading files to `thainlp.org/pythainlp/docs<version>`"
+    - cd ./build/html
+    - find . -type f -name "*" -print -exec curl --ftp-create-dir --ipv4 -T {} ftp://${FTP_USER}:${FTP_PASSWORD}@${FTP_HOST}/public_html/pythainlp/docs/${APPVEYOR_REPO_BRANCH}/{} \;
+    - echo "Done uploading"
+    - echo "Done uploading files to -- thainlp.orgpythainlp/docs/${APPVEYOR_REPO_BRANCH}"
+  
+  artifacts:
+    - path: ./build/html
+      name: document
+
+build_script: 
+  - sudo make html
+
+  - echo "Done building HTML files for the branch -- ${APPVEYOR_REPO_BRANCH}"
+  - echo "Start cleaning the directory /tutorials"
+  - sudo bash ./clean_directory.sh $FTP_USER $FTP_PASSWORD $FTP_HOST $APPVEYOR_REPO_BRANCH
+  - echo "Uploading files to `thainlp.org/pythainlp/docs<version>`"
+  - cd ./build/html
+  - find . -type f -name "*" -print -exec curl --ftp-create-dir --ipv4 -T {} ftp://${FTP_USER}:${FTP_PASSWORD}@${FTP_HOST}/public_html/pythainlp/docs/${APPVEYOR_REPO_BRANCH}/{} \;
+  - echo "Done uploading"
+  - echo "Done uploading files to -- thainlp.orgpythainlp/docs/${APPVEYOR_REPO_BRANCH}"
+
+artifacts:
+  - path: ./build/html
+    name: document

--- a/appveyor.docs.yml
+++ b/appveyor.docs.yml
@@ -35,16 +35,16 @@ artifacts:
     name: document
 
 build_script: 
-- sudo make html
+  - sudo make html
 
-- echo "Done building HTML files for the branch -- ${APPVEYOR_REPO_BRANCH}"
-- echo "Start cleaning the directory /tutorials"
-- sudo bash ./clean_directory.sh $FTP_USER $FTP_PASSWORD $FTP_HOST $APPVEYOR_REPO_BRANCH
-- echo "Uploading files to `thainlp.org/pythainlp/docs<version>`"
-- cd ./build/html
-- find . -type f -name "*" -print -exec curl --ftp-create-dir --ipv4 -T {} ftp://${FTP_USER}:${FTP_PASSWORD}@${FTP_HOST}/public_html/pythainlp/docs/${APPVEYOR_REPO_BRANCH}/{} \;
-- echo "Done uploading"
-- echo "Done uploading files to -- thainlp.orgpythainlp/docs/${APPVEYOR_REPO_BRANCH}"
+  - echo "Done building HTML files for the branch -- ${APPVEYOR_REPO_BRANCH}"
+  - echo "Start cleaning the directory /tutorials"
+  - sudo bash ./clean_directory.sh $FTP_USER $FTP_PASSWORD $FTP_HOST $APPVEYOR_REPO_BRANCH
+  - echo "Uploading files to `thainlp.org/pythainlp/docs<version>`"
+  - cd ./build/html
+  - find . -type f -name "*" -print -exec curl --ftp-create-dir --ipv4 -T {} ftp://${FTP_USER}:${FTP_PASSWORD}@${FTP_HOST}/public_html/pythainlp/docs/${APPVEYOR_REPO_BRANCH}/{} \;
+  - echo "Done uploading"
+  - echo "Done uploading files to -- thainlp.orgpythainlp/docs/${APPVEYOR_REPO_BRANCH}"
 
 artifacts:
 - path: ./build/html

--- a/appveyor.docs.yml
+++ b/appveyor.docs.yml
@@ -14,7 +14,7 @@ install:
 # 2. upload to thainlp.org/pythainlp/docs/<brnach_bane>
 
 only_commits:
-  message: /\(build and deloy docs\)/    
+  message: /(build and deloy docs)/    
 
 build_script: 
   - sudo make html

--- a/appveyor.docs.yml
+++ b/appveyor.docs.yml
@@ -16,11 +16,8 @@ install:
 only_commits:
   message: /\(build and deloy docs\)/    
 
-configuration: Deploy
-
 build_script: 
   - sudo make html
-
   - echo "Done building HTML files for the branch -- ${APPVEYOR_REPO_BRANCH}"
   - echo "Start cleaning the directory /tutorials"
   - sudo bash ./clean_directory.sh $FTP_USER $FTP_PASSWORD $FTP_HOST $APPVEYOR_REPO_BRANCH
@@ -33,19 +30,3 @@ build_script:
 artifacts:
   - path: ./build/html
     name: document
-
-build_script: 
-  - sudo make html
-
-  - echo "Done building HTML files for the branch -- ${APPVEYOR_REPO_BRANCH}"
-  - echo "Start cleaning the directory /tutorials"
-  - sudo bash ./clean_directory.sh $FTP_USER $FTP_PASSWORD $FTP_HOST $APPVEYOR_REPO_BRANCH
-  - echo "Uploading files to `thainlp.org/pythainlp/docs<version>`"
-  - cd ./build/html
-  - find . -type f -name "*" -print -exec curl --ftp-create-dir --ipv4 -T {} ftp://${FTP_USER}:${FTP_PASSWORD}@${FTP_HOST}/public_html/pythainlp/docs/${APPVEYOR_REPO_BRANCH}/{} \;
-  - echo "Done uploading"
-  - echo "Done uploading files to -- thainlp.orgpythainlp/docs/${APPVEYOR_REPO_BRANCH}"
-
-artifacts:
-- path: ./build/html
-  name: document

--- a/docs/clean_directory.sh
+++ b/docs/clean_directory.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Delete all files and folders in the directory: /pythainlp/docs/<version>
+
+# $1 : FTP_USER
+# $2 : FTP_PASSWORD
+# $3 : FTP_HOST
+# $4 : Brnach name
+
+FTP_USER=$1
+FTP_PASSWORD=$2
+FTP_HOST=$3
+BRANCH_NAME=$4
+
+remove_all_files()
+{
+    # DIRECTORY=$1
+    echo "delete files in: $1"
+    for f in `curl  --list-only --ftp-create-dirs --ipv4 ftp://$FTP_USER:$FTP_PASSWORD@$FTP_HOST/$1/`; do
+        if [[ -d "$f" ]] || [[ "$f" = _* ]] || [[ "$f" = .doctree ]] || [[ "$f" != *"."* ]]; then
+            echo "--- deleting files in folder: $1/$f";
+            remove_all_files $1/$f
+        else
+            echo "delete a file: $f"
+            curl --ipv4 ftp://$FTP_USER:$FTP_PASSWORD@$FTP_HOST -Q "DELE $1/$f"
+        fi
+    done
+}
+
+remove_empty_folders()
+{
+
+  echo "delete empty folders in: $1"
+    for f in `curl  --list-only --ftp-create-dirs --ipv4 ftp://$FTP_USER:$FTP_PASSWORD@$FTP_HOST/$1/`; do
+        if [[ -d "$f" ]] || [[ "$f" = _* ]] || [[ "$f" = fonts ]] || [[ "$f" = pythainlp ]] || [[ "$f" = .doctree ]] || [[ "$f" != *"."* ]]; then
+            echo "--- deleting folders in: $1/$f";
+            remove_empty_folders $1/$f
+            curl --ipv4 ftp://$FTP_USER:$FTP_PASSWORD@$FTP_HOST -Q "RMD $1/$f"
+        else
+            echo "delete a folder: $f"
+            curl --ipv4 ftp://$FTP_USER:$FTP_PASSWORD@$FTP_HOST -Q "RMD $1/$f"
+        fi
+    done
+}
+
+echo "Start removing all files within 'public_html/pythainlp/docs/$BRANCH_NAME/'";
+
+remove_all_files public_html/pythainlp/docs/$BRANCH_NAME;
+
+echo "Start removing all empty folders within 'public_html/pythainlp/docs/$BRANCH_NAME/'";
+
+remove_empty_folders public_html/pythainlp/docs/$BRANCH_NAME;
+
+echo "Done";

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ try:
     current_branch = check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
     current_branch = current_branch.decode().strip()
     release = check_output(['git', 'describe', '--tags', '--always'])
-    release = release.decode().strip()
+    release = release.decode().strip().split('-')[0]
     today = check_output(['git', 'show', '-s', '--format=%ad', '--date=short'])
     today = today.decode().strip()
 except Exception:
@@ -39,7 +39,7 @@ except Exception:
     current_branch = '<unknown>'
 
 # The short X.Y version
-version = current_branch
+version = '{} </br> ({})'.format(current_branch, release)
 
 # The full version, including alpha/beta/rc tags
 release = release

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,9 +24,9 @@ curyear = datetime.today().year
 copyright = u'2017-%s, %s (Apache Software License 2.0)' % (curyear, project)
 
 # The short X.Y version
-version = '2.0'
+version = '2.1'
 # The full version, including alpha/beta/rc tags
-release = '2.0.3'
+release = '2.1.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,10 +23,24 @@ author = 'pythainlp_builders'
 curyear = datetime.today().year
 copyright = u'2017-%s, %s (Apache Software License 2.0)' % (curyear, project)
 
+# -- Get version information and date from Git ----------------------------
+
+try:
+    from subprocess import check_output
+    release = check_output(['git', 'describe', '--tags', '--always'])
+    release = release.decode().strip()
+    today = check_output(['git', 'show', '-s', '--format=%ad', '--date=short'])
+    today = today.decode().strip()
+except Exception:
+    release = '<unknown>'
+    today = '<unknown date>'
+
+
 # The short X.Y version
-version = '2.1'
+version = release
+
 # The full version, including alpha/beta/rc tags
-release = '2.1.0'
+# release = '2.1.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,8 @@ copyright = u'2017-%s, %s (Apache Software License 2.0)' % (curyear, project)
 
 try:
     from subprocess import check_output
+    current_branch = check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
+    current_branch = current_branch.decode().strip()
     release = check_output(['git', 'describe', '--tags', '--always'])
     release = release.decode().strip()
     today = check_output(['git', 'show', '-s', '--format=%ad', '--date=short'])
@@ -34,13 +36,13 @@ try:
 except Exception:
     release = '<unknown>'
     today = '<unknown date>'
-
+    current_branch = '<unknown>'
 
 # The short X.Y version
-version = release
+version = current_branch
 
 # The full version, including alpha/beta/rc tags
-# release = '2.1.0'
+release = release
 
 
 # -- General configuration ---------------------------------------------------
@@ -102,7 +104,9 @@ html_theme = 'sphinx_rtd_theme'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    'display_version': True,
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
Add new feature to automatically build Sphinx documentation and upload to thainlp.org/pythainlp/docs/<branch_name>


Any commits in  `dev` or `2.x` with the commit message that contains `(build and deploy docs)` will trigger the Appveyor CI server (project id: [pythainlp-wdor1](https://ci.appveyor.com/project/wannaphongcom/pythainlp-wdor1))  to

1) Build the Sphinx documentation with `make html`
2) Save generated files as build artifacts (https://ci.appveyor.com/project/wannaphongcom/pythainlp-wdor1/build/artifacts)
3) Upload generated files to the thainlp.org (thainlp.org/pythainlp/docs/<base_branch_name>) via FTP


