### PR TITLE
Remove racing condition in making pythainlp data directory

### DIFF
--- a/pythainlp/tools/__init__.py
+++ b/pythainlp/tools/__init__.py
@@ -47,8 +47,7 @@ def get_pythainlp_data_path() -> str:
     path = os.getenv('PYTHAINLP_DATA_DIR',
                      os.path.join("~", PYTHAINLP_DATA_DIR))
     path = os.path.expanduser(path)
-    if not os.path.exists(path):
-        os.makedirs(path)
+    os.makedirs(path, exist_ok=True)
     return path
 
 


### PR DESCRIPTION
### Rationale

To my understanding, PyThaiNLP will always create a new data directory if it does not yet exist. In the original code, the non-existence of the data directory is check before the creation of the directory is attempted. Although this might work fine in single-processing environment, but it will fail arbitrarily if this code is deployed under multi-processing environment. That is, it is possible that two processes reach line 51 (of the original code) around the same time (passing the if-check), but one of the processes will fail before the other will create the same directory before it. This is called **racing condition**.

### Solution

This patch will solve such issue by simply use `exist_ok=True` flag to ignore errors when the directory already exists.

Please review.