### PR TITLE
pythainlp.spell: Fix type annotations, docstring spellings, etc.

### DIFF
--- a/pythainlp/spell/__init__.py
+++ b/pythainlp/spell/__init__.py
@@ -12,18 +12,18 @@ __all__ = ["DEFAULT_SPELL_CHECKER", "correct", "spell", "NorvigSpellChecker"]
 
 def spell(word: str, engine: str = "pn") -> List[str]:
     """
-    This function provides a list of possible correct spelling of
-    the given word. The list of words are from the words in
-    the dictionary that have edit distance of 1 or 2. The result
-    is a  list of word by sorted word occurence in the spelling dictionary
-    in descending order.
+    Provides a list of possible correct spelling of the given word.
+    The list of words are from the words in the dictionary
+    that incurs an edit distance value of 1 or 2.
+    The result is a list of words sorted by their occurrences
+    in the spelling dictionary in descending order.
 
-    :param str word: word to check spelling
+    :param str word: Word to spell check
     :param str engine:
         * *pn* - Peter Norvig's algorithm [norvig_spellchecker]_ (default)
 
     :return: list of possible correct words within 1 or 2 edit distance and
-             sorted by frequency of word occurence in the spelling dictionary
+             sorted by frequency of word occurrences in the spelling dictionary
              in descending order.
     :rtype: list[str]
 
@@ -54,8 +54,8 @@ def spell(word: str, engine: str = "pn") -> List[str]:
 
 def correct(word: str, engine: str = "pn") -> str:
     """
-    This function corrects spelling of the given word
-    by returning the correctly spelled word.
+    Corrects the spelling of the given word by returning
+    the correctly spelled word.
 
     :param str word: word to correct spelling
     :param str engine:

--- a/pythainlp/spell/pn.py
+++ b/pythainlp/spell/pn.py
@@ -8,7 +8,7 @@ Based on Peter Norvig's Python code from http://norvig.com/spell-correct.html
 """
 from collections import Counter
 from string import digits
-from typing import Callable, Iterable, ItemsView, List, Set, Tuple
+from typing import Callable, Iterable, ItemsView, List, Optional, Set, Tuple
 
 from pythainlp import thai_digits, thai_letters
 from pythainlp.corpus import tnc
@@ -77,7 +77,7 @@ class NorvigSpellChecker:
         min_freq: int = 2,
         min_len: int = 2,
         max_len: int = 40,
-        dict_filter: Callable[[str], bool] = _is_thai_and_not_num,
+        dict_filter: Optional[Callable[[str], bool]] = _is_thai_and_not_num,
     ):
         """
         Initializes Peter Norvig's spell checker object.
@@ -274,7 +274,7 @@ class NorvigSpellChecker:
             ['กะปิ', 'กระบิ']
         """
         if not word:
-            return []
+            return [""]
 
         candidates = (
             self.known([word])

--- a/tests/test_spell.py
+++ b/tests/test_spell.py
@@ -11,15 +11,26 @@ from pythainlp.spell import NorvigSpellChecker, correct, spell
 class TestSpellPackage(unittest.TestCase):
 
     def test_spell(self):
-        self.assertEqual(spell(None), "")
-        self.assertEqual(spell(""), "")
-        self.assertIsNotNone(spell("เน้ร"))
-        self.assertIsNotNone(spell("เกสมร์"))
+        self.assertEqual(spell(None), [""])
+        self.assertEqual(spell(""), [""])
 
+        result = spell("เน้ร")
+        self.assertIsInstance(result, list)
+        self.assertGreater(len(result), 0)
+
+        result = spell("เกสมร์")
+        self.assertIsInstance(result, list)
+        self.assertGreater(len(result), 0)
+
+    def test_word_correct(self):
         self.assertEqual(correct(None), "")
         self.assertEqual(correct(""), "")
-        self.assertIsNotNone(correct("ทดสอง"))
 
-        checker = NorvigSpellChecker(dict_filter="")
-        self.assertIsNotNone(checker.dictionary())
+        result = correct("ทดสอง")
+        self.assertIsInstance(result, str)
+        self.assertNotEqual(result, "")
+
+    def test_norvig_spell_checker(self):
+        checker = NorvigSpellChecker(dict_filter=None)
+        self.assertTrue(len(checker.dictionary()) > 0)
         self.assertGreaterEqual(checker.prob("มี"), 0)


### PR DESCRIPTION
Three main improvements:
1. Fixed some mismatched type annotations in the original code
2. Corrected the spelling, ironically, of some words in this subpackage. (I also took some liberty of modifying some docstrings to make it clearer.)
3. Rewrote some lines of Python code that could obviously be improved or corrected.

Please review.