### PR TITLE
Optimize keyboard layout switching translation code & digits translation

### DIFF
--- a/pythainlp/util/digitconv.py
+++ b/pythainlp/util/digitconv.py
@@ -105,6 +105,7 @@ def arabic_digit_to_thai_digit(text: str) -> str:
     if not text or not isinstance(text, str):
         return ""
 
+    # Convert Arabic to Thai numerals
     return text.translate(_arabic_thai_translate_table)
 
 
@@ -116,7 +117,9 @@ def digit_to_text(text: str) -> str:
     if not text or not isinstance(text, str):
         return ""
 
+    # Convert Thai numerals to Arabic
     text = text.translate(_thai_arabic_translate_table)
+    # Spell out Arabic numerals in Thai text
     text = text.translate(_digit_spell_translate_table)
     return text
 

--- a/pythainlp/util/digitconv.py
+++ b/pythainlp/util/digitconv.py
@@ -55,6 +55,10 @@ _spell_digit = {
     "เก้า": "9",
 }
 
+_arabic_thai_translate_table = str.maketrans(_arabic_thai)
+_thai_arabic_translate_table = str.maketrans(_thai_arabic)
+_digit_spell_translate_table = str.maketrans(_digit_spell)
+
 
 def thai_digit_to_arabic_digit(text: str) -> str:
     """
@@ -77,14 +81,7 @@ def thai_digit_to_arabic_digit(text: str) -> str:
     if not text or not isinstance(text, str):
         return ""
 
-    newtext = []
-    for ch in text:
-        if ch in _thai_arabic:
-            newtext.append(_thai_arabic[ch])
-        else:
-            newtext.append(ch)
-
-    return "".join(newtext)
+    return text.translate(_thai_arabic_translate_table)
 
 
 def arabic_digit_to_thai_digit(text: str) -> str:
@@ -108,14 +105,7 @@ def arabic_digit_to_thai_digit(text: str) -> str:
     if not text or not isinstance(text, str):
         return ""
 
-    newtext = []
-    for ch in text:
-        if ch in _arabic_thai:
-            newtext.append(_arabic_thai[ch])
-        else:
-            newtext.append(ch)
-
-    return "".join(newtext)
+    return text.translate(_arabic_thai_translate_table)
 
 
 def digit_to_text(text: str) -> str:
@@ -126,17 +116,9 @@ def digit_to_text(text: str) -> str:
     if not text or not isinstance(text, str):
         return ""
 
-    newtext = []
-    for ch in text:
-        if ch in _thai_arabic:
-            ch = _thai_arabic[ch]
-
-        if ch in _digit_spell:
-            newtext.append(_digit_spell[ch])
-        else:
-            newtext.append(ch)
-
-    return "".join(newtext)
+    text = text.translate(_thai_arabic_translate_table)
+    text = text.translate(_digit_spell_translate_table)
+    return text
 
 
 def text_to_arabic_digit(text: str) -> str:

--- a/pythainlp/util/keyboard.py
+++ b/pythainlp/util/keyboard.py
@@ -100,13 +100,17 @@ EN_TH_KEYB_PAIRS = {
 
 TH_EN_KEYB_PAIRS = {v: k for k, v in EN_TH_KEYB_PAIRS.items()}
 
+EN_TH_TRANSLATE_TABLE = str.maketrans(EN_TH_KEYB_PAIRS)
+TH_EN_TRANSLATE_TABLE = str.maketrans(TH_EN_KEYB_PAIRS)
+
 
 def eng_to_thai(text: str) -> str:
     """
-    Correct text in one language that is incorrectly-typed with
-    a keyboard layout in another language. (type Thai with English keyboard)
+    Corrects the given text that was incorrectly typed using English-US
+    Qwerty keyboard layout to the originally intended keyboard layout
+    that is the Thai Kedmanee keyboard.
 
-    :param str text: incorrect input (type Thai with English keyboard)
+    :param str text: incorrect text input (type Thai with English keyboard)
     :return: Thai text where incorrect typing with
              a keyboard layout is corrected
     :rtype: str
@@ -120,18 +124,16 @@ def eng_to_thai(text: str) -> str:
         >>> eng_to_thai("Tok8kicsj'xitgmLwmp")
         ธนาคารแห่งประเทศไทย
     """
-
-    return "".join(
-        [EN_TH_KEYB_PAIRS[ch] if (ch in EN_TH_KEYB_PAIRS) else ch for ch in text]
-    )
+    return text.translate(EN_TH_TRANSLATE_TABLE)
 
 
 def thai_to_eng(text: str) -> str:
     """
-    Correct text in one language that is incorrectly-typed with
-    a keyboard layout in another language. (type Thai with English keyboard)
+    Corrects the given text that was incorrectly typed using Thai Kedmanee
+    keyboard layout to the originally intended keyboard layout
+    that is the English-US Qwerty keyboard.
 
-    :param str text: incorrect input (type English with Thai keyboard)
+    :param str text: incorrect text input (type English with Thai keyboard)
     :return: English text where incorrect typing with
              a keyboard layout is corrected
     :rtype: str
@@ -145,6 +147,4 @@ def thai_to_eng(text: str) -> str:
         >>> thai_to_eng("ฺฟืา นด ธ้ฟรสฟืก")
         'Bank of Thailand'
     """
-    return "".join(
-        [TH_EN_KEYB_PAIRS[ch] if (ch in TH_EN_KEYB_PAIRS) else ch for ch in text]
-    )
+    return text.translate(TH_EN_TRANSLATE_TABLE)


### PR DESCRIPTION
### `util.keyboard`

The modified source file involves code which convert texts back and forth between English-US QWERTY layout and Thai Kedmanee layout. 

Two main changes are introduced:
1. Instead of manually applying mapping to each character, `str.maketrans` and `str.translate` are deployed. The behavior of functions `eng_to_thai` and `thai_to_eng` do not change whatsoever, but this new approach should yield a slightly better code performance.
2. Docstrings are modified to clarify that the conversion happens between two specific keyboard layouts, not between two languages. I guess we can create an issue to discuss and resolve this.

### `util.digitconv`

Similar to 1. above (for better performance).