### PR TITLE
Fix "ใน" correction when pass numeric type into correct function in spell module

### DIFF
--- a/pythainlp/spell/pn.py
+++ b/pythainlp/spell/pn.py
@@ -320,11 +320,8 @@ class NorvigSpellChecker:
             return word
         except ValueError:
             pass
-            
 
         return self.spell(word)[0]
-
-    
 
 
 DEFAULT_SPELL_CHECKER = NorvigSpellChecker()

--- a/pythainlp/spell/pn.py
+++ b/pythainlp/spell/pn.py
@@ -311,7 +311,20 @@ class NorvigSpellChecker:
         if not word:
             return ""
 
+        # Check for numeric type
+        try:
+            if "." in word:
+                float(word)
+            else:
+                int(word)
+            return word
+        except ValueError:
+            pass
+            
+
         return self.spell(word)[0]
+
+    
 
 
 DEFAULT_SPELL_CHECKER = NorvigSpellChecker()

--- a/tests/test_spell.py
+++ b/tests/test_spell.py
@@ -25,6 +25,9 @@ class TestSpellPackage(unittest.TestCase):
     def test_word_correct(self):
         self.assertEqual(correct(None), "")
         self.assertEqual(correct(""), "")
+        self.assertEqual(correct("1"), "1")
+        self.assertEqual(correct("56"), "56")
+        self.assertEqual(correct("1.01"), "1.01")
 
         result = correct("ทดสอง")
         self.assertIsInstance(result, str)

--- a/tests/test_spell.py
+++ b/tests/test_spell.py
@@ -26,9 +26,10 @@ class TestSpellPackage(unittest.TestCase):
         self.assertEqual(correct(None), "")
         self.assertEqual(correct(""), "")
         self.assertEqual(correct("1"), "1")
+        self.assertEqual(correct("05"), "05")
         self.assertEqual(correct("56"), "56")
         self.assertEqual(correct("1.01"), "1.01")
-
+        
         result = correct("ทดสอง")
         self.assertIsInstance(result, str)
         self.assertNotEqual(result, "")

--- a/tests/test_spell.py
+++ b/tests/test_spell.py
@@ -29,7 +29,7 @@ class TestSpellPackage(unittest.TestCase):
         self.assertEqual(correct("05"), "05")
         self.assertEqual(correct("56"), "56")
         self.assertEqual(correct("1.01"), "1.01")
-        
+
         result = correct("ทดสอง")
         self.assertIsInstance(result, str)
         self.assertNotEqual(result, "")


### PR DESCRIPTION
I've added the try-catch block for checking the numeric type before calling spell method.

        if not word:
            return ""
        # Check for numeric type
        try:
            if "." in word:
                float(word)
            else:
                int(word)
            return word
        except ValueError:
            pass
        return self.spell(word)[0]

