### PR TITLE
Added docs on PYTHAINLP_DATA_DIR environ variable

### DIFF
--- a/docs/notes/installation.rst
+++ b/docs/notes/installation.rst
@@ -1,5 +1,5 @@
 Installation
-=====================================
+============
 
 For stable version::
 
@@ -43,3 +43,15 @@ Note for installation on Windows:
     - This will take some time and need a set of build tools to be installed in your system, for example Microsoft Visual C++ Compiler. It also requires some technical skills on how things are getting built on Windows system, as you may need to configure some environment variables to accommodate the build process.
     - For PyICU, before the installation, you have to set ``ICU_VERSION`` environment variable to ICU version in your system. For example, ``set ICU_VERSION=62.1``.
     - This approach is obviously take more time and effort, but the good side is the library will be optimized for your system. This could mean a better performance.
+
+
+Runtime Configurations
+----------------------
+
+.. envvar:: PYTHAINLP_DATA_DIR
+
+   This environment variable specifies the location where the downloaded data
+   and the corpus database information are stored. If this directory
+   does not exist, PyThaiNLP will automatically create a new one.
+   By default, it is specified to the directory called ``pythainlp-data``
+   within the home directory.

--- a/pythainlp/tools/__init__.py
+++ b/pythainlp/tools/__init__.py
@@ -35,8 +35,8 @@ def get_pythainlp_data_path() -> str:
     Returns the full path where PyThaiNLP keeps its (downloaded) data.
     If the directory does not yet exist, it will be created.
     The path can be specified through the environment variable
-    :envvar:`PYTHAINLP_DATA_DIR`. By default, a directory within
-    the home directory is used.
+    :envvar:`PYTHAINLP_DATA_DIR`. By default, `~/pythainlp-data`
+    will be used.
 
     :return: full path of directory for :mod:`pythainlp` downloaded data
     :rtype: str

--- a/pythainlp/tools/__init__.py
+++ b/pythainlp/tools/__init__.py
@@ -32,8 +32,11 @@ def get_full_data_path(path: str) -> str:
 
 def get_pythainlp_data_path() -> str:
     """
-    This function returns full path where PyThaiNLP keeps its
-    (downloaded) data
+    Returns the full path where PyThaiNLP keeps its (downloaded) data.
+    If the directory does not yet exist, it will be created.
+    The path can be specified through the environment variable
+    :envvar:`PYTHAINLP_DATA_DIR`. By default, a directory within
+    the home directory is used.
 
     :return: full path of directory for :mod:`pythainlp` downloaded data
     :rtype: str


### PR DESCRIPTION
It would be great to document the behavior of the `PYTHAINLP_DATA_DIR` environment variable (which lies deep in the code). This will enable users of this library to discover that they may configure the location from `~/pythainlp-data` to whatever they wish (should also be useful in the context of application containerization, such as with Docker).

This pull requests makes two changes, each at the following locations:
1. In the docstring of the function `get_pythainalp_data_path` in `pythainlp.tools`;
2. In the installation page of the Sphinx doc.