### PR TITLE
More unit tests

### DIFF
--- a/pythainlp/corpus/__init__.py
+++ b/pythainlp/corpus/__init__.py
@@ -44,8 +44,9 @@ def corpus_db_path() -> str:
 def get_corpus_db_detail(name: str) -> dict:
     db = TinyDB(corpus_db_path())
     query = Query()
-
     res = db.search(query.name == name)
+    db.close()
+
     if res:
         return res[0]
     else:
@@ -281,6 +282,7 @@ def remove(name: str) -> bool:
     db = TinyDB(corpus_db_path())
     query = Query()
     data = db.search(query.name == name)
+    db.close()
 
     if data:
         path = get_corpus_path(name)

--- a/pythainlp/corpus/__init__.py
+++ b/pythainlp/corpus/__init__.py
@@ -282,14 +282,15 @@ def remove(name: str) -> bool:
     db = TinyDB(corpus_db_path())
     query = Query()
     data = db.search(query.name == name)
-    db.close()
 
     if data:
         path = get_corpus_path(name)
         os.remove(path)
         db.remove(query.name == name)
+        db.close()
         return True
 
+    db.close()
     return False
 
 

--- a/pythainlp/tokenize/attacut.py
+++ b/pythainlp/tokenize/attacut.py
@@ -5,11 +5,11 @@ Wrapper for AttaCut - Fast and Reasonably Accurate Word Tokenizer for Thai
 """
 from typing import List
 
-import attacut
+from attacut import tokenize
 
 
 def segment(text: str) -> List[str]:
     if not text or not isinstance(text, str):
         return []
 
-    return attacut.tokenize(text)
+    return tokenize(text)

--- a/pythainlp/tokenize/deepcut.py
+++ b/pythainlp/tokenize/deepcut.py
@@ -9,7 +9,7 @@ User need to install deepcut (and its dependency: tensorflow) by themselves.
 
 from typing import List, Union
 
-import deepcut
+from deepcut import tokenize
 
 from .trie import Trie
 
@@ -22,6 +22,6 @@ def segment(text: str, custom_dict: Union[Trie, List[str], str] = None) -> List[
         if isinstance(custom_dict, Trie):
             custom_dict = list(custom_dict)
 
-        return deepcut.tokenize(text, custom_dict)
+        return tokenize(text, custom_dict)
 
-    return deepcut.tokenize(text)
+    return tokenize(text)

--- a/pythainlp/tokenize/ssg.py
+++ b/pythainlp/tokenize/ssg.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 from typing import List
 
-import ssg
+from ssg import syllable_tokenize
 
 
 def segment(text: str) -> List[str]:
     if not text or not isinstance(text, str):
         return []
 
-    return ssg.syllable_tokenize(text)
+    return syllable_tokenize(text)

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -35,10 +35,12 @@ class TestCorpusPackage(unittest.TestCase):
         self.assertIsNotNone(thai_words())
         self.assertIsNotNone(thai_female_names())
         self.assertIsNotNone(thai_male_names())
+        self.assertEqual(get_corpus_db_detail("XXX"), {})
         self.assertIsNone(download("test"))
         self.assertIsNone(download("test", force=True))
         self.assertIsNotNone(get_corpus_db_detail("test"))
         self.assertIsNotNone(remove("test"))
+        self.assertFalse(remove("test"))
 
     def test_tnc(self):
         self.assertIsNotNone(tnc.word_freqs())
@@ -48,6 +50,7 @@ class TestCorpusPackage(unittest.TestCase):
 
     def test_wordnet(self):
         self.assertIsNotNone(wordnet.langs())
+        self.assertTrue("tha" in wordnet.langs())
 
         self.assertEqual(
             wordnet.synset("spy.n.01").lemma_names("tha"), ["สปาย", "สายลับ"]
@@ -68,6 +71,9 @@ class TestCorpusPackage(unittest.TestCase):
         )
         self.assertEqual(
             wordnet.wup_similarity(bird, mouse), bird.wup_similarity(mouse)
+        )
+        self.assertEqual(
+            wordnet.lch_similarity(bird, mouse), bird.lch_similarity(mouse)
         )
 
         cat_key = wordnet.synsets("แมว")[0].lemmas()[0].key()

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -224,18 +224,30 @@ class TestTokenizePackage(unittest.TestCase):
     def test_subword_tokenize(self):
         self.assertEqual(subword_tokenize(None), [])
         self.assertEqual(subword_tokenize(""), [])
+
         self.assertIsNotNone(subword_tokenize("สวัสดีดาวอังคาร", engine="tcc"))
+        self.assertFalse(
+            "า" in subword_tokenize("สวัสดีดาวอังคาร", engine="tcc")
+        )
 
         self.assertEqual(subword_tokenize(None, engine="etcc"), [])
         self.assertEqual(subword_tokenize("", engine="etcc"), [])
         self.assertIsNotNone(
             subword_tokenize("สวัสดิีดาวอังคาร", engine="etcc")
         )
+        self.assertFalse(
+            "า" in subword_tokenize("สวัสดีดาวอังคาร", engine="etcc")
+        )
         self.assertIsNotNone(subword_tokenize("เบียร์สิงห์", engine="etcc"))
 
         self.assertEqual(subword_tokenize(None, engine="ssg"), [])
         self.assertEqual(subword_tokenize("", engine="ssg"), [])
-        self.assertTrue("ดาว" in subword_tokenize("สวัสดีดาวอังคาร", engine="ssg"))
+        self.assertTrue(
+            "ดาว" in subword_tokenize("สวัสดีดาวอังคาร", engine="ssg")
+        )
+        self.assertFalse(
+            "า" in subword_tokenize("สวัสดีดาวอังคาร", engine="ssg")
+        )
 
     def test_syllable_tokenize(self):
         self.assertEqual(syllable_tokenize(None), [])
@@ -243,12 +255,14 @@ class TestTokenizePackage(unittest.TestCase):
         self.assertEqual(
             syllable_tokenize("สวัสดีชาวโลก"), ["สวัส", "ดี", "ชาว", "โลก"]
         )
+        self.assertFalse("า" in syllable_tokenize("สวัสดีชาวโลก"))
 
         self.assertEqual(syllable_tokenize(None, engine="ssg"), [])
         self.assertEqual(syllable_tokenize("", engine="ssg"), [])
         self.assertEqual(
             syllable_tokenize("แมวกินปลา", engine="ssg"), ["แมว", "กิน", "ปลา"]
         )
+        self.assertFalse("า" in syllable_tokenize("แมวกินปลา", engine="etcc"))
 
     def test_tcc(self):
         self.assertEqual(tcc.segment(None), [])

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -78,7 +78,7 @@ class TestTokenizePackage(unittest.TestCase):
             word_tokenize("รถไฟฟ้าBTS", custom_dict=DEFAULT_DICT_TRIE)
         )
 
-        with self.assertRaises(DeprecationWarning):
+        with self.assertWarns(DeprecationWarning):
             dict_word_tokenize("เลิกใช้แล้ว")
 
     def test_Tokenizer(self):

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -26,9 +26,6 @@ from pythainlp.tokenize import (
 
 
 class TestTokenizePackage(unittest.TestCase):
-    def test_dict_word_tokenize(self):
-        self.assertEqual(dict_word_tokenize(""), [])
-
     def test_etcc(self):
         self.assertEqual(etcc.segment(""), "")
         self.assertIsInstance(etcc.segment("คืนความสุข"), list)
@@ -80,6 +77,9 @@ class TestTokenizePackage(unittest.TestCase):
         self.assertIsNotNone(
             word_tokenize("รถไฟฟ้าBTS", custom_dict=DEFAULT_DICT_TRIE)
         )
+
+        with self.assertRaises(DeprecationWarning):
+            dict_word_tokenize("เลิกใช้แล้ว")
 
     def test_Tokenizer(self):
         t_test = Tokenizer(DEFAULT_DICT_TRIE)

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -59,27 +59,34 @@ class TestTokenizePackage(unittest.TestCase):
             word_tokenize("หมอนทองตากลมหูว์MBK39", engine="deepcut")
         )
         self.assertIsNotNone(
-            word_tokenize("หมอนทองตากลมหูว์MBK39", engine="XX")
-        )
-        self.assertIsNotNone(
             word_tokenize("หมอนทองตากลมหูว์MBK39", engine="attacut")
         )
+        self.assertIsNotNone(
+            word_tokenize("หมอนทองตากลมหูว์MBK39", engine="XX")
+        )  # XX engine is not existed
 
         self.assertIsNotNone(dict_trie(()))
         self.assertIsNotNone(dict_trie(("ทดสอบ", "สร้าง", "Trie")))
         self.assertIsNotNone(dict_trie(["ทดสอบ", "สร้าง", "Trie"]))
+        self.assertIsNotNone(dict_trie({"ทดสอบ", "สร้าง", "Trie"}))
         self.assertIsNotNone(dict_trie(thai_words()))
         self.assertIsNotNone(dict_trie(DEFAULT_DICT_TRIE))
         self.assertIsNotNone(
             dict_trie(os.path.join(_CORPUS_PATH, _THAI_WORDS_FILENAME))
         )
 
-        self.assertIsNotNone(
-            word_tokenize("รถไฟฟ้าBTS", custom_dict=DEFAULT_DICT_TRIE)
+        self.assertTrue(
+            "ไฟ" in word_tokenize("รถไฟฟ้า", custom_dict=dict_trie(["ไฟ"]))
         )
 
-        with self.assertWarns(DeprecationWarning):
-            dict_word_tokenize("เลิกใช้แล้ว")
+        # Commented out until this unittest bug get fixed:
+        # https://bugs.python.org/issue29620
+        # with self.assertWarns(DeprecationWarning):
+        #     dict_word_tokenize("เลิกใช้แล้ว", custom_dict=DEFAULT_DICT_TRIE)
+        self.assertEqual(
+            word_tokenize("รถไฟฟ้า", custom_dict=dict_trie(["ไฟ"])),
+            dict_word_tokenize("รถไฟฟ้า", custom_dict=dict_trie(["ไฟ"])),
+        )
 
     def test_Tokenizer(self):
         t_test = Tokenizer(DEFAULT_DICT_TRIE)

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -235,7 +235,7 @@ class TestTokenizePackage(unittest.TestCase):
 
         self.assertEqual(subword_tokenize(None, engine="ssg"), [])
         self.assertEqual(subword_tokenize("", engine="ssg"), [])
-        self.assertIsNotNone(subword_tokenize("สวัสดีดาวอังคาร", engine="ssg"))
+        self.assertTrue("ดาว" in subword_tokenize("สวัสดีดาวอังคาร", engine="ssg"))
 
     def test_syllable_tokenize(self):
         self.assertEqual(syllable_tokenize(None), [])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -243,7 +243,9 @@ class TestUtilPackage(unittest.TestCase):
     def test_delete_tone(self):
         self.assertEqual(delete_tone("จิ้น"), "จิน")
         self.assertEqual(delete_tone("เก๋า"), "เกา")
-        self.assertEqual(delete_tone("จิ้น"), deletetone("จิ้น"))
+
+        with self.assertRaises(DeprecationWarning):
+            deletetone("จิ้น")
 
     def test_normalize(self):
         self.assertEqual(normalize("เเปลก"), "แปลก")
@@ -271,7 +273,6 @@ class TestUtilPackage(unittest.TestCase):
         self.assertEqual(isthai("(ต.ค.)", ignore_chars=".()"), True)
 
     def test_is_native_thai(self):
-        self.assertEqual(is_native_thai("เลข"), thaicheck("เลข"))
         self.assertEqual(is_native_thai(None), False)
         self.assertEqual(is_native_thai(""), False)
         self.assertEqual(is_native_thai("116"), False)
@@ -291,3 +292,6 @@ class TestUtilPackage(unittest.TestCase):
         self.assertEqual(is_native_thai("เลข"), False)
         self.assertEqual(is_native_thai("เทเวศน์"), False)
         self.assertEqual(is_native_thai("เทเวศร์"), False)
+
+        with self.assertRaises(DeprecationWarning):
+            thaicheck("เลข")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -244,8 +244,11 @@ class TestUtilPackage(unittest.TestCase):
         self.assertEqual(delete_tone("จิ้น"), "จิน")
         self.assertEqual(delete_tone("เก๋า"), "เกา")
 
-        with self.assertWarns(DeprecationWarning):
-            deletetone("จิ้น")
+        # Commented out until this unittest bug get fixed:
+        # https://bugs.python.org/issue29620
+        # with self.assertWarns(DeprecationWarning):
+        #     deletetone("จิ้น")
+        self.assertEqual(deletetone("จิ้น"), delete_tone("จิ้น"))
 
     def test_normalize(self):
         self.assertEqual(normalize("เเปลก"), "แปลก")
@@ -293,5 +296,8 @@ class TestUtilPackage(unittest.TestCase):
         self.assertEqual(is_native_thai("เทเวศน์"), False)
         self.assertEqual(is_native_thai("เทเวศร์"), False)
 
-        with self.assertWarns(DeprecationWarning):
-            thaicheck("เลข")
+        # Commented out until this unittest bug get fixed:
+        # https://bugs.python.org/issue29620
+        # with self.assertWarns(DeprecationWarning):
+        #     thaicheck("เลข")
+        self.assertEqual(thaicheck("เลข"), is_native_thai("เลข"))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -168,10 +168,10 @@ class TestUtilPackage(unittest.TestCase):
     # ### pythainlp.util.thai_time
 
     def test_thai_time(self):
+        self.assertEqual(thai_time("8:17"), thai_time("08:17"))
         self.assertEqual(thai_time("8:17"), "แปดนาฬิกาสิบเจ็ดนาที")
         self.assertEqual(thai_time("8:17", "6h"), "สองโมงเช้าสิบเจ็ดนาที")
         self.assertEqual(thai_time("8:17", "m6h"), "แปดโมงสิบเจ็ดนาที")
-        self.assertEqual(thai_time("18:30", "m6h"), "หกโมงครึ่ง")
         self.assertEqual(thai_time("13:30:01", "6h", "m"), "บ่ายโมงครึ่ง")
         self.assertEqual(
             thai_time(datetime.time(12, 3, 0)), "สิบสองนาฬิกาสามนาที"
@@ -181,22 +181,37 @@ class TestUtilPackage(unittest.TestCase):
             "สิบสองนาฬิกาสามนาทีหนึ่งวินาที",
         )
         self.assertEqual(
-            thai_time(
-                datetime.datetime(2014, 5, 22, 12, 3, 0), precision="s"
-            ),
+            thai_time(datetime.datetime(2014, 5, 22, 12, 3, 0), precision="s"),
             "สิบสองนาฬิกาสามนาทีศูนย์วินาที",
         )
         self.assertEqual(
-            thai_time(
-                datetime.datetime(2014, 5, 22, 12, 3, 1), precision="m"
-            ),
+            thai_time(datetime.datetime(2014, 5, 22, 12, 3, 1), precision="m"),
             "สิบสองนาฬิกาสามนาที",
         )
         self.assertEqual(
-            thai_time(
-                datetime.datetime(1976, 10, 6, 12, 30, 1), "6h", "m"
-            ),
+            thai_time(datetime.datetime(1976, 10, 6, 12, 30, 1), "6h", "m"),
             "เที่ยงครึ่ง",
+        )
+        self.assertEqual(thai_time("18:30"), "สิบแปดนาฬิกาสามสิบนาที")
+        self.assertEqual(thai_time("18:30:00"), "สิบแปดนาฬิกาสามสิบนาที")
+        self.assertEqual(
+            thai_time("18:30:01"), "สิบแปดนาฬิกาสามสิบนาทีหนึ่งวินาที"
+        )
+        self.assertEqual(
+            thai_time("18:30:01", precision="m"), "สิบแปดนาฬิกาสามสิบนาที"
+        )
+        self.assertEqual(
+            thai_time("18:30:01", precision="s"),
+            "สิบแปดนาฬิกาสามสิบนาทีหนึ่งวินาที",
+        )
+        self.assertEqual(
+            thai_time("18:30:01", fmt="m6h", precision="m"), "หกโมงครึ่ง"
+        )
+        self.assertEqual(
+            thai_time("18:30:01", fmt="m6h"), "หกโมงสามสิบนาทีหนึ่งวินาที"
+        )
+        self.assertEqual(
+            thai_time("18:30:01", fmt="m6h", precision="m"), "หกโมงครึ่ง"
         )
         self.assertIsNotNone(thai_time("0:30"))
         self.assertIsNotNone(thai_time("0:30", "6h"))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -244,7 +244,7 @@ class TestUtilPackage(unittest.TestCase):
         self.assertEqual(delete_tone("จิ้น"), "จิน")
         self.assertEqual(delete_tone("เก๋า"), "เกา")
 
-        with self.assertRaises(DeprecationWarning):
+        with self.assertWarns(DeprecationWarning):
             deletetone("จิ้น")
 
     def test_normalize(self):
@@ -293,5 +293,5 @@ class TestUtilPackage(unittest.TestCase):
         self.assertEqual(is_native_thai("เทเวศน์"), False)
         self.assertEqual(is_native_thai("เทเวศร์"), False)
 
-        with self.assertRaises(DeprecationWarning):
+        with self.assertWarns(DeprecationWarning):
             thaicheck("เลข")


### PR DESCRIPTION
- More test cases for corpus functions
- More test cases for `thai_time()`
- More "semantic" tests for tokenizers
- Test if deprecated function raises DeprecationWarning (commented out for now, as there is a bug in unittest assertWarns, a PR is in the process at https://github.com/python/cpython/pull/4800)
