### PR TITLE
Add raise error for word_tokenize

### DIFF
--- a/pythainlp/tokenize/__init__.py
+++ b/pythainlp/tokenize/__init__.py
@@ -140,7 +140,7 @@ def word_tokenize(
 
         segments = segment(text)
     else:
-        raise AttributeError()
+        raise ValueError()
 
     if not keep_whitespace:
         segments = [token.strip(" ") for token in segments if token.strip(" ")]

--- a/pythainlp/tokenize/__init__.py
+++ b/pythainlp/tokenize/__init__.py
@@ -139,10 +139,8 @@ def word_tokenize(
         from .pyicu import segment
 
         segments = segment(text)
-    else:  # default, use "newmm" engine
-        from .newmm import segment
-
-        segments = segment(text, custom_dict)
+    else:
+        raise AttributeError()
 
     if not keep_whitespace:
         segments = [token.strip(" ") for token in segments if token.strip(" ")]

--- a/pythainlp/tokenize/__init__.py
+++ b/pythainlp/tokenize/__init__.py
@@ -141,7 +141,8 @@ def word_tokenize(
         segments = segment(text)
     else:
         raise ValueError(
-            f"\"{engine}\" not found.  It might be a typo; if not, please consult our document."
+            f"""\"{engine}\""" not found. 
+            It might be a typo; if not, please consult our document."""
         )
 
     if not keep_whitespace:

--- a/pythainlp/tokenize/__init__.py
+++ b/pythainlp/tokenize/__init__.py
@@ -141,7 +141,7 @@ def word_tokenize(
         segments = segment(text)
     else:
         raise ValueError(
-            f"""\"{engine}\""" not found. 
+            f"""\"{engine}\""" not found.
             It might be a typo; if not, please consult our document."""
         )
 

--- a/pythainlp/tokenize/__init__.py
+++ b/pythainlp/tokenize/__init__.py
@@ -140,7 +140,7 @@ def word_tokenize(
 
         segments = segment(text)
     else:
-        raise ValueError()
+        raise ValueError(f"\"{engine}\" not found.  It might be a typo; if not, please consult our document.")
 
     if not keep_whitespace:
         segments = [token.strip(" ") for token in segments if token.strip(" ")]

--- a/pythainlp/tokenize/__init__.py
+++ b/pythainlp/tokenize/__init__.py
@@ -140,7 +140,9 @@ def word_tokenize(
 
         segments = segment(text)
     else:
-        raise ValueError(f"\"{engine}\" not found.  It might be a typo; if not, please consult our document.")
+        raise ValueError(
+            f"\"{engine}\" not found.  It might be a typo; if not, please consult our document."
+        )
 
     if not keep_whitespace:
         segments = [token.strip(" ") for token in segments if token.strip(" ")]

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -62,7 +62,7 @@ class TestTokenizePackage(unittest.TestCase):
             word_tokenize("หมอนทองตากลมหูว์MBK39", engine="attacut")
         )
         self.assertRaises(
-            ValueError, 
+            ValueError,
             lambda: word_tokenize("หมอนทองตากลมหูว์MBK39", engine="XX")
         )  # XX engine does not exist.
 

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -62,8 +62,9 @@ class TestTokenizePackage(unittest.TestCase):
             word_tokenize("หมอนทองตากลมหูว์MBK39", engine="attacut")
         )
         self.assertRaises(
-            ValueError, lambda: word_tokenize("หมอนทองตากลมหูว์MBK39", engine="XX")
-        )  # XX engine is not existed
+            ValueError, 
+            lambda: word_tokenize("หมอนทองตากลมหูว์MBK39", engine="XX")
+        )  # XX engine does not exist.
 
         self.assertIsNotNone(dict_trie(()))
         self.assertIsNotNone(dict_trie(("ทดสอบ", "สร้าง", "Trie")))

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -61,8 +61,8 @@ class TestTokenizePackage(unittest.TestCase):
         self.assertIsNotNone(
             word_tokenize("หมอนทองตากลมหูว์MBK39", engine="attacut")
         )
-        self.assertIsNotNone(
-            word_tokenize("หมอนทองตากลมหูว์MBK39", engine="XX")
+        self.assertRaises(
+            ValueError, lambda: word_tokenize("หมอนทองตากลมหูว์MBK39", engine="XX")
         )  # XX engine is not existed
 
         self.assertIsNotNone(dict_trie(()))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -256,6 +256,7 @@ class TestUtilPackage(unittest.TestCase):
 
     def test_normalize(self):
         self.assertEqual(normalize("เเปลก"), "แปลก")
+        self.assertEqual(normalize("นํา"), "นำ")
         self.assertIsNotNone(normalize("พรรค์จันทร์ab์"))
 
     # ### pythainlp.util.thai


### PR DESCRIPTION
Expect to raise error behavior that the input engine does not exist. from #366 