### PR TITLE
Remove tqdm from base requirements

### DIFF
--- a/pythainlp/benchmarks/word_tokenization.py
+++ b/pythainlp/benchmarks/word_tokenization.py
@@ -65,7 +65,7 @@ def _flatten_result(my_dict: dict, sep: str = ":") -> dict:
     return dict(items)
 
 
-def benchmark(ref_samples: List[str], samples: List[str]) -> pandas.DataFrame:
+def benchmark(ref_samples: List[str], samples: List[str]) -> pd.DataFrame:
     """
     Performace benchmark of samples.
 

--- a/pythainlp/benchmarks/word_tokenization.py
+++ b/pythainlp/benchmarks/word_tokenization.py
@@ -2,10 +2,10 @@
 
 import re
 import sys
+from typing import List, Tuple
 
 import numpy as np
 import pandas as pd
-
 
 SEPARATOR = "|"
 
@@ -65,7 +65,7 @@ def _flatten_result(my_dict: dict, sep: str = ":") -> dict:
     return dict(items)
 
 
-def benchmark(ref_samples: list, samples: list):
+def benchmark(ref_samples: List[str], samples: List[str]) -> pandas.DataFrame:
     """
     Performace benchmark of samples.
 
@@ -264,8 +264,9 @@ def _find_word_boudaries(bin_reps) -> list:
 
 
 def _find_words_correctly_tokenised(
-    ref_boundaries: list, predicted_boundaries: list
-) -> tuple:
+    ref_boundaries: List[Tuple[int, int]],
+    predicted_boundaries: List[Tuple[int, int]],
+) -> Tuple[int]:
     """
     Find whether each word is correctly tokenized.
 

--- a/pythainlp/corpus/__init__.py
+++ b/pythainlp/corpus/__init__.py
@@ -51,14 +51,23 @@ if not os.path.exists(_CORPUS_DB_PATH):
 
 
 def corpus_path() -> str:
+    """
+    Get path where corpus files are kept locally.
+    """
     return _CORPUS_PATH
 
 
 def corpus_db_url() -> str:
+    """
+    Get remote URL of corpus catalog.
+    """
     return _CORPUS_DB_URL
 
 
 def corpus_db_path() -> str:
+    """
+    Get local path of corpus catalog.
+    """
     return _CORPUS_DB_PATH
 
 

--- a/pythainlp/corpus/core.py
+++ b/pythainlp/corpus/core.py
@@ -48,7 +48,7 @@ def get_corpus(filename: str) -> frozenset:
     `this file
     <https://github.com/PyThaiNLP/pythainlp-corpus/blob/master/db.json>`_
 
-    :param string filename: filename of the corpus to be read
+    :param str filename: filename of the corpus to be read
 
     :return: :mod:`frozenset` consist of lines in the file
     :rtype: :mod:`frozenset`
@@ -81,7 +81,7 @@ def get_corpus_path(name: str) -> Union[str, None]:
     """
     Get corpus path.
 
-    :param string name: corpus name
+    :param str name: corpus name
     :return: path to the corpus or **None** of the corpus doesn't
              exist in the device
     :rtype: str
@@ -141,6 +141,7 @@ def _download(url: str, dst: str) -> int:
         pbar = None
         try:
             from tqdm import tqdm
+
             pbar = tqdm(total=int(r.headers["Content-Length"]))
         except ImportError:
             pbar = None
@@ -173,15 +174,18 @@ def _check_hash(dst: str, md5: str) -> None:
                 raise Exception("Hash does not match expected.")
 
 
-def download(name: str, force: bool = False) -> bool:
+def download(
+    name: str, force: bool = False, corpus_db_url: str = None
+) -> bool:
     """
     Download corpus.
 
     The available corpus names can be seen in this file:
     https://github.com/PyThaiNLP/pythainlp-corpus/blob/master/db.json
 
-    :param string name: corpus name
+    :param str name: corpus name
     :param bool force: force download
+    :param str
     :return: **True** if the corpus is found and succesfully downloaded.
              Otherwise, it returns **False**.
     :rtype: bool
@@ -201,9 +205,12 @@ def download(name: str, force: bool = False) -> bool:
     ``$HOME/pythainlp-data/``
     (e.g. ``/Users/bact/pythainlp-data/wiki_lm_lstm.pth``).
     """
-    corpus_db = get_corpus_db(corpus_db_url())
+    if not corpus_db_url:
+        corpus_db_url = corpus_db_url()
+
+    corpus_db = get_corpus_db(corpus_db_url)
     if not corpus_db:
-        print(f"Cannot download corpus database from: {corpus_db_url()}")
+        print(f"Cannot download corpus database from: {corpus_db_url}")
         return False
 
     corpus_db = corpus_db.json()
@@ -259,7 +266,7 @@ def remove(name: str) -> bool:
     """
     Remove corpus
 
-    :param string name: corpus name
+    :param str name: corpus name
     :return: **True** if the corpus is found and succesfully removed.
              Otherwise, it returns **False**.
     :rtype: bool

--- a/pythainlp/corpus/core.py
+++ b/pythainlp/corpus/core.py
@@ -175,7 +175,7 @@ def _check_hash(dst: str, md5: str) -> None:
 
 
 def download(
-    name: str, force: bool = False, corpus_db_url: str = None
+    name: str, force: bool = False, url: str = None
 ) -> bool:
     """
     Download corpus.
@@ -185,7 +185,7 @@ def download(
 
     :param str name: corpus name
     :param bool force: force download
-    :param str
+    :param str url: URL of the corpus catalog
     :return: **True** if the corpus is found and succesfully downloaded.
              Otherwise, it returns **False**.
     :rtype: bool
@@ -205,12 +205,12 @@ def download(
     ``$HOME/pythainlp-data/``
     (e.g. ``/Users/bact/pythainlp-data/wiki_lm_lstm.pth``).
     """
-    if not corpus_db_url:
-        corpus_db_url = corpus_db_url()
+    if not url:
+        url = corpus_db_url()
 
-    corpus_db = get_corpus_db(corpus_db_url)
+    corpus_db = get_corpus_db(url)
     if not corpus_db:
-        print(f"Cannot download corpus database from: {corpus_db_url}")
+        print(f"Cannot download corpus catalog from: {url}")
         return False
 
     corpus_db = corpus_db.json()

--- a/pythainlp/corpus/core.py
+++ b/pythainlp/corpus/core.py
@@ -173,7 +173,7 @@ def _check_hash(dst: str, md5: str) -> None:
                 raise Exception("Hash does not match expected.")
 
 
-def download(name: str, force: bool = False) -> None:
+def download(name: str, force: bool = False) -> bool:
     """
     Download corpus.
 
@@ -182,6 +182,9 @@ def download(name: str, force: bool = False) -> None:
 
     :param string name: corpus name
     :param bool force: force download
+    :return: **True** if the corpus is found and succesfully downloaded.
+             Otherwise, it returns **False**.
+    :rtype: bool
 
     :Example:
     ::

--- a/pythainlp/soundex/core.py
+++ b/pythainlp/soundex/core.py
@@ -17,7 +17,7 @@ def soundex(text: str, engine: str = DEFAULT_SOUNDEX_ENGINE) -> str:
     """
     This function converts Thai text into phonetic code.
 
-    :param string text: word
+    :param str text: word
     :param str engine: soundex engine
     :return: Soundex code
     :rtype: str

--- a/pythainlp/tag/named_entity.py
+++ b/pythainlp/tag/named_entity.py
@@ -89,10 +89,10 @@ class ThaiNameTagger:
         """
         This function tags named-entitiy from text in IOB format.
         
-        :param string text: text in Thai to be tagged
-        :param boolean pos: To include POS tags in the results (`True`) or
+        :param str text: text in Thai to be tagged
+        :param bool pos: To include POS tags in the results (`True`) or
                             exclude (`False`). The defualt value is `True`
-        :param boolean tag: output like html tag.
+        :param bool tag: output like html tag.
         :return: a list of tuple associated with tokenized word, NER tag,
                  POS tag (if the parameter `pos` is specified as `True`),
                  and output like html tag (if the parameter `tag` is

--- a/pythainlp/tools/__init__.py
+++ b/pythainlp/tools/__init__.py
@@ -3,7 +3,7 @@ __all__ = [
     "get_full_data_path",
     "get_pythainlp_data_path",
     "get_pythainlp_path",
-    "PYTHAINLP_DATA_DIR"
+    "PYTHAINLP_DATA_DIR",
 ]
 
 from pythainlp.tools.path import (

--- a/pythainlp/tools/path.py
+++ b/pythainlp/tools/path.py
@@ -49,8 +49,9 @@ def get_pythainlp_data_path() -> str:
         get_pythainlp_data_path()
         # output: '/root/pythainlp-data'
     """
-    path = os.getenv('PYTHAINLP_DATA_DIR',
-                     os.path.join("~", PYTHAINLP_DATA_DIR))
+    path = os.getenv(
+        "PYTHAINLP_DATA_DIR", os.path.join("~", PYTHAINLP_DATA_DIR)
+    )
     path = os.path.expanduser(path)
     os.makedirs(path, exist_ok=True)
     return path

--- a/pythainlp/transliterate/core.py
+++ b/pythainlp/transliterate/core.py
@@ -3,6 +3,7 @@
 DEFAULT_ROMANIZE_ENGINE = "royin"
 DEFAULT_TRANSLITERATE_ENGINE = "thaig2p"
 
+
 def romanize(text: str, engine: str = DEFAULT_ROMANIZE_ENGINE) -> str:
     """
     This function renders Thai words in the Latin alphabet or "romanization",
@@ -51,7 +52,9 @@ def romanize(text: str, engine: str = DEFAULT_ROMANIZE_ENGINE) -> str:
     return romanize(text)
 
 
-def transliterate(text: str, engine: str = DEFAULT_TRANSLITERATE_ENGINE) -> str:
+def transliterate(
+    text: str, engine: str = DEFAULT_TRANSLITERATE_ENGINE
+) -> str:
     """
     This function transliterates Thai text.
 

--- a/pythainlp/word_vector/core.py
+++ b/pythainlp/word_vector/core.py
@@ -177,8 +177,8 @@ def similarity(word1: str, word2: str) -> float:
     """
     This function computae cosine similarity between two words.
 
-    :param string word1: first word to be compared
-    :param string word2: second word to be compared
+    :param str word1: first word to be compared
+    :param str word2: second word to be compared
 
     :raises KeyError: if either `word1` or `word2` is not in the vocabulary
                       of the model.
@@ -218,8 +218,8 @@ def sentence_vectorizer(text: str, use_mean: bool = True) -> ndarray:
     Then, word vectors are aggregatesd into one vector of 300 dimension
     by calulating either mean, or summation of all word vectors.
 
-    :param string text: text input
-    :param boolean use_mean: if `True` aggregate word vectors with mean of all
+    :param str text: text input
+    :param bool use_mean: if `True` aggregate word vectors with mean of all
                              word vectors. Otherwise, aggregate with summation
                              of all word vectors
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ dill==0.3.*
 python-crfsuite==0.9.*
 requests==2.23.*
 tinydb==4.1.*
-tqdm==4.46.*

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ requirements = [
     "python-crfsuite>=0.9.6",
     "requests>=2.22.0",
     "tinydb>=3.0",
-    "tqdm>=4.1",
 ]
 
 extras = {

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -9,68 +9,70 @@ with open("./tests/data/sentences.yml", "r", encoding="utf8") as stream:
 
 
 class TestBenchmarksPackage(unittest.TestCase):
-
     def test_preprocessing(self):
-        self.assertIsNotNone(word_tokenization.preprocessing(
-            txt="ทดสอบ การ ทำ ความสะอาด ข้อมูล<tag>ok</tag>"
-        ))
+        self.assertIsNotNone(
+            word_tokenization.preprocessing(
+                txt="ทดสอบ การ ทำ ความสะอาด ข้อมูล<tag>ok</tag>"
+            )
+        )
 
     def test_benchmark_not_none(self):
-        self.assertIsNotNone(word_tokenization.benchmark(
-            ["วัน", "จัน", "ทร์", "สี", "เหลือง"],
-            ["วัน", "จันทร์", "สี", "เหลือง"]
-        ))
+        self.assertIsNotNone(
+            word_tokenization.benchmark(
+                ["วัน", "จัน", "ทร์", "สี", "เหลือง"],
+                ["วัน", "จันทร์", "สี", "เหลือง"],
+            )
+        )
 
     def test_binary_representation(self):
         sentence = "อากาศ|ร้อน|มาก|ครับ"
         rept = word_tokenization._binary_representation(sentence)
 
         self.assertEqual(
-            [1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0],
-            rept.tolist()
+            [1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0], rept.tolist()
         )
 
     def test_compute_stats(self):
-        for pair in TEST_DATA['sentences']:
-            exp, act = pair['expected'], pair['actual']
+        for pair in TEST_DATA["sentences"]:
+            exp, act = pair["expected"], pair["actual"]
 
             result = word_tokenization.compute_stats(
                 word_tokenization.preprocessing(exp),
-                word_tokenization.preprocessing(act)
-            ) 
+                word_tokenization.preprocessing(act),
+            )
 
             self.assertIsNotNone(result)
 
     def test_benchmark(self):
         expected = []
         actual = []
-        for pair in TEST_DATA['sentences']:
-            expected.append(pair['expected'])
-            actual.append(pair['actual'])
+        for pair in TEST_DATA["sentences"]:
+            expected.append(pair["expected"])
+            actual.append(pair["actual"])
 
         df = word_tokenization.benchmark(expected, actual)
 
         self.assertIsNotNone(df)
 
     def test_count_correctly_tokenised_words(self):
-        for d in TEST_DATA['binary_sentences']:
-            sample = np.array(list(d['actual'])).astype(int)
-            ref_sample = np.array(list(d['expected'])).astype(int)
+        for d in TEST_DATA["binary_sentences"]:
+            sample = np.array(list(d["actual"])).astype(int)
+            ref_sample = np.array(list(d["expected"])).astype(int)
 
             sb = list(word_tokenization._find_word_boudaries(sample))
             rb = list(word_tokenization._find_word_boudaries(ref_sample))
 
             # in binary [{0, 1}, ...]
-            correctly_tokenized_words = word_tokenization\
-                ._find_words_correctly_tokenised(rb, sb)
+            correctly_tokenized_words = word_tokenization._find_words_correctly_tokenised(
+                rb, sb
+            )
 
             self.assertEqual(
-                np.sum(correctly_tokenized_words),
-                d['expected_count']
+                np.sum(correctly_tokenized_words), d["expected_count"]
             )
 
     def test_words_correctly_tokenised(self):
-        r = [(0, 2), (2, 10), (10, 12) ]
+        r = [(0, 2), (2, 10), (10, 12)]
         s = [(0, 10), (10, 12)]
 
         expected = "01"
@@ -79,10 +81,7 @@ class TestBenchmarksPackage(unittest.TestCase):
         self.assertEqual(expected, "".join(np.array(labels).astype(str)))
 
     def test_flatten_result(self):
-        result = dict(
-            key1=dict(v1=6),
-            key2=dict(v2=7)
-        )
+        result = dict(key1=dict(v1=6), key2=dict(v2=7))
 
         actual = word_tokenization._flatten_result(result)
-        self.assertEqual(actual, {'key1:v1': 6, 'key2:v2': 7})
+        self.assertEqual(actual, {"key1:v1": 6, "key2:v2": 7})

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -27,21 +27,31 @@ class TestCorpusPackage(unittest.TestCase):
         self.assertIsNotNone(conceptnet.edges("รัก"))
 
     def test_corpus(self):
-        self.assertIsNotNone(countries())
-        self.assertIsNotNone(provinces())
-        self.assertIsNotNone(thai_negations())
-        self.assertIsNotNone(thai_stopwords())
-        self.assertIsNotNone(thai_syllables())
-        self.assertIsNotNone(thai_words())
-        self.assertIsNotNone(thai_female_names())
-        self.assertIsNotNone(thai_male_names())
-        self.assertEqual(get_corpus_db_detail("XXX"), {})
-        self.assertIsNotNone(download("test"))
-        self.assertIsNotNone(download("test", force=True))
-        self.assertFalse(download("XxxXXxxx817d37sf"))  # not exist
-        self.assertIsNotNone(get_corpus_db_detail("test"))
-        self.assertIsNotNone(remove("test"))
-        self.assertFalse(remove("test"))
+        self.assertTrue(isinstance(thai_negations(), frozenset))
+        self.assertTrue(isinstance(thai_stopwords(), frozenset))
+        self.assertTrue(isinstance(thai_syllables(), frozenset))
+        self.assertTrue(isinstance(thai_words(), frozenset))
+
+        self.assertTrue(isinstance(countries(), frozenset))
+        self.assertTrue(isinstance(provinces(), frozenset))
+        self.assertTrue(isinstance(thai_female_names(), frozenset))
+        self.assertTrue(isinstance(thai_male_names(), frozenset))
+
+        self.assertEqual(
+            get_corpus_db_detail("XXX"), {}
+        )  # corpus does not exist
+        self.assertTrue(download("test"))  # download the first time
+        self.assertTrue(download(name="test", force=True))  # force download
+        self.assertTrue(download(name="test"))  # try download existing
+        self.assertFalse(
+            download(name="test", corpus_db_url="wrongurl")
+        )  # URL not exist
+        self.assertFalse(
+            download(name="XxxXXxxx817d37sf")
+        )  # corpus name not exist
+        self.assertIsNotNone(get_corpus_db_detail("test"))  # corpus exists
+        self.assertTrue(remove("test"))  # remove existing
+        self.assertFalse(remove("test"))  # remove non-existing
 
     def test_tnc(self):
         self.assertIsNotNone(tnc.word_freqs())
@@ -50,7 +60,7 @@ class TestCorpusPackage(unittest.TestCase):
         self.assertIsNotNone(ttc.word_freqs())
 
     def test_wordnet(self):
-        self.assertIsNotNone(wordnet.langs())
+        self.assertTrue(isinstance(wordnet.langs(), list))
         self.assertTrue("tha" in wordnet.langs())
 
         self.assertEqual(

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -44,7 +44,7 @@ class TestCorpusPackage(unittest.TestCase):
         self.assertTrue(download(name="test", force=True))  # force download
         self.assertTrue(download(name="test"))  # try download existing
         self.assertFalse(
-            download(name="test", corpus_db_url="wrongurl")
+            download(name="test", url="wrongurl")
         )  # URL not exist
         self.assertFalse(
             download(name="XxxXXxxx817d37sf")

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -38,6 +38,7 @@ class TestCorpusPackage(unittest.TestCase):
         self.assertEqual(get_corpus_db_detail("XXX"), {})
         self.assertIsNotNone(download("test"))
         self.assertIsNotNone(download("test", force=True))
+        self.assertFalse(download("XxxXXxxx817d37sf"))  # not exist
         self.assertIsNotNone(get_corpus_db_detail("test"))
         self.assertIsNotNone(remove("test"))
         self.assertFalse(remove("test"))

--- a/tests/test_soundex.py
+++ b/tests/test_soundex.py
@@ -6,7 +6,6 @@ from pythainlp.soundex import lk82, metasound, soundex, udom83
 
 
 class TestSoundexPackage(unittest.TestCase):
-
     def test_soundex(self):
         self.assertIsNotNone(soundex("a", engine="lk82"))
         self.assertIsNotNone(soundex("a", engine="udom83"))

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -5,13 +5,10 @@ import unittest
 from pythainlp.tag import perceptron, pos_tag, pos_tag_sents, unigram
 from pythainlp.tag.locations import tag_provinces
 from pythainlp.tag.named_entity import ThaiNameTagger
-from pythainlp.tokenize import (
-    word_tokenize,
-)
+from pythainlp.tokenize import word_tokenize
 
 
 class TestTagPackage(unittest.TestCase):
-
     def test_pos_tag(self):
         tokens = ["ผม", "รัก", "คุณ"]
 
@@ -81,108 +78,102 @@ class TestTagPackage(unittest.TestCase):
                 """คณะวิทยาศาสตร์ประยุกต์และวิศวกรรมศาสตร์ มหาวิทยาลัยขอนแก่น
                 วิทยาเขตหนองคาย 112 หมู่ 7 บ้านหนองเดิ่น ตำบลหนองกอมเกาะ อำเภอเมือง
                 จังหวัดหนองคาย 43000""",
-                tag=True
+                tag=True,
             )
         )
 
         # arguement `tag` is True
         self.assertEqual(
-            ner.get_ner(
-                "วันที่ 15 ก.ย. 61 ทดสอบระบบเวลา 14:49 น.",
-                tag=True
-            ),
+            ner.get_ner("วันที่ 15 ก.ย. 61 ทดสอบระบบเวลา 14:49 น.", tag=True),
             "วันที่ <DATE>15 ก.ย. 61</DATE> "
-            "ทดสอบระบบเวลา <TIME>14:49 น.</TIME>")
+            "ทดสอบระบบเวลา <TIME>14:49 น.</TIME>",
+        )
 
         self.assertEqual(
             ner.get_ner(
-                "url = https://thainlp.org/pythainlp/docs/2.0/",
-                tag=True
+                "url = https://thainlp.org/pythainlp/docs/2.0/", tag=True
             ),
-            "url = <URL>https://thainlp.org/pythainlp/docs/2.0/</URL>")
+            "url = <URL>https://thainlp.org/pythainlp/docs/2.0/</URL>",
+        )
 
         self.assertEqual(
-            ner.get_ner(
-                "example@gmail.com",
-                tag=True
-            ),
-            "<EMAIL>example@gmail.com</EMAIL>")
+            ner.get_ner("example@gmail.com", tag=True),
+            "<EMAIL>example@gmail.com</EMAIL>",
+        )
 
         self.assertEqual(
-            ner.get_ner(
-                "รหัสไปรษณีย์ 19130",
-                tag=True
-            ),
-            "รหัสไปรษณีย์ <ZIP>19130</ZIP>")
+            ner.get_ner("รหัสไปรษณีย์ 19130", tag=True),
+            "รหัสไปรษณีย์ <ZIP>19130</ZIP>",
+        )
 
         self.assertEqual(
-            ner.get_ner(
-                "เบอร์โทรศัพท์ 091-123-4567",
-                tag=True
-            ),
-            "เบอร์โทรศัพท์ <PHONE>091-123-4567</PHONE>")
+            ner.get_ner("เบอร์โทรศัพท์ 091-123-4567", tag=True),
+            "เบอร์โทรศัพท์ <PHONE>091-123-4567</PHONE>",
+        )
 
         self.assertEqual(
-            ner.get_ner(
-                "อาจารย์เอกพล ประจำคณะวิศวกรรมศาสตร์ ",
-                tag=True
-            ),
+            ner.get_ner("อาจารย์เอกพล ประจำคณะวิศวกรรมศาสตร์ ", tag=True),
             "<PERSON>อาจารย์เอกพล</PERSON> ประจำ<ORGANIZATION>"
-            "คณะวิศวกรรมศาสตร์</ORGANIZATION> ")
+            "คณะวิศวกรรมศาสตร์</ORGANIZATION> ",
+        )
 
         self.assertEqual(
             ner.get_ner(
                 "มาตรา 80 ปพพ ให้ใช้อัตราภาษีร้อยละ 10.0"
                 " ในการคำนวณภาษีมูลค่าเพิ่ม",
-                tag=True
+                tag=True,
             ),
             "<LAW>มาตรา 80 ปพพ</LAW> "
             "ให้ใช้อัตราภาษี<PERCENT>ร้อยละ 10.0</PERCENT>"
-            " ในการคำนวณภาษีมูลค่าเพิ่ม")
+            " ในการคำนวณภาษีมูลค่าเพิ่ม",
+        )
 
         self.assertEqual(
-            ner.get_ner(
-                "ยาว 20 เซนติเมตร",
-                tag=True
-            ),
-            "ยาว <LEN>20 เซนติเมตร</LEN>")
+            ner.get_ner("ยาว 20 เซนติเมตร", tag=True),
+            "ยาว <LEN>20 เซนติเมตร</LEN>",
+        )
 
         self.assertEqual(
-            ner.get_ner(
-                "1 บาท",
-                pos=True,
-                tag=True),
-            "<MONEY>1 บาท</MONEY>")
+            ner.get_ner("1 บาท", pos=True, tag=True), "<MONEY>1 บาท</MONEY>"
+        )
 
         self.assertEqual(
-            ner.get_ner(
-                "ไทย",
-                pos=False,
-                tag=True
-            ),
-            "<LOCATION>ไทย</LOCATION>")
+            ner.get_ner("ไทย", pos=False, tag=True), "<LOCATION>ไทย</LOCATION>"
+        )
 
         # arguement `tag` is False and `pos` is True
         self.assertEqual(
-            ner.get_ner(
-                "ไทย",
-                pos=True,
-                tag=False
-            ),
-            [('ไทย', 'PROPN', 'B-LOCATION')])
+            ner.get_ner("ไทย", pos=True, tag=False),
+            [("ไทย", "PROPN", "B-LOCATION")],
+        )
 
         # arguement `tag` is False and `pos` is False
         self.assertEqual(
             ner.get_ner(
                 "วันที่ 15 ก.ย. 61 ทดสอบระบบเวลา 14:49 น.",
                 pos=False,
-                tag=False
+                tag=False,
             ),
-            [('วันที่', 'O'), (' ', 'O'), ('15', 'B-DATE'),
-             (' ', 'I-DATE'), ('ก.ย.', 'I-DATE'), (' ', 'I-DATE'),
-             ('61', 'I-DATE'), (' ', 'O'), ('ทดสอบ', 'O'), ('ระบบ', 'O'),
-             ('เวลา', 'O'), (' ', 'O'), ('14', 'B-TIME'), (':', 'I-TIME'),
-             ('49', 'I-TIME'), (' ', 'I-TIME'), ('น.', 'I-TIME')])
+            [
+                ("วันที่", "O"),
+                (" ", "O"),
+                ("15", "B-DATE"),
+                (" ", "I-DATE"),
+                ("ก.ย.", "I-DATE"),
+                (" ", "I-DATE"),
+                ("61", "I-DATE"),
+                (" ", "O"),
+                ("ทดสอบ", "O"),
+                ("ระบบ", "O"),
+                ("เวลา", "O"),
+                (" ", "O"),
+                ("14", "B-TIME"),
+                (":", "I-TIME"),
+                ("49", "I-TIME"),
+                (" ", "I-TIME"),
+                ("น.", "I-TIME"),
+            ],
+        )
 
         # self.assertEqual(
         #     ner.get_ner("แมวทำอะไรตอนห้าโมงเช้า"),

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,8 +2,18 @@
 
 import unittest
 
+from pythainlp.tools import (
+    get_full_data_path,
+    get_pythainlp_data_path,
+    get_pythainlp_path,
+)
+
 
 class TestToolsPackage(unittest.TestCase):
-
-    def setUp():
-        pass
+    def test_path(self):
+        data_filename = "ttc_freq.txt"
+        self.assertTrue(
+            get_full_data_path(data_filename).endswith(data_filename)
+        )
+        self.assertTrue(isinstance(get_pythainlp_data_path(), str))
+        self.assertTrue(isinstance(get_pythainlp_path, str))

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -16,4 +16,4 @@ class TestToolsPackage(unittest.TestCase):
             get_full_data_path(data_filename).endswith(data_filename)
         )
         self.assertTrue(isinstance(get_pythainlp_data_path(), str))
-        self.assertTrue(isinstance(get_pythainlp_path, str))
+        self.assertTrue(isinstance(get_pythainlp_path(), str))

--- a/tests/test_transliterate.py
+++ b/tests/test_transliterate.py
@@ -3,15 +3,14 @@
 import unittest
 
 import torch
+from pythainlp.corpus import download
 from pythainlp.transliterate import romanize, transliterate
 from pythainlp.transliterate.ipa import trans_list, xsampa_list
 from pythainlp.transliterate.royin import romanize as romanize_royin
 from pythainlp.transliterate.thai2rom import ThaiTransliterator
-from pythainlp.corpus import download
 
 
 class TestTransliteratePackage(unittest.TestCase):
-
     def test_romanize(self):
         self.assertEqual(romanize(None), "")
         self.assertEqual(romanize(""), "")
@@ -49,7 +48,9 @@ class TestTransliteratePackage(unittest.TestCase):
         self.assertEqual(romanize("สุนัข", engine="thai2rom"), "sunak")
         self.assertEqual(romanize("นก", engine="thai2rom"), "nok")
         self.assertEqual(romanize("ความอิ่ม", engine="thai2rom"), "khwam-im")
-        self.assertEqual(romanize("กานต์ ณรงค์", engine="thai2rom"), "kan narong")
+        self.assertEqual(
+            romanize("กานต์ ณรงค์", engine="thai2rom"), "kan narong"
+        )
         self.assertEqual(romanize("สกุนต์", engine="thai2rom"), "sakun")
         self.assertEqual(romanize("ชารินทร์", engine="thai2rom"), "charin")
 
@@ -60,33 +61,42 @@ class TestTransliteratePackage(unittest.TestCase):
         END_TOKEN = 3  # END_TOKEN or <end> is represented by 3
 
         self.assertListEqual(
-            transliterater._prepare_sequence_in(
-                "A"
-            ).cpu().detach().numpy().tolist(),
-            torch.tensor(
-                [UNK_TOKEN, END_TOKEN],
-                dtype=torch.long
-            ).cpu().detach().numpy().tolist()
+            transliterater._prepare_sequence_in("A")
+            .cpu()
+            .detach()
+            .numpy()
+            .tolist(),
+            torch.tensor([UNK_TOKEN, END_TOKEN], dtype=torch.long)
+            .cpu()
+            .detach()
+            .numpy()
+            .tolist(),
         )
 
         self.assertListEqual(
-            transliterater._prepare_sequence_in(
-                "♥"
-            ).cpu().detach().numpy().tolist(),
-            torch.tensor(
-                [UNK_TOKEN, END_TOKEN],
-                dtype=torch.long
-            ).cpu().detach().numpy().tolist()
+            transliterater._prepare_sequence_in("♥")
+            .cpu()
+            .detach()
+            .numpy()
+            .tolist(),
+            torch.tensor([UNK_TOKEN, END_TOKEN], dtype=torch.long)
+            .cpu()
+            .detach()
+            .numpy()
+            .tolist(),
         )
 
         self.assertNotEqual(
-            transliterater._prepare_sequence_in(
-                "ก"
-            ).cpu().detach().numpy().tolist(),
-            torch.tensor(
-                [UNK_TOKEN, END_TOKEN],
-                dtype=torch.long
-            ).cpu().detach().numpy().tolist()
+            transliterater._prepare_sequence_in("ก")
+            .cpu()
+            .detach()
+            .numpy()
+            .tolist(),
+            torch.tensor([UNK_TOKEN, END_TOKEN], dtype=torch.long)
+            .cpu()
+            .detach()
+            .numpy()
+            .tolist(),
         )
 
     def test_transliterate(self):

--- a/tests/test_word_vector.py
+++ b/tests/test_word_vector.py
@@ -6,7 +6,6 @@ from pythainlp import word_vector
 
 
 class TestWordVectorPackage(unittest.TestCase):
-
     def test_thai2vec(self):
         self.assertGreaterEqual(word_vector.similarity("แบคทีเรีย", "คน"), 0)
         self.assertIsNotNone(word_vector.sentence_vectorizer(""))
@@ -15,8 +14,7 @@ class TestWordVectorPackage(unittest.TestCase):
         )
         self.assertIsNotNone(
             word_vector.sentence_vectorizer(
-                "เสรีภาพในการรวมตัว\nสมาคม",
-                use_mean=True
+                "เสรีภาพในการรวมตัว\nสมาคม", use_mean=True
             )
         )
         self.assertIsNotNone(


### PR DESCRIPTION
This PR will close  #406.

If `tqdm` module exist, use it to show progress.

If it doesn't, do not show progress, just show "Done." when the download finished.