### PR TITLE
Properly check if download() is needed in get_corpus_path()

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Using PyThaiNLP:
 - [PyThaiNLP Get Started](https://www.thainlp.org/pythainlp/tutorials/notebooks/pythainlp_get_started.html)
 - More tutorials at [https://www.thainlp.org/pythainlp/tutorials/](https://www.thainlp.org/pythainlp/tutorials/)
 - See full documentation at [https://thainlp.org/pythainlp/docs/2.1/](https://thainlp.org/pythainlp/docs/2.1/)
-- Some additional data (like word lists and language models) maybe automatically downloaded by the library during runtime and it will be kept under the directory `~/pythainlp-data` by default.
+- Some additional data (like word lists and language models) may get automatically download during runtime and it will be kept under the directory `~/pythainlp-data` by default. See corpus catalog at [https://github.com/PyThaiNLP/pythainlp-corpus](https://github.com/PyThaiNLP/pythainlp-corpus).
   - The data location can be changed, using `PYTHAINLP_DATA_DIR` environment variable.
 - For PyThaiNLP tokenization performance and measurement methods, see [tokenization benchmark](tokenization-benchmark.md)
 - 📫 follow our [PyThaiNLP](https://www.facebook.com/pythainlp/) Facebook page

--- a/pythainlp/corpus/__init__.py
+++ b/pythainlp/corpus/__init__.py
@@ -36,16 +36,20 @@ from pythainlp.tools import get_full_data_path, get_pythainlp_path
 _CORPUS_DIRNAME = "corpus"
 _CORPUS_PATH = os.path.join(get_pythainlp_path(), _CORPUS_DIRNAME)
 
+# remote corpus catalog URL
 _CORPUS_DB_URL = (
     "https://raw.githubusercontent.com/"
-    + "PyThaiNLP/pythainlp-corpus/"
-    + "2.2/db.json"
+    "PyThaiNLP/pythainlp-corpus/"
+    "2.2/db.json"
 )
 
+# local corpus catalog filename
 _CORPUS_DB_FILENAME = "db.json"
+
+# local corpus catalog full path
 _CORPUS_DB_PATH = get_full_data_path(_CORPUS_DB_FILENAME)
 
-# Create a local corpus database if it does not already exist
+# create a local corpus database if it does not already exist
 if not os.path.exists(_CORPUS_DB_PATH):
     TinyDB(_CORPUS_DB_PATH)
 

--- a/pythainlp/corpus/core.py
+++ b/pythainlp/corpus/core.py
@@ -82,7 +82,7 @@ def get_corpus_path(name: str) -> Union[str, None]:
     Get corpus path.
 
     :param str name: corpus name
-    :return: path to the corpus or **None** of the corpus doesn't
+    :return: path to the corpus or **None** of the corpus doesn't \
              exist in the device
     :rtype: str
 
@@ -121,7 +121,7 @@ def get_corpus_path(name: str) -> Union[str, None]:
 
         if not os.path.exists(path):
             download(name)
-            path = get_full_data_path(db.search(query.name == name)[0]["file"])
+            path = get_full_data_path(name)
 
     db.close()
     return path

--- a/pythainlp/corpus/core.py
+++ b/pythainlp/corpus/core.py
@@ -117,21 +117,17 @@ def get_corpus_path(name: str) -> Union[str, None]:
         print(get_corpus_path('wiki_lm_lstm'))
         # output: /root/pythainlp-data/thwiki_model_lstm.pth
     """
+    corpus_db_detail = get_corpus_db_detail(name)
+    if corpus_db_detail:
+        corpus_filename = corpus_db_detail["file_nane"]
+        if corpus_filename:
+            path = get_full_data_path(corpus_filename)
+            if not os.path.exists(path):  # if not exist, try once
+                download(name)
+            if os.path.exists(path):
+                return path
 
-    def _get_path(name: str):
-        path = None
-        res = get_corpus_db_detail(name)
-        if res and res["file_name"] and os.path.exists(res["file_name"]):
-            path = get_full_data_path(res["file_name"])
-        return path
-
-    path = _get_path(name)
-
-    if not path:  # if not found, try download once
-        download(name)
-        path = _get_path(name)
-
-    return path
+    return None
 
 
 def _download(url: str, dst: str) -> int:

--- a/pythainlp/corpus/core.py
+++ b/pythainlp/corpus/core.py
@@ -117,16 +117,21 @@ def get_corpus_path(name: str) -> Union[str, None]:
         print(get_corpus_path('wiki_lm_lstm'))
         # output: /root/pythainlp-data/thwiki_model_lstm.pth
     """
+    # check if the corpus is in local catalog, download if not
     corpus_db_detail = get_corpus_db_detail(name)
     if not corpus_db_detail or not corpus_db_detail.get("file_name"):
-        return None
-
-    path = get_full_data_path(corpus_db_detail["file_name"])
-    if not os.path.exists(path):  # if not exist, try once
         download(name)
-    if os.path.exists(path):
-        return path
+        corpus_db_detail = get_corpus_db_detail(name)
 
+    if corpus_db_detail and corpus_db_detail.get("file_name"):
+        # corpus is in the local catalog, get full path to the file
+        path = get_full_data_path(corpus_db_detail.get("file_name"))
+        # check if the corpus file actually exists, download if not
+        if not os.path.exists(path):
+            download(name)
+        if os.path.exists(path):
+            return path
+    
     return None
 
 

--- a/pythainlp/corpus/core.py
+++ b/pythainlp/corpus/core.py
@@ -117,11 +117,12 @@ def get_corpus_path(name: str) -> Union[str, None]:
     path = None
 
     if db.search(query.name == name):
-        path = get_full_data_path(db.search(query.name == name)[0]["file"])
+        filename = db.search(query.name == name)[0]["file"]
+        path = get_full_data_path(filename)
 
-        if not os.path.exists(path):
-            download(name)
-            path = get_full_data_path(name)
+    if not path or not filename or not os.path.exists(path):
+        download(name)
+        path = get_full_data_path(name)
 
     db.close()
     return path
@@ -175,9 +176,7 @@ def _check_hash(dst: str, md5: str) -> None:
                 raise Exception("Hash does not match expected.")
 
 
-def download(
-    name: str, force: bool = False, url: str = None
-) -> bool:
+def download(name: str, force: bool = False, url: str = None) -> bool:
     """
     Download corpus.
 

--- a/pythainlp/corpus/core.py
+++ b/pythainlp/corpus/core.py
@@ -131,7 +131,7 @@ def get_corpus_path(name: str) -> Union[str, None]:
             download(name)
         if os.path.exists(path):
             return path
-    
+
     return None
 
 

--- a/pythainlp/corpus/core.py
+++ b/pythainlp/corpus/core.py
@@ -121,6 +121,7 @@ def get_corpus_path(name: str) -> Union[str, None]:
 
         if not os.path.exists(path):
             download(name)
+            path = get_full_data_path(db.search(query.name == name)[0]["file"])
 
     db.close()
     return path

--- a/pythainlp/corpus/core.py
+++ b/pythainlp/corpus/core.py
@@ -16,6 +16,9 @@ from tinydb import Query, TinyDB
 
 
 def get_corpus_db(url: str) -> requests.Response:
+    """
+    Get corpus catalog from server.
+    """
     corpus_db = None
     try:
         corpus_db = requests.get(url)
@@ -28,6 +31,9 @@ def get_corpus_db(url: str) -> requests.Response:
 
 
 def get_corpus_db_detail(name: str) -> dict:
+    """
+    Get details about a corpus, using information from local catalog.
+    """
     local_db = TinyDB(corpus_db_path())
     query = Query()
     res = local_db.search(query.name == name)
@@ -41,7 +47,7 @@ def get_corpus_db_detail(name: str) -> dict:
 
 def get_corpus(filename: str) -> frozenset:
     """
-    Read corpus from file and return a frozenset.
+    Read corpus data from file and return a frozenset.
 
     (Please see the filename from
     `this file
@@ -239,7 +245,7 @@ def download(name: str, force: bool = False, url: str = None) -> bool:
                     {
                         "name": name,
                         "version": corpus["version"],
-                        "file": corpus["file_name"],
+                        "file_name": corpus["file_name"],
                     }
                 )
         else:

--- a/pythainlp/corpus/core.py
+++ b/pythainlp/corpus/core.py
@@ -118,14 +118,14 @@ def get_corpus_path(name: str) -> Union[str, None]:
         # output: /root/pythainlp-data/thwiki_model_lstm.pth
     """
     corpus_db_detail = get_corpus_db_detail(name)
-    if corpus_db_detail:
-        corpus_filename = corpus_db_detail["file_nane"]
-        if corpus_filename:
-            path = get_full_data_path(corpus_filename)
-            if not os.path.exists(path):  # if not exist, try once
-                download(name)
-            if os.path.exists(path):
-                return path
+    if not corpus_db_detail or not corpus_db_detail.get("file_name"):
+        return None
+
+    path = get_full_data_path(corpus_db_detail["file_name"])
+    if not os.path.exists(path):  # if not exist, try once
+        download(name)
+    if os.path.exists(path):
+        return path
 
     return None
 

--- a/pythainlp/corpus/core.py
+++ b/pythainlp/corpus/core.py
@@ -122,7 +122,8 @@ def get_corpus_path(name: str) -> Union[str, None]:
 
     if not path or not filename or not os.path.exists(path):
         download(name)
-        path = get_full_data_path(name)
+        filename = db.search(query.name == name)[0]["file"]
+        path = get_full_data_path(filename)
 
     db.close()
     return path

--- a/pythainlp/corpus/core.py
+++ b/pythainlp/corpus/core.py
@@ -35,8 +35,8 @@ def get_corpus_db_detail(name: str) -> dict:
 
     if res:
         return res[0]
-    else:
-        return dict()
+
+    return dict()
 
 
 def get_corpus(filename: str) -> frozenset:
@@ -114,12 +114,9 @@ def get_corpus_path(name: str) -> Union[str, None]:
 
     def _get_path(name: str):
         path = None
-        db = TinyDB(corpus_db_path())
-        query = Query()
-        res = db.search(query.name == name)
-        if res and res[0]["file"] and os.path.exists(res[0]["file"]):
-            path = get_full_data_path(res[0]["file"])
-        db.close()
+        res = get_corpus_db_detail(name)
+        if res and res["file_name"] and os.path.exists(res["file_name"]):
+            path = get_full_data_path(res["file_name"])
         return path
 
     path = _get_path(name)

--- a/pythainlp/tag/named_entity.py
+++ b/pythainlp/tag/named_entity.py
@@ -7,13 +7,14 @@ __all__ = ["ThaiNameTagger"]
 
 from typing import List, Tuple, Union
 
-import pycrfsuite
-from pythainlp.corpus import download, get_corpus_path, thai_stopwords
+from pycrfsuite import Tagger as CRFTagger
+from pythainlp.corpus import get_corpus_path, thai_stopwords
 from pythainlp.tag import pos_tag
 from pythainlp.tokenize import word_tokenize
 from pythainlp.util import isthai
 
-_WORD_TOKENIZER = "newmm"  # ตัวตัดคำ
+_CORPUS_NAME = "thainer-1-4"
+_TOKENIZER_ENGINE = "newmm"  # word tokenizer engine
 
 
 def _is_stopword(word: str) -> bool:  # เช็คว่าเป็นคำฟุ่มเฟือย
@@ -74,14 +75,10 @@ def _doc2features(doc, i) -> dict:
 class ThaiNameTagger:
     def __init__(self):
         """
-        Thai named-entity recognizer
+        Thai named-entity recognizer.
         """
-        self.__data_path = get_corpus_path("thainer-1-4")
-        if not self.__data_path:
-            download("thainer-1-4")
-            self.__data_path = get_corpus_path("thainer-1-4")
-        self.crf = pycrfsuite.Tagger()
-        self.crf.open(self.__data_path)
+        self.crf = CRFTagger()
+        self.crf.open(get_corpus_path(_CORPUS_NAME))
 
     def get_ner(
         self, text: str, pos: bool = True, tag: bool = False
@@ -137,41 +134,41 @@ class ThaiNameTagger:
                             tag=True)
             'วันที่ <DATE>15 ก.ย. 61</DATE> ทดสอบระบบเวลา <TIME>14:49 น.</TIME>'
         """
-        self.__tokens = word_tokenize(text, engine=_WORD_TOKENIZER)
-        self.__pos_tags = pos_tag(
-            self.__tokens, engine="perceptron", corpus="orchid_ud"
-        )
-        self.__x_test = self.__extract_features(self.__pos_tags)
-        self.__y = self.crf.tag(self.__x_test)
+        tokens = word_tokenize(text, engine=_TOKENIZER_ENGINE)
+        pos_tags = pos_tag(tokens, engine="perceptron", corpus="orchid_ud")
+        x_test = self.__extract_features(pos_tags)
+        y = self.crf.tag(x_test)
 
-        self.sent_ner = [
-            (self.__pos_tags[i][0], data) for i, data in enumerate(self.__y)
-        ]
+        sent_ner = [(pos_tags[i][0], data) for i, data in enumerate(y)]
+
         if tag:
-            self.temp = ""
-            self.sent = ""
-            for idx, (word, ner) in enumerate(self.sent_ner):
-                if "B-" in ner and self.temp != "":
-                    self.sent += "</" + self.temp + ">"
-                    self.temp = ner.replace("B-", "")
-                    self.sent += "<" + self.temp + ">"
-                elif "B-" in ner:
-                    self.temp = ner.replace("B-", "")
-                    self.sent += "<" + self.temp + ">"
-                elif "O" == ner and self.temp != "":
-                    self.sent += "</" + self.temp + ">"
-                    self.temp = ""
-                self.sent += word
-                if idx == len(self.sent_ner) - 1 and self.temp != "":
-                    self.sent += "</" + self.temp + ">"
-            return self.sent
-        elif pos:
+            temp = ""
+            sent = ""
+            for idx, (word, ner) in enumerate(sent_ner):
+                if ner.startswith("B-") and temp != "":
+                    sent += "</" + temp + ">"
+                    temp = ner[2:]
+                    sent += "<" + temp + ">"
+                elif ner.startswith("B-"):
+                    temp = ner[2:]
+                    sent += "<" + temp + ">"
+                elif ner == "O" and temp != "":
+                    sent += "</" + temp + ">"
+                    temp = ""
+                sent += word
+
+                if idx == len(sent_ner) - 1 and temp != "":
+                    sent += "</" + temp + ">"
+
+            return sent
+
+        if pos:
             return [
-                (self.__pos_tags[i][0], self.__pos_tags[i][1], data)
-                for i, data in enumerate(self.__y)
+                (pos_tags[i][0], pos_tags[i][1], data)
+                for i, data in enumerate(y)
             ]
-        else:
-            return self.sent_ner
+
+        return sent_ner
 
     @staticmethod
     def __extract_features(doc):

--- a/pythainlp/tag/named_entity.py
+++ b/pythainlp/tag/named_entity.py
@@ -14,7 +14,7 @@ from pythainlp.tokenize import word_tokenize
 from pythainlp.util import isthai
 
 _CORPUS_NAME = "thainer-1-4"
-_TOKENIZER_ENGINE = "newmm"  # word tokenizer engine
+_TOKENIZER_ENGINE = "newmm"  # should be the same as one used in training data
 
 
 def _is_stopword(word: str) -> bool:  # เช็คว่าเป็นคำฟุ่มเฟือย
@@ -136,7 +136,7 @@ class ThaiNameTagger:
         """
         tokens = word_tokenize(text, engine=_TOKENIZER_ENGINE)
         pos_tags = pos_tag(tokens, engine="perceptron", corpus="orchid_ud")
-        x_test = self.__extract_features(pos_tags)
+        x_test = ThaiNameTagger.__extract_features(pos_tags)
         y = self.crf.tag(x_test)
 
         sent_ner = [(pos_tags[i][0], data) for i, data in enumerate(y)]

--- a/pythainlp/tag/pos_tag.py
+++ b/pythainlp/tag/pos_tag.py
@@ -180,14 +180,13 @@ def pos_tag(
         # [('เก้าอี้', None), ('มี', 'VERB'), ('จำนวน', 'NOUN'), ('ขา', None),
         #   ('<space>', None), ('<equal>', None), ('3', 'NUM')]
     """
+    if not words:
+        return []
 
-    # NOTE:
     _corpus = corpus
     _tag = []
     if corpus == "orchid_ud":
         corpus = "orchid"
-    if not words:
-        return []
 
     if engine == "perceptron":
         from .perceptron import tag as tag_

--- a/pythainlp/tools/__init__.py
+++ b/pythainlp/tools/__init__.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 __all__ = [
+    "PYTHAINLP_DEFAULT_DATA_DIR",
     "get_full_data_path",
     "get_pythainlp_data_path",
     "get_pythainlp_path",
-    "PYTHAINLP_DATA_DIR",
 ]
 
 from pythainlp.tools.path import (
+    PYTHAINLP_DEFAULT_DATA_DIR,
     get_full_data_path,
     get_pythainlp_data_path,
     get_pythainlp_path,
-    PYTHAINLP_DATA_DIR,
 )

--- a/pythainlp/tools/path.py
+++ b/pythainlp/tools/path.py
@@ -6,7 +6,7 @@ For text processing and text conversion, see pythainlp.util
 """
 import os
 
-import pythainlp
+from pythainlp import __file__ as pythainlp_file
 
 PYTHAINLP_DEFAULT_DATA_DIR = "pythainlp-data"
 
@@ -72,4 +72,4 @@ def get_pythainlp_path() -> str:
         get_pythainlp_path()
         # output: '/usr/local/lib/python3.6/dist-packages/pythainlp'
     """
-    return os.path.dirname(pythainlp.__file__)
+    return os.path.dirname(pythainlp_file)

--- a/pythainlp/tools/path.py
+++ b/pythainlp/tools/path.py
@@ -8,7 +8,7 @@ import os
 
 import pythainlp
 
-PYTHAINLP_DATA_DIR = "pythainlp-data"
+PYTHAINLP_DEFAULT_DATA_DIR = "pythainlp-data"
 
 
 def get_full_data_path(path: str) -> str:
@@ -49,10 +49,10 @@ def get_pythainlp_data_path() -> str:
         get_pythainlp_data_path()
         # output: '/root/pythainlp-data'
     """
-    path = os.getenv(
-        "PYTHAINLP_DATA_DIR", os.path.join("~", PYTHAINLP_DATA_DIR)
+    pythainlp_data_dir = os.getenv(
+        "PYTHAINLP_DATA_DIR", os.path.join("~", PYTHAINLP_DEFAULT_DATA_DIR)
     )
-    path = os.path.expanduser(path)
+    path = os.path.expanduser(pythainlp_data_dir)
     os.makedirs(path, exist_ok=True)
     return path
 

--- a/pythainlp/transliterate/royin.py
+++ b/pythainlp/transliterate/royin.py
@@ -143,41 +143,47 @@ def _replace_vowels(word: str) -> str:
     return word
 
 
-def _replace_consonants(word: str, res: str) -> str:
+def _replace_consonants(word: str, consonants: str) -> str:
     _HO_HIP = "\u0e2b"  # ห
     _RO_RUA = "\u0e23"  # ร
-    if not res:
+    if not consonants:
         pass
-    elif len(res) == 1:
-        word = word.replace(res[0], _CONSONANTS[res[0]][0])
+    elif len(consonants) == 1:
+        word = word.replace(consonants[0], _CONSONANTS[consonants[0]][0])
     else:
         i = 0
-        len_word = len(res)
-        while i < len_word:
-            if i == 0 and res[0] == _HO_HIP:
-                word = word.replace(res[0], "")
-                del res[0]
-                len_word -= 1
-            elif i == 0 and res[0] != _HO_HIP:
-                word = word.replace(res[0], _CONSONANTS[res[0]][0])
+        len_cons = len(consonants)
+        while i < len_cons:
+            if i == 0 and consonants[0] == _HO_HIP:
+                word = word.replace(consonants[0], "")
+                del consonants[0]
+                len_cons -= 1
+            elif i == 0 and consonants[0] != _HO_HIP:
+                word = word.replace(
+                    consonants[0], _CONSONANTS[consonants[0]][0]
+                )
                 i += 1
-            elif res[i] == _RO_RUA and (
+            elif consonants[i] == _RO_RUA and (
                 word[i] == _RO_RUA and len(word) == i + 1
             ):
-                word = word.replace(res[i], _CONSONANTS[res[i]][1])
-            elif res[i] == _RO_RUA and (
+                word = word.replace(
+                    consonants[i], _CONSONANTS[consonants[i]][1]
+                )
+            elif consonants[i] == _RO_RUA and (
                 word[i] == _RO_RUA and word[i + 1] == _RO_RUA
             ):
                 word = list(word)
                 del word[i + 1]
-                if i + 2 == len_word:
+                if i + 2 == len_cons:
                     word[i] = "an"
                 else:
                     word[i] = "a"
                 word = "".join(word)
                 i += 1
             else:
-                word = word.replace(res[i], _CONSONANTS[res[i]][1])
+                word = word.replace(
+                    consonants[i], _CONSONANTS[consonants[i]][1]
+                )
                 i += 1
     return word
 
@@ -185,19 +191,19 @@ def _replace_consonants(word: str, res: str) -> str:
 # support function for romanize()
 def _romanize(word: str) -> str:
     """
-    :param str word: Thai word to be romanized, should have already been tokenized.
+    :param str word: a Thai word, should have already been tokenized.
     :return: Spells out how the Thai word should be pronounced.
     """
     word = _replace_vowels(_normalize(word))
-    res = _RE_CONSONANT.findall(word)
+    consonants = _RE_CONSONANT.findall(word)
 
     # 2-character word, all consonants
-    if len(word) == 2 and len(res) == 2:
+    if len(word) == 2 and len(consonants) == 2:
         word = list(word)
         word.insert(1, "o")
         word = "".join(word)
 
-    word = _replace_consonants(word, res)
+    word = _replace_consonants(word, consonants)
 
     return word
 

--- a/pythainlp/transliterate/royin.py
+++ b/pythainlp/transliterate/royin.py
@@ -167,10 +167,11 @@ def _replace_consonants(word: str, consonants: str) -> str:
                 )
                 i += 1
         elif consonants[i] == _RO_RUA and word[i] == _RO_RUA:
-            if len(word) == i + 1:
+            if i + 1 == len(word):
                 word = word.replace(
                     consonants[i], _CONSONANTS[consonants[i]][1]
                 )
+                i += 1
             elif word[i + 1] == _RO_RUA:
                 word = list(word)
                 del word[i + 1]

--- a/pythainlp/transliterate/royin.py
+++ b/pythainlp/transliterate/royin.py
@@ -146,32 +146,32 @@ def _replace_vowels(word: str) -> str:
 def _replace_consonants(word: str, consonants: str) -> str:
     _HO_HIP = "\u0e2b"  # ห
     _RO_RUA = "\u0e23"  # ร
+
     if not consonants:
-        pass
-    elif len(consonants) == 1:
-        word = word.replace(consonants[0], _CONSONANTS[consonants[0]][0])
-    else:
-        i = 0
-        len_cons = len(consonants)
-        while i < len_cons:
-            if i == 0 and consonants[0] == _HO_HIP:
+        return word
+
+    if len(consonants) == 1:
+        return word.replace(consonants[0], _CONSONANTS[consonants[0]][0])
+
+    i = 0
+    len_cons = len(consonants)
+    while i < len_cons:
+        if i == 0:
+            if consonants[0] == _HO_HIP:
                 word = word.replace(consonants[0], "")
                 del consonants[0]
                 len_cons -= 1
-            elif i == 0 and consonants[0] != _HO_HIP:
+            else:
                 word = word.replace(
                     consonants[0], _CONSONANTS[consonants[0]][0]
                 )
                 i += 1
-            elif consonants[i] == _RO_RUA and (
-                word[i] == _RO_RUA and len(word) == i + 1
-            ):
+        elif consonants[i] == _RO_RUA and word[i] == _RO_RUA:
+            if len(word) == i + 1:
                 word = word.replace(
                     consonants[i], _CONSONANTS[consonants[i]][1]
                 )
-            elif consonants[i] == _RO_RUA and (
-                word[i] == _RO_RUA and word[i + 1] == _RO_RUA
-            ):
+            elif word[i + 1] == _RO_RUA:
                 word = list(word)
                 del word[i + 1]
                 if i + 2 == len_cons:
@@ -180,11 +180,10 @@ def _replace_consonants(word: str, consonants: str) -> str:
                     word[i] = "a"
                 word = "".join(word)
                 i += 1
-            else:
-                word = word.replace(
-                    consonants[i], _CONSONANTS[consonants[i]][1]
-                )
-                i += 1
+        else:
+            word = word.replace(consonants[i], _CONSONANTS[consonants[i]][1])
+            i += 1
+
     return word
 
 

--- a/pythainlp/transliterate/royin.py
+++ b/pythainlp/transliterate/royin.py
@@ -171,7 +171,6 @@ def _replace_consonants(word: str, consonants: str) -> str:
                 word = word.replace(
                     consonants[i], _CONSONANTS[consonants[i]][1]
                 )
-                i += 1
             elif word[i + 1] == _RO_RUA:
                 word = list(word)
                 del word[i + 1]
@@ -180,6 +179,11 @@ def _replace_consonants(word: str, consonants: str) -> str:
                 else:
                     word[i] = "a"
                 word = "".join(word)
+                i += 1
+            else:
+                word = word.replace(
+                    consonants[i], _CONSONANTS[consonants[i]][1]
+                )
                 i += 1
         else:
             word = word.replace(consonants[i], _CONSONANTS[consonants[i]][1])

--- a/pythainlp/transliterate/thai2rom.py
+++ b/pythainlp/transliterate/thai2rom.py
@@ -15,6 +15,7 @@ device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
 _MODEL_NAME = "thai2rom-pytorch-attn"
 
+
 class ThaiTransliterator:
     def __init__(self):
         """

--- a/pythainlp/transliterate/thai2rom.py
+++ b/pythainlp/transliterate/thai2rom.py
@@ -9,24 +9,23 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from pythainlp.corpus import download, get_corpus_path
+from pythainlp.corpus import get_corpus_path
 
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
+_MODEL_NAME = "thai2rom-pytorch-attn"
 
 class ThaiTransliterator:
     def __init__(self):
         """
-        Transliteration of Thai words
+        Transliteration of Thai words.
+
         Now supports Thai to Latin (romanization)
         """
-        # Download the model, if it's not on your machine.
-        self.__filemodel = get_corpus_path("thai2rom-pytorch-attn")
-        if not self.__filemodel:
-            download("thai2rom-pytorch-attn")
-            self.__filemodel = get_corpus_path("thai2rom-pytorch-attn")
+        # get the model, will download if it's not available locally
+        self.__model_filename = get_corpus_path(_MODEL_NAME)
 
-        loader = torch.load(self.__filemodel, map_location=device)
+        loader = torch.load(self.__model_filename, map_location=device)
 
         INPUT_DIM, E_EMB_DIM, E_HID_DIM, E_DROPOUT = loader["encoder_params"]
         OUTPUT_DIM, D_EMB_DIM, D_HID_DIM, D_DROPOUT = loader["decoder_params"]

--- a/pythainlp/transliterate/thaig2p.py
+++ b/pythainlp/transliterate/thaig2p.py
@@ -10,24 +10,24 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from pythainlp.corpus import download, get_corpus_path
+from pythainlp.corpus import get_corpus_path
 
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
+_MODEL_NAME = "thai-g2p"
 
 
 class ThaiG2P:
     def __init__(self):
         """
-        Transliteration of Thai words
+        Transliteration of Thai words.
+
         Now supports Thai to Latin (romanization)
         """
-        # Download the model, if it's not on your machine.
-        self.__filemodel = get_corpus_path("thai-g2p")
-        if not self.__filemodel:
-            download("thai-g2p")
-            self.__filemodel = get_corpus_path("thai-g2p")
+        # get the model, will download if it's not available locally
+        self.__model_filename = get_corpus_path(_MODEL_NAME)
 
-        loader = torch.load(self.__filemodel, map_location=device)
+        loader = torch.load(self.__model_filename, map_location=device)
 
         INPUT_DIM, E_EMB_DIM, E_HID_DIM, E_DROPOUT = loader["encoder_params"]
         OUTPUT_DIM, D_EMB_DIM, D_HID_DIM, D_DROPOUT = loader["decoder_params"]
@@ -60,7 +60,7 @@ class ThaiG2P:
 
     def _prepare_sequence_in(self, text: str):
         """
-        Prepare input sequence for PyTorch
+        Prepare input sequence for PyTorch.
         """
         idxs = []
         for ch in text:

--- a/pythainlp/ulmfit/core.py
+++ b/pythainlp/ulmfit/core.py
@@ -7,7 +7,7 @@ from typing import Callable, Collection
 
 import numpy as np
 import torch
-from pythainlp.corpus import download, get_corpus_path
+from pythainlp.corpus import get_corpus_path
 from pythainlp.tokenize import THAI2FIT_TOKENIZER
 from pythainlp.ulmfit.preprocess import (
     fix_html,
@@ -32,25 +32,10 @@ _MODEL_NAME_LSTM = "wiki_lm_lstm"
 _ITOS_NAME_LSTM = "wiki_itos_lstm"
 
 
-# Download pretrained models
-def _get_path(fname: str) -> str:
-    """
-    :meth: download get path of file from pythainlp-corpus
-    :param str fname: file name
-    :return: path to downloaded file
-    """
-    path = get_corpus_path(fname)
-    if not path:
-        download(fname)
-        path = get_corpus_path(fname)
-    return path
-
-
-# Pretrained paths
-# TODO: Let the user decide if they like to download (at setup?)
+# Pretrained model paths
 THWIKI_LSTM = dict(
-    wgts_fname=_get_path(_MODEL_NAME_LSTM),
-    itos_fname=_get_path(_ITOS_NAME_LSTM),
+    wgts_fname=get_corpus_path(_MODEL_NAME_LSTM),
+    itos_fname=get_corpus_path(_ITOS_NAME_LSTM),
 )
 
 # Preprocessing rules for Thai text

--- a/pythainlp/word_vector/core.py
+++ b/pythainlp/word_vector/core.py
@@ -4,33 +4,26 @@ from typing import List, Tuple
 from gensim.models import KeyedVectors
 from gensim.models.keyedvectors import Word2VecKeyedVectors
 from numpy import ndarray, zeros
-from pythainlp.corpus import download, get_corpus_path
+from pythainlp.corpus import get_corpus_path
 from pythainlp.tokenize import THAI2FIT_TOKENIZER
 
 WV_DIM = 300  # word vector dimension
 
-_THAI2FIT_WV = "thai2fit_wv"
+_MODEL_NAME = "thai2fit_wv"
 
 _TK_SP = "xxspace"
 _TK_EOL = "xxeol"
 
 
-def _download() -> str:
-    path = get_corpus_path(_THAI2FIT_WV)
-    if not path:
-        download(_THAI2FIT_WV)
-        path = get_corpus_path(_THAI2FIT_WV)
-    return path
-
-
 def get_model() -> Word2VecKeyedVectors:
     """
-    Download model
+    Get word vector model.
 
     :return: `gensim` word2vec model
     :rtype: gensim.models.keyedvectors.Word2VecKeyedVectors
     """
-    return KeyedVectors.load_word2vec_format(_download(), binary=True)
+    path = get_corpus_path(_MODEL_NAME)
+    return KeyedVectors.load_word2vec_format(path, binary=True)
 
 
 _MODEL = get_model()

--- a/tests/test_transliterate.py
+++ b/tests/test_transliterate.py
@@ -3,11 +3,45 @@
 import unittest
 
 import torch
-from pythainlp.corpus import download
 from pythainlp.transliterate import romanize, transliterate
 from pythainlp.transliterate.ipa import trans_list, xsampa_list
-from pythainlp.transliterate.royin import romanize as romanize_royin
 from pythainlp.transliterate.thai2rom import ThaiTransliterator
+
+_BASIC_TESTS = {
+    None: "",
+    "": "",
+    "หมอก": "mok",
+    "หาย": "hai",
+    "แมว": "maeo",
+    "เดือน": "duean",
+    "ดำ": "dam",
+    "ดู": "du",
+    "บัว": "bua",
+    "กก": "kok",
+    "กร": "kon",
+    "กรร": "kan",
+    "กรรม": "kam",
+    "กรม": "krom",  # failed
+    "ฝ้าย": "fai",
+    "นพพร": "nopphon",
+    "ทีปกร": "thipakon",  # failed
+    "ธรรพ์": "than",  # failed
+    "ธรรม": "tham",  # failed
+    "มหา": "maha",  # failed
+    "หยาก": "yak",  # failed
+    "อยาก": "yak",  # failed
+    "ยมก": "yamok",  # failed
+    "กลัว": "klua",  # failed
+    "บ้านไร่": "banrai",  # failed
+    "ชารินทร์": "charin",  # failed
+}
+
+_CONSISTENCY_TESTS = [
+    ("กระจก", "กระ", "จก"),
+    ("ระเบิด", "ระ", "เบิด"),
+    ("หยากไย่", "หยาก", "ไย่"),
+    ("ตากใบ", "ตาก", "ใบ"),
+]
 
 
 class TestTransliteratePackage(unittest.TestCase):
@@ -16,32 +50,18 @@ class TestTransliteratePackage(unittest.TestCase):
         self.assertEqual(romanize(""), "")
         self.assertEqual(romanize("แมว"), "maeo")
 
-        self.assertEqual(romanize_royin(None), "")
-        self.assertEqual(romanize_royin(""), "")
-        self.assertEqual(romanize_royin("หาย"), "hai")
-        self.assertEqual(romanize_royin("หมอก"), "mok")
-        # self.assertEqual(romanize_royin("มหา"), "maha")  # not pass
-        # self.assertEqual(romanize_royin("หยาก"), "yak")  # not pass
-        # self.assertEqual(romanize_royin("อยาก"), "yak")  # not pass
-        # self.assertEqual(romanize_royin("ยมก"), "yamok")  # not pass
-        # self.assertEqual(romanize_royin("กลัว"), "klua")  # not pass
-        # self.assertEqual(romanize_royin("กลัว"), "klua")  # not pass
+        for word in _BASIC_TESTS:
+            expect = _BASIC_TESTS[word]
+            self.assertEqual(romanize(word, engine="royin"), expect)
 
-        self.assertEqual(romanize("แมว", engine="royin"), "maeo")  # not pass
-        self.assertEqual(romanize("เดือน", engine="royin"), "duean")
-        self.assertEqual(romanize("ดู", engine="royin"), "du")
-        self.assertEqual(romanize("ดำ", engine="royin"), "dam")
-        self.assertEqual(romanize("บัว", engine="royin"), "bua")
-        self.assertEqual(romanize("กร", engine="royin"), "kon")
-        self.assertEqual(romanize("กรร", engine="royin"), "kan")
-        self.assertEqual(romanize("กรรม", engine="royin"), "kam")
-        self.assertIsNotNone(romanize("กก", engine="royin"))
-        self.assertIsNotNone(romanize("ฝ้าย", engine="royin"))
-        self.assertIsNotNone(romanize("นพพร", engine="royin"))
-        self.assertIsNotNone(romanize("ทีปกร", engine="royin"))
-        self.assertIsNotNone(romanize("กรม", engine="royin"))
-        self.assertIsNotNone(romanize("ธรรพ์", engine="royin"))
-        self.assertIsNotNone(romanize("กฏa์1์ ์", engine="royin"))
+        # for word, part1, part2 in _CONSISTENCY_TESTS:
+        #     self.assertEqual(
+        #         romanize(word, engine="royin"),
+        #         (
+        #             romanize(part1, engine="royin")
+        #             + romanize(part2, engine="royin")
+        #         ),
+        #     )
 
     def test_romanize_thai2rom(self):
         self.assertEqual(romanize("แมว", engine="thai2rom"), "maeo")

--- a/tests/test_transliterate.py
+++ b/tests/test_transliterate.py
@@ -21,25 +21,25 @@ _BASIC_TESTS = {
     "กร": "kon",
     "กรร": "kan",
     "กรรม": "kam",
-    "กรม": "krom",  # failed
+    # "กรม": "krom",  # failed
     "ฝ้าย": "fai",
     "นพพร": "nopphon",
-    "ทีปกร": "thipakon",  # failed
-    "ธรรพ์": "than",  # failed
-    "ธรรม": "tham",  # failed
-    "มหา": "maha",  # failed
-    "หยาก": "yak",  # failed
-    "อยาก": "yak",  # failed
-    "ยมก": "yamok",  # failed
-    "กลัว": "klua",  # failed
-    "บ้านไร่": "banrai",  # failed
-    "ชารินทร์": "charin",  # failed
+    # "ทีปกร": "thipakon",  # failed
+    # "ธรรพ์": "than",  # failed
+    # "ธรรม": "tham",  # failed
+    # "มหา": "maha",  # failed
+    # "หยาก": "yak",  # failed
+    # "อยาก": "yak",  # failed
+    # "ยมก": "yamok",  # failed
+    # "กลัว": "klua",  # failed
+    # "บ้านไร่": "banrai",  # failed
+    # "ชารินทร์": "charin",  # failed
 }
 
 _CONSISTENCY_TESTS = [
     ("กระจก", "กระ", "จก"),
     ("ระเบิด", "ระ", "เบิด"),
-    ("หยากไย่", "หยาก", "ไย่"),
+    # ("หยากไย่", "หยาก", "ไย่"),  # failed
     ("ตากใบ", "ตาก", "ใบ"),
 ]
 
@@ -54,14 +54,14 @@ class TestTransliteratePackage(unittest.TestCase):
             expect = _BASIC_TESTS[word]
             self.assertEqual(romanize(word, engine="royin"), expect)
 
-        # for word, part1, part2 in _CONSISTENCY_TESTS:
-        #     self.assertEqual(
-        #         romanize(word, engine="royin"),
-        #         (
-        #             romanize(part1, engine="royin")
-        #             + romanize(part2, engine="royin")
-        #         ),
-        #     )
+        for word, part1, part2 in _CONSISTENCY_TESTS:
+            self.assertEqual(
+                romanize(word, engine="royin"),
+                (
+                    romanize(part1, engine="royin")
+                    + romanize(part2, engine="royin")
+                ),
+            )
 
     def test_romanize_thai2rom(self):
         self.assertEqual(romanize("แมว", engine="thai2rom"), "maeo")

--- a/tests/test_transliterate.py
+++ b/tests/test_transliterate.py
@@ -27,7 +27,7 @@ class TestTransliteratePackage(unittest.TestCase):
         # self.assertEqual(romanize_royin("กลัว"), "klua")  # not pass
         # self.assertEqual(romanize_royin("กลัว"), "klua")  # not pass
 
-        self.assertEqual(romanize("แมว", engine="royin"), "maeo") # not pass
+        self.assertEqual(romanize("แมว", engine="royin"), "maeo")  # not pass
         self.assertEqual(romanize("เดือน", engine="royin"), "duean")
         self.assertEqual(romanize("ดู", engine="royin"), "du")
         self.assertEqual(romanize("ดำ", engine="royin"), "dam")

--- a/tests/test_transliterate.py
+++ b/tests/test_transliterate.py
@@ -36,11 +36,15 @@ _BASIC_TESTS = {
     # "ชารินทร์": "charin",  # failed
 }
 
+# these are set of two-syllable words,
+# to test if the transliteration/romanization is consistent, say
+# romanize(1+2) = romanize(1) + romanize(2)
 _CONSISTENCY_TESTS = [
-    ("กระจก", "กระ", "จก"),
-    ("ระเบิด", "ระ", "เบิด"),
+    # ("กระจก", "กระ", "จก"),  # failed
+    # ("ระเบิด", "ระ", "เบิด"),  # failed
     # ("หยากไย่", "หยาก", "ไย่"),  # failed
     ("ตากใบ", "ตาก", "ใบ"),
+    # ("จัดสรร", "จัด", "สรร"),  # failed
 ]
 
 
@@ -50,10 +54,12 @@ class TestTransliteratePackage(unittest.TestCase):
         self.assertEqual(romanize(""), "")
         self.assertEqual(romanize("แมว"), "maeo")
 
+    def test_romanize_royin_basic(self):
         for word in _BASIC_TESTS:
             expect = _BASIC_TESTS[word]
             self.assertEqual(romanize(word, engine="royin"), expect)
 
+    def test_romanize_royin_consistency(self):
         for word, part1, part2 in _CONSISTENCY_TESTS:
             self.assertEqual(
                 romanize(word, engine="royin"),

--- a/tests/test_transliterate.py
+++ b/tests/test_transliterate.py
@@ -27,7 +27,7 @@ class TestTransliteratePackage(unittest.TestCase):
         # self.assertEqual(romanize_royin("กลัว"), "klua")  # not pass
         # self.assertEqual(romanize_royin("กลัว"), "klua")  # not pass
 
-        # self.assertEqual(romanize("แมว", engine="royin"), "maeo") # not pass
+        self.assertEqual(romanize("แมว", engine="royin"), "maeo") # not pass
         self.assertEqual(romanize("เดือน", engine="royin"), "duean")
         self.assertEqual(romanize("ดู", engine="royin"), "du")
         self.assertEqual(romanize("ดำ", engine="royin"), "dam")
@@ -37,6 +37,7 @@ class TestTransliteratePackage(unittest.TestCase):
         self.assertEqual(romanize("กรรม", engine="royin"), "kam")
         self.assertIsNotNone(romanize("กก", engine="royin"))
         self.assertIsNotNone(romanize("ฝ้าย", engine="royin"))
+        self.assertIsNotNone(romanize("นพพร", engine="royin"))
         self.assertIsNotNone(romanize("ทีปกร", engine="royin"))
         self.assertIsNotNone(romanize("กรม", engine="royin"))
         self.assertIsNotNone(romanize("ธรรพ์", engine="royin"))

--- a/tests/test_transliterate.py
+++ b/tests/test_transliterate.py
@@ -101,7 +101,6 @@ class TestTransliteratePackage(unittest.TestCase):
         )
 
     def test_transliterate(self):
-        download("thai-g2p", force=True)
         self.assertEqual(transliterate(""), "")
         self.assertEqual(transliterate("แมว", "pyicu"), "mæw")
         self.assertEqual(transliterate("คน", engine="ipa"), "kʰon")


### PR DESCRIPTION
- Remove corpus download code that scattered around and put them in one single `get_corpus_path()`.
- Make sure the download starts when necessary as intended (check both listing in the corpus catalog and the actual existence of the file)
- In the future, will there be any change (like to resolve #298 and #385), hopefully one can change it only once at `get_corpus_path()` and need to

Also:
- Refactor `royin` romanization function
- Add more test cases for `royin` romanization (found few bugs along the way - see #415)
- Refactor `ThaiNameTagger()`, remove unnessary `self.` references

This will partly close #411 