### PR TITLE
Add family names

### DIFF
--- a/docs/api/corpus.rst
+++ b/docs/api/corpus.rst
@@ -19,6 +19,7 @@ Modules
 .. autofunction:: thai_words
 .. autofunction:: thai_syllables
 .. autofunction:: thai_negations
+.. autofunction:: thai_family_names
 .. autofunction:: thai_female_names
 .. autofunction:: thai_male_names
 .. autofunction:: pythainlp.corpus.conceptnet.edges

--- a/pythainlp/corpus/__init__.py
+++ b/pythainlp/corpus/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     "get_corpus_path",
     "provinces",
     "remove",
+    "thai_family_names",
     "thai_female_names",
     "thai_male_names",
     "thai_negations",
@@ -86,6 +87,7 @@ from pythainlp.corpus.core import (
 from pythainlp.corpus.common import (
     countries,
     provinces,
+    thai_family_names,
     thai_female_names,
     thai_male_names,
     thai_negations,

--- a/pythainlp/corpus/common.py
+++ b/pythainlp/corpus/common.py
@@ -6,6 +6,7 @@ Common list of words.
 __all__ = [
     "countries",
     "provinces",
+    "thai_family_names",
     "thai_female_names",
     "thai_male_names",
     "thai_negations",
@@ -14,8 +15,9 @@ __all__ = [
     "thai_words",
 ]
 
-from pythainlp.corpus import get_corpus
 from typing import Union
+
+from pythainlp.corpus import get_corpus
 
 _THAI_COUNTRIES = set()
 _THAI_COUNTRIES_FILENAME = "countries_th.txt"
@@ -36,6 +38,8 @@ _THAI_STOPWORDS_FILENAME = "stopwords_th.txt"
 _THAI_NEGATIONS = set()
 _THAI_NEGATIONS_FILENAME = "negations_th.txt"
 
+_THAI_FAMLIY_NAMES = set()
+_THAI_FAMLIY_NAMES_FILENAME = "family_names_th.txt"
 _THAI_FEMALE_NAMES = set()
 _THAI_FEMALE_NAMES_FILENAME = "person_names_female_th.txt"
 _THAI_MALE_NAMES = set()
@@ -165,6 +169,22 @@ def thai_negations() -> frozenset:
         _THAI_NEGATIONS = get_corpus(_THAI_NEGATIONS_FILENAME)
 
     return _THAI_NEGATIONS
+
+
+def thai_family_names() -> frozenset:
+    """
+    Return a frozenset of Thai family names
+    \n(See: `dev/pythainlp/corpus/family_names_th.txt\
+    <https://github.com/PyThaiNLP/pythainlp/blob/dev/pythainlp/corpus/family_names_th.txt>`_)
+
+    :return: :class:`frozenset` containing Thai family names.
+    :rtype: :class:`frozenset`
+    """
+    global _THAI_FAMLIY_NAMES
+    if not _THAI_FAMLIY_NAMES:
+        _THAI_FAMLIY_NAMES = get_corpus(_THAI_FAMLIY_NAMES_FILENAME)
+
+    return _THAI_FAMLIY_NAMES
 
 
 def thai_female_names() -> frozenset:

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -12,6 +12,7 @@ from pythainlp.corpus import (
     get_corpus_path,
     provinces,
     remove,
+    thai_family_names,
     thai_female_names,
     thai_male_names,
     thai_negations,
@@ -41,6 +42,8 @@ class TestCorpusPackage(unittest.TestCase):
         self.assertEqual(
             len(provinces(details=False)), len(provinces(details=True))
         )
+        self.assertIsInstance(thai_family_names(), frozenset)
+        self.assertIsInstance(list(thai_family_names())[0], str)
         self.assertIsInstance(thai_female_names(), frozenset)
         self.assertIsInstance(thai_male_names(), frozenset)
 


### PR DESCRIPTION
`thai_family_names()` - make access to Thai family names in the existing corpus.

(sorry for the bad branch name)