### PR TITLE
Fix remove_repeat_vowels() bug that remove spaces between vowel

### DIFF
--- a/pythainlp/util/normalize.py
+++ b/pythainlp/util/normalize.py
@@ -38,7 +38,7 @@ _NOREPEAT_CHARS = (
     f"{follow_v}{lead_v}{above_v}{below_v}\u0e3a\u0e4c\u0e4d\u0e4e"
 )
 _NOREPEAT_PAIRS = list(
-    zip([f"({ch}[ ]*)+" for ch in _NOREPEAT_CHARS], _NOREPEAT_CHARS)
+    zip([f"({ch}[ ]*)+{ch}" for ch in _NOREPEAT_CHARS], _NOREPEAT_CHARS)
 )
 
 _RE_TONEMARKS = re.compile(f"[{tonemarks}]+")


### PR DESCRIPTION
It was mistakenly convert string like "ะ า" to "ะา".
With this fix it will produces "ะ า", correctly.