### PR TITLE
PyThaiNLP v2.3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: Unit test and code coverage
 
 on:
   push:
-    branches:
-      - dev
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,10 +108,10 @@ Make sure the same tests pass on Travis CI and AppVeyor.
   #current_version = 2.3.6-dev0
 
   bumpversion minor
-  #current_version = 2.3.0-dev0
+  #current_version = 2.3.1-dev0
 
   bumpversion build
-  #current_version = 2.3.0-dev1
+  #current_version = 2.3.1-dev1
 
   bumpversion major
   #current_version = 3.0.0-dev0

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ PyThaiNLP เป็นไลบารีภาษาไพทอนสำหร�
 
 | Version | Description | Status |
 |:------:|:--:|:------:|
-| [2.3.0](https://github.com/PyThaiNLP/pythainlp/releases) | Stable | [Change Log](https://github.com/PyThaiNLP/pythainlp/issues/445) |
+| [2.3.1](https://github.com/PyThaiNLP/pythainlp/releases) | Stable | [Change Log](https://github.com/PyThaiNLP/pythainlp/issues/445) |
 | [`dev`](https://github.com/PyThaiNLP/pythainlp/tree/dev) | Release Candidate for 2.4  | [Change Log](https://github.com/PyThaiNLP/pythainlp/issues/545) |
 
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ PyThaiNLP เป็นไลบารีภาษาไพทอนสำหร�
 | Version | Description | Status |
 |:------:|:--:|:------:|
 | [2.3.0](https://github.com/PyThaiNLP/pythainlp/releases) | Stable | [Change Log](https://github.com/PyThaiNLP/pythainlp/issues/445) |
-| [`dev`](https://github.com/PyThaiNLP/pythainlp/tree/dev) | Release Candidate for 2.4  | [Change Log](https://github.com/PyThaiNLP/pythainlp/issues/445) |
+| [`dev`](https://github.com/PyThaiNLP/pythainlp/tree/dev) | Release Candidate for 2.4  | [Change Log](https://github.com/PyThaiNLP/pythainlp/issues/545) |
 
 
 ## Getting Started

--- a/README_TH.md
+++ b/README_TH.md
@@ -22,7 +22,7 @@ PyThaiNLP เป็นไลบารีภาษาไพทอนสำหร�
 
 | รุ่น | คำอธิบาย | สถานะ |
 |:------:|:--:|:------:|
-| [2.3.0](https://github.com/PyThaiNLP/pythainlp/releases) | Stable | [Change Log](https://github.com/PyThaiNLP/pythainlp/issues/445) |
+| [2.3.1](https://github.com/PyThaiNLP/pythainlp/releases) | Stable | [Change Log](https://github.com/PyThaiNLP/pythainlp/issues/445) |
 | [`dev`](https://github.com/PyThaiNLP/pythainlp/tree/dev) | Release Candidate for 2.4  | [Change Log](https://github.com/PyThaiNLP/pythainlp/issues/545) |
 
 ติดตามพวกเราบน [PyThaiNLP Facebook page](https://www.facebook.com/pythainlp/) เพื่อรับข่าวสารเพิ่มเติม

--- a/README_TH.md
+++ b/README_TH.md
@@ -23,7 +23,7 @@ PyThaiNLP เป็นไลบารีภาษาไพทอนสำหร�
 | รุ่น | คำอธิบาย | สถานะ |
 |:------:|:--:|:------:|
 | [2.3.0](https://github.com/PyThaiNLP/pythainlp/releases) | Stable | [Change Log](https://github.com/PyThaiNLP/pythainlp/issues/445) |
-| [`dev`](https://github.com/PyThaiNLP/pythainlp/tree/dev) | Release Candidate for 2.4  | [Change Log](https://github.com/PyThaiNLP/pythainlp/issues/445) |
+| [`dev`](https://github.com/PyThaiNLP/pythainlp/tree/dev) | Release Candidate for 2.4  | [Change Log](https://github.com/PyThaiNLP/pythainlp/issues/545) |
 
 ติดตามพวกเราบน [PyThaiNLP Facebook page](https://www.facebook.com/pythainlp/) เพื่อรับข่าวสารเพิ่มเติม
 

--- a/pythainlp/__init__.py
+++ b/pythainlp/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = "2.3.0"
+__version__ = "2.3.1-dev0"
 
 thai_consonants = "กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรลวศษสหฬอฮ"  # 44 chars
 

--- a/pythainlp/__init__.py
+++ b/pythainlp/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = "2.3.1-beta0"
+__version__ = "2.3.1"
 
 thai_consonants = "กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรลวศษสหฬอฮ"  # 44 chars
 

--- a/pythainlp/__init__.py
+++ b/pythainlp/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = "2.3.1-dev0"
+__version__ = "2.3.1-beta0"
 
 thai_consonants = "กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรลวศษสหฬอฮ"  # 44 chars
 

--- a/pythainlp/word_vector/core.py
+++ b/pythainlp/word_vector/core.py
@@ -257,7 +257,7 @@ def sentence_vectorizer(text: str, use_mean: bool = True) -> ndarray:
         elif word == "\n":
             word = _TK_EOL
 
-        if word in _MODEL.index2word:
+        if word in _MODEL.index_to_key:
             vec += _MODEL.word_vec(word)
 
     if use_mean:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.3.1-dev0
+current_version = 2.3.1-beta0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.3.1-beta0
+current_version = 2.3.1
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.3.0
+current_version = 2.3.1-dev0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ extras = {
 
 setup(
     name="pythainlp",
-    version="2.3.1-beta0",
+    version="2.3.1",
     description="Thai Natural Language Processing library",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ extras = {
 
 setup(
     name="pythainlp",
-    version="2.3.1-dev0",
+    version="2.3.1-beta0",
     description="Thai Natural Language Processing library",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ extras = {
 
 setup(
     name="pythainlp",
-    version="2.3.0",
+    version="2.3.1-dev0",
     description="Thai Natural Language Processing library",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
`PyThaiNLP v2.3.1` is This release is a bug fix release of PyThaiNLP 2.3.

**Bug Fixed**
- Fix gensim #546

Documentation: [https://pythainlp.github.io/docs/2.3/index.html](https://pythainlp.github.io/docs/2.3/index.html
)
Report bug: [https://github.com/PyThaiNLP/pythainlp/issues](https://github.com/PyThaiNLP/pythainlp/issues)


You can install or upgrade using *pip install -U pythainlp*


See [PyThaiNLP 2.3 change log](https://github.com/PyThaiNLP/pythainlp/issues/445) #445

## Deprecation and other API changes
- NER change a ThaiNER model (from ThaiNER 1.4 to ThaiNER 1.5). If you need use ThaiNER 1.4 model, You can use version in ThaiNameTagger class. `pythainlp.tag.named_entity.ThaiNameTagger(version: str = '1.4')` (Docs: https://pythainlp.github.io/dev-docs/api/tag.html#pythainlp.tag.named_entity.ThaiNameTagger)

## Tokenizer
- #484 Add: model option for `attacut.tokenize()`
- #502 Add: `corpus.util.revise_wordset()` to revise tokenization dictionary
- #503 Add: `NERCut` tokenization engine

## Corpus
- **License change:**
  - All corpora, datasets, and documentation created by PyThaiNLP project are now released under [Creative Commons Zero 1.0 Universal Public Domain Dedication License](https://creativecommons.org/publicdomain/zero/1.0/) (CC0).
  - All language models created by PyThaiNLP project are released under [Creative Commons Attribution 4.0 International Public License](https://creativecommons.org/licenses/by/4.0/) (CC-by).
- #449 Fix: remove instances with `[` or `]` from etcc.txt
- #467 Add: `corpus.common.provinces()` can now return romanized names
- #476 Add: `thai_family_names()` to get a set of Thai family names
- #487 Fix: `thailand_provinces_th.csv` not found issue
- #492 Fix: remove erroneous `AITT` tag from ORCHID to UD table -- thanks @c4n for the fix

## POS Tagger
- #464 Add: `LST20` language model for part-of-speech tagging
- #468 Add: port `PerceptronTagger` from NTLK. POS tagging no longer needs NLTK for dependency.
- #478 Update: ORCHID POS tags documentation

## Name Entity Tagging
- #526 Update ThaiNER 1.4 to ThaiNER 1.5
- #538 Add ThaiNameTagger version and add ThaiNER 1.4 support

## Transliterate
- #485 Fixed Romanize failed in some examples
- #511 Add Thai W2P (Thai Word-to-Phoneme converter)

## Text Summarize
- #523 Add mT5 text summarize to `pythainlp.summarize`

## Chunk parser
- #524 Add `pythainlp.tag.chunk`

## Util
- #481 Fix: `remove_repeat_vowels()` bug that remove spaces between different vowels
- #483 Add: add `remove()` method to remove a word from a trie -- thanks @korakot
- #490 Fix: `thai_strftime()` - normalize output for unsupported directive (running in glibc and musl should produce the same output)
- #512 Add: `emoji_to_thai()` to convert emoji to Thai description -- thanks @ppirch for the development
- #513 Add: `thai_keyboard_dist()` to calculate euclidean distance between two characters according to their location on a Thai keyboard layout -- thanks @ppirch for the development

Thanks all the [contributors](https://github.com/PyThaiNLP/pythainlp/graphs/contributors). (Image made with [contributors-img](https://contributors-img.firebaseapp.com))
<a href="https://github.com/PyThaiNLP/pythainlp/graphs/contributors">
  <img src="https://contributors-img.firebaseapp.com/image?repo=PyThaiNLP/pythainlp" />
</a>


We build Thai NLP.

PyThaiNLP