### PR TITLE
Deprecated syllable_tokenize #322

### DIFF
--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -422,7 +422,8 @@ def syllable_tokenize(
         'รถ', 'จักร', 'ดี', 'เซล', ' ', 'หรือ', 'จาก', 'ไฟ', 'ฟ้า']
     """
     warnings.warn(
-        "syllable_tokenize will be deprecated in PyThaiNLP version 2.4, use subword_tokenize instead",
+        """syllable_tokenize will be deprecated in PyThaiNLP version 2.4,
+        use subword_tokenize instead""",
         PendingDeprecationWarning
     )
 

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -422,8 +422,8 @@ def syllable_tokenize(
         'รถ', 'จักร', 'ดี', 'เซล', ' ', 'หรือ', 'จาก', 'ไฟ', 'ฟ้า']
     """
     warnings.warn(
-        "syllable_tokenize is deprecated, use subword_tokenize instead",
-        DeprecationWarning
+        "syllable_tokenize will be deprecated in PyThaiNLP version 2.4, use subword_tokenize instead",
+        PendingDeprecationWarning
     )
 
     if not text or not isinstance(text, str):

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -303,7 +303,7 @@ def subword_tokenize(
         * *tcc* (default) -  Thai Character Cluster (Theeramunkong et al. 2000)
         * *etcc* - Enhanced Thai Character Cluster (Inrut et al. 2001)
         * *wangchanberta* - SentencePiece from wangchanberta model.
-        * *dict* (default) - newmm word tokenizer with a syllable dictionary
+        * *dict* - newmm word tokenizer with a syllable dictionary
         * *ssg* - CRF syllable segmenter for Thai
 
     :Example:

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -300,6 +300,24 @@ class TestTokenizePackage(unittest.TestCase):
         self.assertFalse(
             " " in subword_tokenize("พันธมิตร ชา นม", keep_whitespace=False)
         )
+        self.assertEqual(
+            subword_tokenize("สวัสดีชาวโลก", engine="dict"), ["สวัส", "ดี", "ชาว", "โลก"]
+        )
+        self.assertFalse("า" in subword_tokenize("สวัสดีชาวโลก", engine="dict"))
+        self.assertEqual(subword_tokenize(None, engine="ssg"), [])
+        self.assertEqual(syllable_tokenize("", engine="ssg"), [])
+        self.assertEqual(
+            subword_tokenize("แมวกินปลา", engine="ssg"), ["แมว", "กิน", "ปลา"]
+        )
+        self.assertTrue(
+            "ดาว" in subword_tokenize("สวัสดีดาวอังคาร", engine="ssg")
+        )
+        self.assertFalse(
+            "า" in subword_tokenize("สวัสดีดาวอังคาร", engine="ssg")
+        )
+        self.assertFalse(
+            " " in subword_tokenize("พันธมิตร ชา นม", keep_whitespace=False)
+        )
         with self.assertRaises(ValueError):
             subword_tokenize("นกแก้ว", engine="XX")  # engine does not exist
 


### PR DESCRIPTION
syllable_tokenize is deprecated, use subword_tokenize instead #322

### What does this changes

Deprecated syllable_tokenize

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test
