### PR TITLE
Use get_vector() instead of deprecated word_vec()

### DIFF
--- a/pythainlp/word_vector/core.py
+++ b/pythainlp/word_vector/core.py
@@ -50,17 +50,9 @@ def doesnt_match(words: List[str]) -> str:
     Pick the word "พริกไทย" (name of food) out of the list of meals
     ("อาหารเช้า", "อาหารเที่ยง", "อาหารเย็น").
 
-    >>> from pythainlp.
-    
-    
-    
-    
-    
-    
-    
-    tor import doesnt_match
+    >>> from pythainlp.word_vector import doesnt_match
     >>>
-    >>> words = ['อาหารเช้า','อาหารเที่ยง','อาหารเย็น','พริกไทย']
+    >>> words = ['อาหารเช้า', 'อาหารเที่ยง', 'อาหารเย็น', 'พริกไทย']
     >>> doesnt_match(words)
     พริกไทย
 
@@ -196,7 +188,7 @@ def similarity(word1: str, word2: str) -> float:
     (train and electric train).
 
     >>> from pythainlp.word_vector import similarity
-    >>> similarity('รถไฟ','รถไฟฟ้า')
+    >>> similarity('รถไฟ', 'รถไฟฟ้า')
     0.43387136
 
 
@@ -204,7 +196,7 @@ def similarity(word1: str, word2: str) -> float:
     (leopard and electric train).
 
     >>> from pythainlp.word_vector import similarity
-    >>> similarity('เสือดาว','รถไฟฟ้า')
+    >>> similarity('เสือดาว', 'รถไฟฟ้า')
     0.04300258
 
     """

--- a/pythainlp/word_vector/core.py
+++ b/pythainlp/word_vector/core.py
@@ -50,7 +50,15 @@ def doesnt_match(words: List[str]) -> str:
     Pick the word "พริกไทย" (name of food) out of the list of meals
     ("อาหารเช้า", "อาหารเที่ยง", "อาหารเย็น").
 
-    >>> from pythainlp.word_vector import doesnt_match
+    >>> from pythainlp.
+    
+    
+    
+    
+    
+    
+    
+    tor import doesnt_match
     >>>
     >>> words = ['อาหารเช้า','อาหารเที่ยง','อาหารเย็น','พริกไทย']
     >>> doesnt_match(words)
@@ -258,7 +266,7 @@ def sentence_vectorizer(text: str, use_mean: bool = True) -> ndarray:
             word = _TK_EOL
 
         if word in _MODEL.index_to_key:
-            vec += _MODEL.word_vec(word)
+            vec += _MODEL.get_vector(word)
 
     if use_mean:
         vec /= len_words


### PR DESCRIPTION
### What does this changes

Update the function call to get word vector in `pythainlp/word_vector/core.py`

### What was wrong

Deprecated `word_vec()` is called.

### How this fixes it

Use `get_vector()` instead.

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [ ] Passed code styles and structures
- [ ] Passed code linting checks and unit test

