### PR TITLE
Fix token_max_len bug that makes it always zero

### DIFF
--- a/pythainlp/tokenize/newmm.py
+++ b/pythainlp/tokenize/newmm.py
@@ -183,7 +183,7 @@ def segment(
             token_max_idx = 0
             token_max_len = 0
             for i, token in enumerate(tokens):
-                if len(token) > token_max_len:
+                if len(token) >= token_max_len:
                     token_max_len = len(token)
                     token_max_idx = i
 

--- a/pythainlp/tokenize/newmm.py
+++ b/pythainlp/tokenize/newmm.py
@@ -181,8 +181,8 @@ def segment(
         else:
             tokens = list(_onecut(sample, custom_dict))
             token_max_idx = 0
+            token_max_len = 0
             for i, token in enumerate(tokens):
-                token_max_len = 0
                 if len(token) > token_max_len:
                     token_max_len = len(token)
                     token_max_idx = i


### PR DESCRIPTION
### What does this changes

Fix safe mode algorithm that choose the cut-off position.

### What was wrong

`token_max_len = 0` was inside for loop, makes it always reset to zero.

This make the cut-off position may not be the one that covers longest token.

### How this fixes it

Move `token_max_len = 0` outside of for loop.

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test
