### PR TITLE
Add text_to_num and words_to_num

### DIFF
--- a/docs/api/util.rst
+++ b/docs/api/util.rst
@@ -32,6 +32,7 @@ Modules
 .. autofunction:: remove_zw
 .. autofunction:: reorder_vowels
 .. autofunction:: text_to_arabic_digit
+.. autofunction:: text_to_num
 .. autofunction:: text_to_thai_digit
 .. autofunction:: thai_strftime
 .. autofunction:: thai_to_eng
@@ -40,5 +41,6 @@ Modules
 .. autofunction:: thaiword_to_num
 .. autofunction:: thaiword_to_time
 .. autofunction:: time_to_thaiword
+.. autofunction:: words_to_num
 .. autoclass:: Trie
    :members:

--- a/pythainlp/util/__init__.py
+++ b/pythainlp/util/__init__.py
@@ -41,6 +41,8 @@ __all__ = [
     "thaiword_to_num",
     "thaiword_to_time",
     "time_to_thaiword",
+    "text_to_num",
+    "words_to_num",
 ]
 
 from pythainlp.util.collate import collate
@@ -85,4 +87,4 @@ from pythainlp.util.thai import (
 from pythainlp.util.thaiwordcheck import is_native_thai
 from pythainlp.util.time import thai_time, thaiword_to_time, time_to_thaiword
 from pythainlp.util.trie import Trie, dict_trie
-from pythainlp.util.wordtonum import thaiword_to_num
+from pythainlp.util.wordtonum import thaiword_to_num, text_to_num, words_to_num

--- a/pythainlp/util/wordtonum.py
+++ b/pythainlp/util/wordtonum.py
@@ -51,7 +51,7 @@ def _check_is_thainum(word: str):
     for j in list(_digits.keys()):
         if j in word:
             return (True , 'num')
-    for j in ["สิบ", "ร้อย", "พัน", "หมื่น", "แสน", "ล้าน", "จุด"]:
+    for j in ["สิบ", "ร้อย", "พัน", "หมื่น", "แสน", "ล้าน", "จุด", "ลบ"]:
         if j in word:
             return (True, 'unit')
     return (False, None)
@@ -147,36 +147,17 @@ def words_to_num(words: list) -> float:
 
     """
     num = 0
-    _temp = 0
-    _last = None
-    for i,v in enumerate(words):
-        c = _check_is_thainum(v)
-        if c[1] == 'num' and i+1 == len(words) and _last=="จุด" and i+1 != len(words):
-            _temp *= int(thaiword_to_num(v))
-        elif c[1] == 'num' and i+1 == len(words):
-            _temp = int(thaiword_to_num(v))
-            num+=_temp
-        elif c[1] == 'num':
-            _temp = int(thaiword_to_num(v))
-            _last = 'num'
-        elif c[1] == 'unit' and v=="จุด":
-            if _temp!=0:
-                num+=_temp
-            _last = 'จุด'
-            num += _decimal_unit(words[i+1:])
-            break
-        elif c[1] == 'unit'and num != 0 and num < thaiword_to_num(v):
-            num*=thaiword_to_num(v)
-            _last = 'unit'
-        elif c[1] == 'unit' and _last == 'num':
-            _temp*=thaiword_to_num(v)
-            _last = 'unit'
-            num+=_temp
-            _temp = 0
-        elif c[1] == 'unit' and _last != 'num' and _temp == 0:
-            _temp=thaiword_to_num(v)
-            _last = 'num'
-            num+=_temp
+    if "จุด" not in words:
+        num = thaiword_to_num(''.join(words))
+    else:
+        words_int = ''.join(words[:words.index("จุด")])
+        words_float = words[words.index("จุด") + 1:]
+        num = thaiword_to_num(words_int)
+        if num <= -1:
+            num -= _decimal_unit(words_float)
+        else:
+            num += _decimal_unit(words_float)
+
     return num
 
 
@@ -220,6 +201,5 @@ def text_to_num(text: str) -> List[str]:
             list_word_new.append(word)
         else:
             list_word_new.append(word)
-            thainum.append(word)
             last_index = -1
     return list_word_new

--- a/pythainlp/util/wordtonum.py
+++ b/pythainlp/util/wordtonum.py
@@ -50,11 +50,12 @@ _tokenizer = Tokenizer(custom_dict=_valid_tokens)
 def _check_is_thainum(word: str):
     for j in list(_digits.keys()):
         if j in word:
-            return (True , 'num')
+            return (True, 'num')
     for j in ["สิบ", "ร้อย", "พัน", "หมื่น", "แสน", "ล้าน", "จุด", "ลบ"]:
         if j in word:
             return (True, 'unit')
     return (False, None)
+
 
 _dict_words = [i for i in list(thai_words()) if not _check_is_thainum(i)[0]]
 _dict_words += list(_digits.keys())
@@ -186,7 +187,11 @@ def text_to_num(text: str) -> List[str]:
     last_index = -1
     list_word_new = []
     for i, word in enumerate(_temp):
-        if _check_is_thainum(word)[0] and last_index+1 == i and i+1 == len(_temp):
+        if (
+            _check_is_thainum(word)[0]
+            and last_index+1 == i
+            and i+1 == len(_temp)
+        ):
             thainum.append(word)
             list_word_new.append(str(words_to_num(thainum)))
         elif _check_is_thainum(word)[0] and last_index+1 == i:
@@ -195,7 +200,11 @@ def text_to_num(text: str) -> List[str]:
         elif _check_is_thainum(word)[0]:
             thainum.append(word)
             last_index = i
-        elif not _check_is_thainum(word)[0] and last_index+1 == i and last_index != -1:
+        elif (
+            not _check_is_thainum(word)[0]
+            and last_index+1 == i
+            and last_index != -1
+        ):
             list_word_new.append(str(words_to_num(thainum)))
             thainum = []
             list_word_new.append(word)

--- a/pythainlp/util/wordtonum.py
+++ b/pythainlp/util/wordtonum.py
@@ -6,8 +6,10 @@ First version of the code adapted from Korakot Chaovavanich's notebook
 https://colab.research.google.com/drive/148WNIeclf0kOU6QxKd6pcfwpSs8l-VKD#scrollTo=EuVDd0nNuI8Q
 """
 import re
+from typing import List
 
 from pythainlp.tokenize import Tokenizer
+from pythainlp.corpus import thai_words
 
 _ptn_digits = r"(|หนึ่ง|เอ็ด|สอง|ยี่|สาม|สี่|ห้า|หก|เจ็ด|แปด|เก้า)"
 _ptn_six_figures = (
@@ -43,6 +45,22 @@ _valid_tokens = (
     set(_digits.keys()) | set(_powers_of_10.keys()) | {"ล้าน", "ลบ"}
 )
 _tokenizer = Tokenizer(custom_dict=_valid_tokens)
+
+
+def _check_is_thainum(word: str):
+    for j in list(_digits.keys()):
+        if j in word:
+            return (True , 'num')
+    for j in ["สิบ", "ร้อย", "พัน", "หมื่น", "แสน", "ล้าน", "จุด"]:
+        if j in word:
+            return (True, 'unit')
+    return (False, None)
+
+_dict_words = [i for i in list(thai_words()) if not _check_is_thainum(i)[0]]
+_dict_words += list(_digits.keys())
+_dict_words += ["สิบ", "ร้อย", "พัน", "หมื่น", "แสน", "ล้าน", "จุด"]
+
+_tokenizer_thaiwords = Tokenizer(_dict_words)
 
 
 def thaiword_to_num(word: str) -> int:
@@ -102,3 +120,106 @@ def thaiword_to_num(word: str) -> int:
         accumulated = -accumulated
 
     return accumulated
+
+
+def _decimal_unit(words: list) -> float:
+    _num = 0.0
+    for i, v in enumerate(words):
+        _num += int(thaiword_to_num(v)) / (10**(i+1))
+    return _num
+
+
+def words_to_num(words: list) -> float:
+    """
+    Thai Words to float
+
+    :param str text: Thai words
+    :return: float of words
+    :rtype: float
+
+    :Example:
+    ::
+
+        from pythainlp.util import words_to_num
+
+        words_to_num(["ห้า", "สิบ", "จุด", "เก้า", "ห้า"])
+        # output: 50.95
+
+    """
+    num = 0
+    _temp = 0
+    _last = None
+    for i,v in enumerate(words):
+        c = _check_is_thainum(v)
+        if c[1] == 'num' and i+1 == len(words) and _last=="จุด" and i+1 != len(words):
+            _temp *= int(thaiword_to_num(v))
+        elif c[1] == 'num' and i+1 == len(words):
+            _temp = int(thaiword_to_num(v))
+            num+=_temp
+        elif c[1] == 'num':
+            _temp = int(thaiword_to_num(v))
+            _last = 'num'
+        elif c[1] == 'unit' and v=="จุด":
+            if _temp!=0:
+                num+=_temp
+            _last = 'จุด'
+            num += _decimal_unit(words[i+1:])
+            break
+        elif c[1] == 'unit'and num != 0 and num < thaiword_to_num(v):
+            num*=thaiword_to_num(v)
+            _last = 'unit'
+        elif c[1] == 'unit' and _last == 'num':
+            _temp*=thaiword_to_num(v)
+            _last = 'unit'
+            num+=_temp
+            _temp = 0
+        elif c[1] == 'unit' and _last != 'num' and _temp == 0:
+            _temp=thaiword_to_num(v)
+            _last = 'num'
+            num+=_temp
+    return num
+
+
+def text_to_num(text: str) -> List[str]:
+    """
+    Thai text to list thai word with floating point number
+
+    :param str text: Thai text with the spelled-out numerals
+    :return: list of thai words with float value of the input
+    :rtype: List[str]
+
+    :Example:
+    ::
+
+        from pythainlp.util import text_to_num
+
+        text_to_num("เก้าร้อยแปดสิบจุดเก้าห้าบาทนี่คือจำนวนทั้งหมด")
+        # output: ['980.95', 'บาท', 'นี่', 'คือ', 'จำนวน', 'ทั้งหมด']
+
+        text_to_num("สิบล้านสองหมื่นหนึ่งพันแปดร้อยแปดสิบเก้าบาท")
+        # output: ['10021889', 'บาท']
+
+    """
+    _temp = _tokenizer_thaiwords.word_tokenize(text)
+    thainum = []
+    last_index = -1
+    list_word_new = []
+    for i, word in enumerate(_temp):
+        if _check_is_thainum(word)[0] and last_index+1 == i and i+1 == len(_temp):
+            thainum.append(word)
+            list_word_new.append(str(words_to_num(thainum)))
+        elif _check_is_thainum(word)[0] and last_index+1 == i:
+            thainum.append(word)
+            last_index = i
+        elif _check_is_thainum(word)[0]:
+            thainum.append(word)
+            last_index = i
+        elif not _check_is_thainum(word)[0] and last_index+1 == i and last_index != -1:
+            list_word_new.append(str(words_to_num(thainum)))
+            thainum = []
+            list_word_new.append(word)
+        else:
+            list_word_new.append(word)
+            thainum.append(word)
+            last_index = -1
+    return list_word_new

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -129,7 +129,7 @@ class TestUtilPackage(unittest.TestCase):
         self.assertEqual(words_to_num("ร้อยสิบล้านแปดแสนห้าพัน"), 110805000)
         self.assertEqual(words_to_num("ลบหนึ่ง"), -1)
         text = "ลบหนึ่งร้อยล้านสี่แสนห้าพันยี่สิบเอ็ด"
-        self.assertEqual(words_to_num(thaiword_to_num(text)), text)
+        self.assertEqual(num_to_thaiword(words_to_num(text)), text)
         self.assertIsNotNone(
             text_to_num("เก้าร้อยแปดสิบจุดเก้าห้าบาทนี่คือจำนวนทั้งหมด")
         )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -113,6 +113,9 @@ class TestUtilPackage(unittest.TestCase):
         self.assertEqual(words_to_num("แปด"), 8)
         self.assertEqual(words_to_num("ยี่สิบ"), 20)
         self.assertEqual(words_to_num("ร้อยสิบสอง"), 112)
+        self.assertEqual(words_to_num("ลบแปด"), -8)
+        self.assertEqual(words_to_num("ลบยี่สิบ"), -20)
+        self.assertEqual(words_to_num("ลบร้อยสิบสอง"), -112)
         self.assertEqual(
             words_to_num("หกล้านหกแสนหกหมื่นหกพันหกร้อยหกสิบหก"), 6666666
         )
@@ -135,6 +138,9 @@ class TestUtilPackage(unittest.TestCase):
         )
         self.assertIsNotNone(
             text_to_num("สิบล้านสองหมื่นหนึ่งพันแปดร้อยแปดสิบเก้าบาท")
+        )
+        self.assertIsNotNone(
+            text_to_num("สิบล้านสองหมื่นหนึ่งพันแปดร้อยแปดสิบเก้า")
         )
 
         self.assertEqual(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -130,8 +130,12 @@ class TestUtilPackage(unittest.TestCase):
         self.assertEqual(words_to_num("ลบหนึ่ง"), -1)
         text = "ลบหนึ่งร้อยล้านสี่แสนห้าพันยี่สิบเอ็ด"
         self.assertEqual(words_to_num(thaiword_to_num(text)), text)
-        self.assertIsNotNone(text_to_num("เก้าร้อยแปดสิบจุดเก้าห้าบาทนี่คือจำนวนทั้งหมด"))
-        self.assertIsNotNone(text_to_num("สิบล้านสองหมื่นหนึ่งพันแปดร้อยแปดสิบเก้าบาท"))
+        self.assertIsNotNone(
+            text_to_num("เก้าร้อยแปดสิบจุดเก้าห้าบาทนี่คือจำนวนทั้งหมด")
+        )
+        self.assertIsNotNone(
+            text_to_num("สิบล้านสองหมื่นหนึ่งพันแปดร้อยแปดสิบเก้าบาท")
+        )
 
         self.assertEqual(
             arabic_digit_to_thai_digit("ไทยแลนด์ 4.0"), "ไทยแลนด์ ๔.๐"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -45,6 +45,8 @@ from pythainlp.util import (
     thai_to_eng,
     thaiword_to_num,
     thai_keyboard_dist,
+    text_to_num,
+    words_to_num,
 )
 
 
@@ -106,6 +108,30 @@ class TestUtilPackage(unittest.TestCase):
             thaiword_to_num(None)
         with self.assertRaises(TypeError):
             thaiword_to_num(["หนึ่ง"])
+
+        self.assertEqual(words_to_num("ศูนย์"), 0)
+        self.assertEqual(words_to_num("แปด"), 8)
+        self.assertEqual(words_to_num("ยี่สิบ"), 20)
+        self.assertEqual(words_to_num("ร้อยสิบสอง"), 112)
+        self.assertEqual(
+            words_to_num("หกล้านหกแสนหกหมื่นหกพันหกร้อยหกสิบหก"), 6666666
+        )
+        self.assertEqual(words_to_num("สองล้านสามแสนหกร้อยสิบสอง"), 2300612)
+        self.assertEqual(words_to_num("หนึ่งร้อยสิบล้าน"), 110000000)
+        self.assertEqual(
+            words_to_num("สิบห้าล้านล้านเจ็ดสิบสอง"), 15000000000072
+        )
+        self.assertEqual(words_to_num("หนึ่งล้านล้าน"), 1000000000000)
+        self.assertEqual(
+            words_to_num("สองแสนสี่หมื่นสามสิบล้านสี่พันล้าน"),
+            240030004000000000,
+        )
+        self.assertEqual(words_to_num("ร้อยสิบล้านแปดแสนห้าพัน"), 110805000)
+        self.assertEqual(words_to_num("ลบหนึ่ง"), -1)
+        text = "ลบหนึ่งร้อยล้านสี่แสนห้าพันยี่สิบเอ็ด"
+        self.assertEqual(words_to_num(thaiword_to_num(text)), text)
+        self.assertIsNotNone(text_to_num("เก้าร้อยแปดสิบจุดเก้าห้าบาทนี่คือจำนวนทั้งหมด"))
+        self.assertIsNotNone(text_to_num("สิบล้านสองหมื่นหนึ่งพันแปดร้อยแปดสิบเก้าบาท"))
 
         self.assertEqual(
             arabic_digit_to_thai_digit("ไทยแลนด์ 4.0"), "ไทยแลนด์ ๔.๐"


### PR DESCRIPTION
### What does this changes

Add text_to_num and words_to_num

- `text_to_num` is Thai text to list thai word with floating point number.
- `words_to_num` is Thai Words to float

### How to used
```python
from pythainlp.util import words_to_num, text_to_num

words_to_num(["ห้า", "สิบ", "จุด", "เก้า", "ห้า"])
# output: 50.95

text_to_num("เก้าร้อยแปดสิบจุดเก้าห้าบาทนี่คือจำนวนทั้งหมด")
# output: ['980.95', 'บาท', 'นี่', 'คือ', 'จำนวน', 'ทั้งหมด']

text_to_num("สิบล้านสองหมื่นหนึ่งพันแปดร้อยแปดสิบเก้าบาท")
# output: ['10021889', 'บาท']
```

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test
