### PR TITLE
Update nlpo3 python v1.2.2

### DIFF
--- a/docker_requirements.txt
+++ b/docker_requirements.txt
@@ -27,4 +27,4 @@ tensorflow==2.5.1
 pandas==0.24
 tltk==1.3.8
 OSKut==1.3
-nlpo3==1.2.1
+nlpo3==1.2.2

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ extras = {
     ],
     "tltk": ["tltk>=1.3.8"],
     "oskut": ["oskut>=1.3"],
-    "nlpo3": ["nlpo3>=1.2.1"],
+    "nlpo3": ["nlpo3>=1.2.2"],
     "full": [
         "PyYAML>=5.3.1",
         "attacut>=1.0.4",
@@ -100,7 +100,7 @@ extras = {
         "symspellpy>=6.7.0",
         "tltk>=1.3.8",
         "oskut>=1.3",
-        "nlpo3>=1.2.1",
+        "nlpo3>=1.2.2",
     ],
 }
 


### PR DESCRIPTION
### What does this changes

Upgrade to nlpo3-python v1.2.2 to fix issue when using a dictionary file with blank lines.
See https://github.com/PyThaiNLP/nlpo3/issues/51

### What was wrong

Trim function was previously unable to handle a string with only whitespaces.
This makes an error when it got a string with only one "newline" char in it (from a blank line in a text file).

### How this fixes it

Update to nlpo3-python 1.2.2 where it already got fixed.
See https://github.com/PyThaiNLP/nlpo3/pull/54

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [ ] Passed code styles and structures
- [ ] Passed code linting checks and unit test
