### PR TITLE
Spoonerism: Add supports words more 3 syllables

### DIFF
--- a/pythainlp/transliterate/spoonerism.py
+++ b/pythainlp/transliterate/spoonerism.py
@@ -63,10 +63,14 @@ def puan(word: str, show_pronunciation: bool = True) -> str:
             list_w_char[1][1], list_w_char[2][1], 1)
         )
     else:  # > 3 syllables
-        _list_w.append(_list_pron[0].replace(list_w_char[0][1], list_w_char[-1][1], 1))
-        for i in range(1,len(list_w_char)-1):
+        _list_w.append(
+            _list_pron[0].replace(list_w_char[0][1], list_w_char[-1][1], 1)
+        )
+        for i in range(1, len(list_w_char)-1):
             _list_w.append(_list_pron[i])
-        _list_w.append(_list_pron[-1].replace(list_w_char[-1][1], list_w_char[0][1], 1))
+        _list_w.append(_list_pron[-1].replace(
+            list_w_char[-1][1], list_w_char[0][1], 1)
+        )
     if not show_pronunciation:
         _list_w = [i.replace("หฺ", "").replace('ฺ', '') for i in _list_w]
     return _mix_list.join(_list_w)

--- a/pythainlp/transliterate/spoonerism.py
+++ b/pythainlp/transliterate/spoonerism.py
@@ -10,7 +10,6 @@ def puan(word: str, show_pronunciation: bool = True) -> str:
     Thai Spoonerism
 
     This function converts Thai word to spoonerism word.
-    It only supports words with 2 to 3 syllables.
 
     :param str word: Thai word to be spoonerized
     :param bool show_pronunciation: True (default) or False
@@ -64,10 +63,10 @@ def puan(word: str, show_pronunciation: bool = True) -> str:
             list_w_char[1][1], list_w_char[2][1], 1)
         )
     else:  # > 3 syllables
-        raise ValueError(
-            """{0} is more than 3 syllables.\n
-            It only supports words with 2 to 3 syllables.""".format(word)
-        )
+        _list_w.append(_list_pron[0].replace(list_w_char[0][1], list_w_char[-1][1], 1))
+        for i in range(1,len(list_w_char)-1):
+            _list_w.append(_list_pron[i])
+        _list_w.append(_list_pron[-1].replace(list_w_char[-1][1], list_w_char[0][1], 1))
     if not show_pronunciation:
-        _list_w = [i.replace("หฺ", "") for i in _list_w]
+        _list_w = [i.replace("หฺ", "").replace('ฺ', '') for i in _list_w]
     return _mix_list.join(_list_w)

--- a/tests/test_transliterate.py
+++ b/tests/test_transliterate.py
@@ -155,8 +155,7 @@ class TestTransliteratePackage(unittest.TestCase):
 
     def test_puan(self):
         self.assertEqual(puan("นาริน"), "นิน-รา")
-        self.assertEqual(puan("นาริน", False), "นินรา")
+        self.assertEqual(puan("นาริน", show_pronunciation=False), "นินรา")
         self.assertEqual(puan("แสงดีนะ"), "แสง-ดะ-นี")
-        self.assertEqual(puan("แสงดีนะ", False), "แสงดะนี")
-        with self.assertRaises(ValueError):
-            self.assertEqual(puan("สวัสดีครับ"), "สวัสดีครับ")
+        self.assertEqual(puan("แสงดีนะ", show_pronunciation=False), "แสงดะนี")
+        self.assertEqual(puan("การทำความดี", show_pronunciation=False), "ดานทำความกี")

--- a/tests/test_transliterate.py
+++ b/tests/test_transliterate.py
@@ -154,6 +154,7 @@ class TestTransliteratePackage(unittest.TestCase):
         self.assertIsNotNone(pronunciate("jks", engine="w2p"))
 
     def test_puan(self):
+        self.assertEqual(puan("แมว"), "แมว")
         self.assertEqual(puan("นาริน"), "นิน-รา")
         self.assertEqual(puan("นาริน", show_pronunciation=False), "นินรา")
         self.assertEqual(puan("แสงดีนะ"), "แสง-ดะ-นี")

--- a/tests/test_transliterate.py
+++ b/tests/test_transliterate.py
@@ -158,4 +158,6 @@ class TestTransliteratePackage(unittest.TestCase):
         self.assertEqual(puan("นาริน", show_pronunciation=False), "นินรา")
         self.assertEqual(puan("แสงดีนะ"), "แสง-ดะ-นี")
         self.assertEqual(puan("แสงดีนะ", show_pronunciation=False), "แสงดะนี")
-        self.assertEqual(puan("การทำความดี", show_pronunciation=False), "ดานทำความกี")
+        self.assertEqual(
+            puan("การทำความดี", show_pronunciation=False), "ดานทำความกี"
+        )


### PR DESCRIPTION
### What does this changes

Spoonerism: Add supports words more 3 syllables

### What was wrong

From https://web.facebook.com/groups/thainlp/posts/1455899381458214/, I get feedback about rule for words more 3 syllables to spoonerism. Now, It's finish code.

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test
