### PR TITLE
Add Thai-French Machine Translation

### DIFF
--- a/docs/api/translate.rst
+++ b/docs/api/translate.rst
@@ -9,12 +9,9 @@ Modules
 
 .. autoclass:: Translate
    :members:
-.. autofunction:: download_model_all
-.. autoclass:: EnThTranslator
-   :members: translate
-.. autoclass:: ThEnTranslator
-   :members: translate
-.. autoclass:: ThZhTranslator
-   :members: translate
-.. autoclass:: ZhThTranslator
-   :members: translate
+.. autofunction::  pythainlp.translate.en_th.download_model_all
+.. autoclass::  pythainlp.translate.en_th.EnThTranslator
+.. autoclass::  pythainlp.translate.en_th.ThEnTranslator
+.. autoclass::  pythainlp.translate.zh_th.ThZhTranslator
+.. autoclass::  pythainlp.translate.zh_th.ZhThTranslator
+.. autoclass::  pythainlp.translate.th_fr.ThFrTranslator

--- a/pythainlp/translate/__init__.py
+++ b/pythainlp/translate/__init__.py
@@ -4,9 +4,6 @@ Language translation.
 """
 
 __all__ = [
-    "EnThTranslator",
-    "ThEnTranslator",
-    "download_model_all",
     "ThZhTranslator",
     "ZhThTranslator",
     "Translate"
@@ -14,11 +11,6 @@ __all__ = [
 
 from pythainlp.translate.core import Translate
 
-from pythainlp.translate.en_th import (
-    EnThTranslator,
-    ThEnTranslator,
-    download_model_all,
-)
 from pythainlp.translate.zh_th import (
     ThZhTranslator,
     ZhThTranslator,

--- a/pythainlp/translate/core.py
+++ b/pythainlp/translate/core.py
@@ -13,6 +13,7 @@ class Translate:
         * *en* - *th* - English to Thai
         * *th* - *zh* - Thai to Chinese
         * *zh* - *th* - Chinese to Thai
+        * *th* - *fr* - Thai to French
 
     :Example:
 
@@ -34,6 +35,7 @@ class Translate:
             * *en* - *th* - English to Thai
             * *th* - *zh* - Thai to Chinese
             * *zh* - *th* - Chinese to Thai
+            * *th* - *fr* - Thai to French
 
         :Example:
 
@@ -61,6 +63,9 @@ class Translate:
         elif src_lang == "zh" and target_lang == "th":
             from pythainlp.translate.zh_th import ZhThTranslator
             self.model = ZhThTranslator()
+        elif src_lang == "th" and target_lang == "fr":
+            from pythainlp.translate.th_fr import ThFrTranslator
+            self.model = ThFrTranslator()
         else:
             raise ValueError("Not support language!")
 

--- a/pythainlp/translate/th_fr.py
+++ b/pythainlp/translate/th_fr.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""
+Thai-French Machine Translation
+
+Trained by OPUS Corpus
+
+Model from Language Technology Research Group at the University of Helsinki
+
+BLEU 20.4
+
+- GitHub: https://github.com/Helsinki-NLP/OPUS-MT-train/tree/master/models/th-fr
+- Huggingface https://huggingface.co/Helsinki-NLP/opus-mt-th-fr
+"""
+from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
+
+
+class ThFrTranslator:
+    """
+    Thai-French Machine Translation
+
+    Trained by OPUS Corpus
+
+    Model from Language Technology Research Group at the University of Helsinki
+
+    BLEU 20.4
+
+    - GitHub: https://github.com/Helsinki-NLP/OPUS-MT-train/tree/master/models/th-fr
+    - Huggingface https://huggingface.co/Helsinki-NLP/opus-mt-th-fr
+    """
+    def __init__(self, pretrained: str = "Helsinki-NLP/opus-mt-th-fr") -> None:
+        self.tokenizer_thzh = AutoTokenizer.from_pretrained(pretrained)
+        self.model_thzh = AutoModelForSeq2SeqLM.from_pretrained(pretrained)
+
+    def translate(self, text: str) -> str:
+        """
+        Translate text from Thai to French
+
+        :param str text: input text in source language
+        :return: translated text in target language
+        :rtype: str
+
+        :Example:
+
+        Translate text from Thai to French::
+
+            from pythainlp.translate.th_fr import ThFrTranslator
+
+            thfr = ThFrTranslator()
+
+            thfr.translate("ทดสอบระบบ")
+            # output: "Test du système."
+
+        """
+        self.translated = self.model_thzh.generate(
+            **self.tokenizer_thzh(text, return_tensors="pt", padding=True)
+        )
+        return [
+            self.tokenizer_thzh.decode(
+                t, skip_special_tokens=True
+            ) for t in self.translated
+        ][0]

--- a/pythainlp/translate/th_fr.py
+++ b/pythainlp/translate/th_fr.py
@@ -8,7 +8,6 @@ Model from Language Technology Research Group at the University of Helsinki
 
 BLEU 20.4
 
-- GitHub: https://github.com/Helsinki-NLP/OPUS-MT-train/tree/master/models/th-fr
 - Huggingface https://huggingface.co/Helsinki-NLP/opus-mt-th-fr
 """
 from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
@@ -24,7 +23,6 @@ class ThFrTranslator:
 
     BLEU 20.4
 
-    - GitHub: https://github.com/Helsinki-NLP/OPUS-MT-train/tree/master/models/th-fr
     - Huggingface https://huggingface.co/Helsinki-NLP/opus-mt-th-fr
     """
     def __init__(self, pretrained: str = "Helsinki-NLP/opus-mt-th-fr") -> None:

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -3,12 +3,14 @@
 import unittest
 
 from pythainlp.translate import (
-    EnThTranslator,
-    ThEnTranslator,
     ThZhTranslator,
     ZhThTranslator,
-    download_model_all,
     Translate
+)
+from pythainlp.translate.en_th import (
+    EnThTranslator,
+    ThEnTranslator,
+    download_model_all
 )
 from pythainlp.corpus import remove
 
@@ -63,6 +65,12 @@ class TestTranslatePackage(unittest.TestCase):
         self.assertIsNotNone(
             self.zh_th_translator.translate(
                 "我爱你",
+            )
+        )
+        self.th_fr_translator = Translate('th', 'fr')
+        self.assertIsNotNone(
+            self.th_fr_translator.translate(
+                "ทดสอบระบบ",
             )
         )
         with self.assertRaises(ValueError):


### PR DESCRIPTION
### What does this changes

Add Thai-French Machine Translation

Trained by OPUS Corpus

Model from Language Technology Research Group at the University of Helsinki

BLEU 20.4

- GitHub: https://github.com/Helsinki-NLP/OPUS-MT-train/tree/master/models/th-fr
- Huggingface https://huggingface.co/Helsinki-NLP/opus-mt-th-fr

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test
