### PR TITLE
Add Thai-NNER

### DIFF
--- a/docker_requirements.txt
+++ b/docker_requirements.txt
@@ -28,3 +28,4 @@ pandas==0.24
 tltk==1.3.8
 OSKut==1.3
 nlpo3==1.2.2
+thai-nner==0.3

--- a/docs/api/tag.rst
+++ b/docs/api/tag.rst
@@ -232,6 +232,8 @@ Modules
 .. autofunction:: chunk_parse
 .. autoclass:: NER
    :members:
+.. autoclass:: NNER
+   :members:
 .. autoclass:: pythainlp.tag.thainer.ThaiNameTagger
    :members: get_ner
 .. autofunction:: pythainlp.tag.tltk.get_ner

--- a/pythainlp/tag/__init__.py
+++ b/pythainlp/tag/__init__.py
@@ -13,10 +13,11 @@ __all__ = [
     "tag_provinces",
     "chunk_parse",
     "NER",
+    "NNER",
 ]
 
 from pythainlp.tag.locations import tag_provinces
 from pythainlp.tag.pos_tag import pos_tag, pos_tag_sents
 from pythainlp.tag._tag_perceptron import PerceptronTagger
 from pythainlp.tag.chunk import chunk_parse
-from pythainlp.tag.named_entity import NER
+from pythainlp.tag.named_entity import NER, NNER

--- a/pythainlp/tag/named_entity.py
+++ b/pythainlp/tag/named_entity.py
@@ -108,5 +108,12 @@ class NNER:
     **Options for engine**
         * *thai_nner* - Thai NER engine
     """
-    def __init__(self, text) -> None:
-        pass
+    def __init__(self, engine: str = "thai_nner") -> None:
+        self.load_engine(engine)
+
+    def load_engine(self, engine: str = "thai_nner") -> None:
+        from pythainlp.tag.thai_nner import Thai_NNER
+        self.engine = Thai_NNER()
+
+    def tag(self, text):
+        return self.engine.tag(text)

--- a/pythainlp/tag/named_entity.py
+++ b/pythainlp/tag/named_entity.py
@@ -96,3 +96,17 @@ class NER:
             return self.engine.get_ner(text, tag=tag)
         else:
             return self.engine.get_ner(text, tag=tag, pos=pos)
+
+
+class NNER:
+    """
+    Nested Named Entity Recognition
+
+    :param str engine: Nested Named entity recognizer engine
+    :param str corpus: corpus
+    
+    **Options for engine**
+        * *thai_nner* - Thai NER engine
+    """
+    def __init__(self, text) -> None:
+        pass

--- a/pythainlp/tag/named_entity.py
+++ b/pythainlp/tag/named_entity.py
@@ -104,7 +104,7 @@ class NNER:
 
     :param str engine: Nested Named entity recognizer engine
     :param str corpus: corpus
-    
+
     **Options for engine**
         * *thai_nner* - Thai NER engine
     """
@@ -115,5 +115,52 @@ class NNER:
         from pythainlp.tag.thai_nner import Thai_NNER
         self.engine = Thai_NNER()
 
-    def tag(self, text):
+    def tag(self, text) -> Tuple[List[str], List[dict]]:
+        """
+        This function tags nested named-entitiy.
+
+        :param str text: text in Thai to be tagged
+
+        :return: a list of tuple associated with tokenized word, NNER tag.
+        :rtype: Tuple[List[str], List[dict]]
+
+        :Example:
+
+            >>> from pythainlp.tag.named_entity import NNER
+            >>> nner = NNER()
+            >>> nner.tag("แมวทำอะไรตอนห้าโมงเช้า")
+            ([
+                '<s>',
+                '',
+                'แมว',
+                'ทํา',
+                '',
+                'อะไร',
+                'ตอน',
+                '',
+                'ห้า',
+                '',
+                'โมง',
+                '',
+                'เช้า',
+                '</s>'
+            ],
+            [
+                {
+                    'text': ['', 'ห้า'],
+                    'span': [7, 9],
+                    'entity_type': 'cardinal'
+                },
+                {
+                    'text': ['', 'ห้า', '', 'โมง'],
+                    'span': [7, 11],
+                    'entity_type': 'time'
+                },
+                {
+                    'text': ['', 'โมง'],
+                    'span': [9, 11],
+                    'entity_type': 'unit'
+                }
+            ])
+        """
         return self.engine.tag(text)

--- a/pythainlp/tag/thai_nner.py
+++ b/pythainlp/tag/thai_nner.py
@@ -1,8 +1,9 @@
 from thai_nner import NNER
+from pythainlp.corpus import get_path_folder_corpus, get_corpus_path
 
 class Thai_NNER:
-    def __init__(self) -> None:
-        pass
+    def __init__(self, path_model = get_corpus_path('thai_nner','1.0')) -> None:
+        self.model = NNER(path_model=path_model)
 
-    def tag(self):
-        pass
+    def tag(self, text):
+        return self.model.get_tag(text)

--- a/pythainlp/tag/thai_nner.py
+++ b/pythainlp/tag/thai_nner.py
@@ -1,0 +1,8 @@
+from thai_nner import NNER
+
+class Thai_NNER:
+    def __init__(self) -> None:
+        pass
+
+    def tag(self):
+        pass

--- a/pythainlp/tag/thai_nner.py
+++ b/pythainlp/tag/thai_nner.py
@@ -1,9 +1,14 @@
+from typing import List, Tuple
 from thai_nner import NNER
-from pythainlp.corpus import get_path_folder_corpus, get_corpus_path
+from pythainlp.corpus import get_corpus_path
+
 
 class Thai_NNER:
-    def __init__(self, path_model = get_corpus_path('thai_nner','1.0')) -> None:
+    def __init__(
+        self,
+        path_model=get_corpus_path('thai_nner', '1.0')
+    ) -> None:
         self.model = NNER(path_model=path_model)
 
-    def tag(self, text):
+    def tag(self, text) -> Tuple[List[str], List[dict]]:
         return self.model.get_tag(text)

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ extras = {
         "numpy>=1.16.1",
         "onnxruntime>=1.10.0"
     ],
+    "thai_nner": ["thai_nner"],
     "full": [
         "PyYAML>=5.3.1",
         "attacut>=1.0.4",
@@ -106,6 +107,7 @@ extras = {
         "oskut>=1.3",
         "nlpo3>=1.2.2",
         "onnxruntime>=1.10.0",
+        "thai_nner"
     ],
 }
 

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -14,6 +14,7 @@ from pythainlp.tag import (
     unigram,
     tltk,
     NER,
+    NNER,
 )
 from pythainlp.tag.locations import tag_provinces
 from pythainlp.tag.thainer import ThaiNameTagger
@@ -370,3 +371,7 @@ class TestTagPackage(unittest.TestCase):
         self.assertIsNotNone(ner.tag("แมวทำอะไรตอนห้าโมงเช้า", tag=True))
         with self.assertRaises(ValueError):
             NER(engine="thainer", corpus="cat")
+
+    def test_NNER_class(self):
+        nner = NNER()
+        self.assertIsNotNone(nner.tag("แมวทำอะไรตอนห้าโมงเช้า"))


### PR DESCRIPTION
### What does this changes

This pull request include thai-nner to PyThaiNLP. It is `pythainlp.tag.NNER` class. It was use `thai_nner` library and include model by pythainlp-corpus.

This issue is #664.

Thai-NNER: https://github.com/vistec-AI/Thai-NNER

```python
from pythainlp.tag.named_entity import NNER
nner = NNER()
nner.tag("แมวทำอะไรตอนห้าโมงเช้า")
# output: (['<s>', '', 'แมว', 'ทํา', '', 'อะไร', 'ตอน', '', 'ห้า', '', 'โมง', '', 'เช้า', '</s>'],
# [{'text': ['', 'ห้า'], 'span': [7, 9], 'entity_type': 'cardinal'}, {'text': ['', 'ห้า', '', 'โมง'], 'span': [7, 11], 'entity_type': 'time'}, {'text': ['', 'โมง'], 'span': [9, 11], 'entity_type': 'unit'}])
```

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test
