### PR TITLE
Normalise Lakkhangyao

### DIFF
--- a/pythainlp/util/normalize.py
+++ b/pythainlp/util/normalize.py
@@ -33,6 +33,7 @@ _REORDER_PAIRS = [
         f"([{follow_v}]+)([{tonemarks}]+)",
         "\\2\\1",
     ),  # FOLLOW VOWEL + TONEMARK+ -> TONEMARK + FOLLOW VOWEL
+    ("([^\u0e24\u0e26])\u0e45", "\\1\u0e32"),  # Lakkhangyao -> Sara Aa
 ]
 
 # VOWELS + Phinthu, Thanthakhat, Nikhahit, Yamakkan

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -498,7 +498,7 @@ class TestUtilPackage(unittest.TestCase):
 
         # normalize lakkhangyao to sara aa
         self.assertEqual(normalize("นๅคา"), "นาคา")
-        self.assertEqual(normalize("ฤาษี"), "ฤาษี")
+        self.assertEqual(normalize("ฤๅษี"), "ฤๅษี")
 
         # remove repeating following vowels
         self.assertEqual(normalize("กาา"), "กา")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -496,6 +496,10 @@ class TestUtilPackage(unittest.TestCase):
         # reorder consonant + follow vowel + tone mark
         self.assertEqual(normalize("\u0e01\u0e32\u0e48"), "\u0e01\u0e48\u0e32")
 
+        # normalize lakkhangyao to sara aa
+        self.assertEqual(normalize("นๅคา"), "นาคา")
+        self.assertEqual(normalize("ฤาษี"), "ฤาษี")
+
         # remove repeating following vowels
         self.assertEqual(normalize("กาา"), "กา")
         self.assertEqual(normalize("กา า  า  า"), "กา")


### PR DESCRIPTION
### What does this change do?

Add a normalising rule for Lakkhangyao `ๅ`
According to [this](https://th.wikipedia.org/wiki/%E0%B8%A5%E0%B8%B2%E0%B8%81%E0%B8%82%E0%B9%89%E0%B8%B2%E0%B8%87), it should only follow, `ฤ` and `ฦ`. Apart from that it should be normalised to `า`.

### How this fixes it

Add the following regex in reorder_vowels function
```
("([^\u0e24\u0e26])\u0e45", "\\1\u0e32"),  # Lakkhangyao -> Sara Aa
```

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [/] Passed code styles and structures
- [/] Passed code linting checks and unit test
