### PR TITLE
Add live dead syllable classify

### DIFF
--- a/docs/api/util.rst
+++ b/docs/api/util.rst
@@ -32,6 +32,7 @@ Modules
 .. autofunction:: remove_tonemark
 .. autofunction:: remove_zw
 .. autofunction:: reorder_vowels
+.. autofunction:: sound_syllable
 .. autofunction:: text_to_arabic_digit
 .. autofunction:: text_to_num
 .. autofunction:: text_to_thai_digit

--- a/pythainlp/util/__init__.py
+++ b/pythainlp/util/__init__.py
@@ -43,6 +43,7 @@ __all__ = [
     "time_to_thaiword",
     "text_to_num",
     "words_to_num",
+    "sound_syllable",
 ]
 
 from pythainlp.util.collate import collate
@@ -89,3 +90,4 @@ from pythainlp.util.thaiwordcheck import is_native_thai
 from pythainlp.util.time import thai_time, thaiword_to_time, time_to_thaiword
 from pythainlp.util.trie import Trie, dict_trie
 from pythainlp.util.wordtonum import thaiword_to_num, text_to_num, words_to_num
+from pythainlp.util.syllable import sound_syllable

--- a/pythainlp/util/syllable.py
+++ b/pythainlp/util/syllable.py
@@ -26,8 +26,8 @@ not_spelling_class = [j for j in thai_consonants_all if j not in _temp]
 
 # vowel's short sound
 short = "ะัิึุ"
-re_short = re.compile("เ([ก-ฉ][่้๊๋]?)ะ|แ([ก-ฉ][่้๊๋]?)ะ|เ([ก-ฉ][่้๊๋]?)อะ|โ([ก-ฉ][่้๊๋]?)ะ|เ([ก-ฉ][่้๊๋]?)าะ", re.U)
-pattern = re.compile("เ([ก-ฉ][่้๊๋]?)า", re.U)  # เ-า is live syllable
+re_short = re.compile("เ(.*)ะ|แ(.*)ะ|เ(.*)อะ|โ(.*)ะ|เ(.*)าะ", re.U)
+pattern = re.compile("เ(.*)า", re.U)  # เ-า is live syllable
 
 _check_1 = []
 # these spelling consonant are live syllable.
@@ -73,19 +73,19 @@ def sound_syllable(syllable: str) -> str:
             (
                 any((c in set("าีืแูาเโ")) for c in syllable) == False
                 and any((c in set("ำใไ")) for c in syllable) == False
-                and pattern.findall(syllable) != True
+                and bool(pattern.search(syllable)) != True
             )
     ):
         return "dead"
     elif any((c in set("าีืแูาโ")) for c in syllable):  # in syllable:
-        if spelling_consonant != syllable[-1]:
+        if spelling_consonant in _check_1 and bool(re_short.search(syllable)) != True:
             return "live"
-        elif spelling_consonant in _check_1:
+        elif spelling_consonant != syllable[-1] and bool(re_short.search(syllable)) != True:
             return "live"
         elif spelling_consonant in _check_2:
             return "dead"
         elif (
-            re_short.findall(syllable)
+            bool(re_short.search(syllable))
             or
             any((c in set(short)) for c in syllable)
         ):
@@ -93,18 +93,18 @@ def sound_syllable(syllable: str) -> str:
         return "live"
     elif any((c in set("ำใไ")) for c in syllable):
         return "live"  # if these vowel's long sound are live syllable
-    elif pattern.findall(syllable):  # if it is เ-า
+    elif bool(pattern.search(syllable)):  # if it is เ-า
         return "live"
     elif spelling_consonant in _check_1:
         if (
-            re_short.findall(syllable)
+            bool(re_short.search(syllable))
             or
             any((c in set(short)) for c in syllable)
         ) and len(consonants) < 2:
             return "dead"
         return "live"
     elif (
-        re_short.findall(syllable)  # if found vowel's short sound
+        bool(re_short.search(syllable))  # if found vowel's short sound
         or
         any((c in set(short)) for c in syllable)  # consonant in short
     ):

--- a/pythainlp/util/syllable.py
+++ b/pythainlp/util/syllable.py
@@ -26,8 +26,8 @@ not_spelling_class = [j for j in thai_consonants_all if j not in _temp]
 
 # vowel's short sound
 short = "ะัิึุ"
-re_short = re.compile("เ(.*)ะ|แ(.*)ะ|เ(.*)อะ|โ(.*)ะ|เ(.*)าะ", re.U)
-pattern = re.compile("เ(.*)า", re.U)  # เ-า is live syllable
+re_short = re.compile("เ([ก-ฉ][่้๊๋]?)ะ|แ([ก-ฉ][่้๊๋]?)ะ|เ([ก-ฉ][่้๊๋]?)อะ|โ([ก-ฉ][่้๊๋]?)ะ|เ([ก-ฉ][่้๊๋]?)าะ", re.U)
+pattern = re.compile("เ([ก-ฉ][่้๊๋]?)า", re.U)  # เ-า is live syllable
 
 _check_1 = []
 # these spelling consonant are live syllable.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -48,6 +48,7 @@ from pythainlp.util import (
     thai_keyboard_dist,
     text_to_num,
     words_to_num,
+    sound_syllable,
 )
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -697,6 +697,9 @@ class TestUtilPackage(unittest.TestCase):
             ("บ", "dead"),
             ("บ่", "dead"),
             ("ก็", "dead"),
+            ("เพราะ", "dead"),
+            ("เกาะ", "dead"),
+            ("แคะ", "dead"),
         ]
         for i, j in test:
             self.assertEqual(sound_syllable(i), j)


### PR DESCRIPTION
### What does this changes

Add live-dead syllable classification. from #682, I found that it has bug and I was fix.

## Example
```python
from pythainlp.util import sound_syllable

print(sound_syllable("มา"))
# output: live

print(sound_syllable("เลข"))
# output: dead

print(sound_syllable("เพราะ"))
# output: dead
```

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test
