### PR TITLE
map NG tag to PART

### DIFF
--- a/pythainlp/tag/lst20.py
+++ b/pythainlp/tag/lst20.py
@@ -17,6 +17,7 @@ TO_UD = {
     "CL": "NOUN",
     "FX": "NOUN",
     "IJ": "INTJ",
+    "NG": "PART",
     "NN": "NOUN",
     "NU": "NUM",
     "PA": "PART",


### PR DESCRIPTION
### What does this changes

map "NG" tag to "PART" when run pos tagger with `corpus="lst20_ud"`

### What was wrong

Missing `NG` tag (see https://arxiv.org/abs/2008.05055)
Accoding to UnivesalDependency Guideline, it should be mapped to `PART` (see https://universaldependencies.org/u/pos/PART.html)


### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [/] Passed code styles and structures
- [/] Passed code linting checks and unit test
