### PR TITLE
Add tone detector

### DIFF
--- a/docs/api/util.rst
+++ b/docs/api/util.rst
@@ -40,6 +40,7 @@ Modules
 .. autofunction:: text_to_thai_digit
 .. autofunction:: thai_strftime
 .. autofunction:: thai_to_eng
+.. autofunction:: thai_word_tone_detector
 .. autofunction:: thai_digit_to_arabic_digit
 .. autofunction:: thaiword_to_date
 .. autofunction:: thaiword_to_num

--- a/docs/api/util.rst
+++ b/docs/api/util.rst
@@ -33,6 +33,8 @@ Modules
 .. autofunction:: remove_zw
 .. autofunction:: reorder_vowels
 .. autofunction:: sound_syllable
+.. autofunction:: syllable_lenght
+.. autofunction:: syllable_open_close_detector
 .. autofunction:: text_to_arabic_digit
 .. autofunction:: text_to_num
 .. autofunction:: text_to_thai_digit
@@ -43,6 +45,7 @@ Modules
 .. autofunction:: thaiword_to_num
 .. autofunction:: thaiword_to_time
 .. autofunction:: time_to_thaiword
+.. autofunction:: tone_detector
 .. autofunction:: words_to_num
 .. autoclass:: Trie
    :members:

--- a/docs/api/util.rst
+++ b/docs/api/util.rst
@@ -33,7 +33,7 @@ Modules
 .. autofunction:: remove_zw
 .. autofunction:: reorder_vowels
 .. autofunction:: sound_syllable
-.. autofunction:: syllable_lenght
+.. autofunction:: syllable_length
 .. autofunction:: syllable_open_close_detector
 .. autofunction:: text_to_arabic_digit
 .. autofunction:: text_to_num

--- a/pythainlp/util/__init__.py
+++ b/pythainlp/util/__init__.py
@@ -42,8 +42,11 @@ __all__ = [
     "thaiword_to_time",
     "time_to_thaiword",
     "text_to_num",
+    "tone_detector",
     "words_to_num",
     "sound_syllable",
+    "syllable_lenght",
+    "syllable_open_close_detector",
 ]
 
 from pythainlp.util.collate import collate
@@ -90,4 +93,4 @@ from pythainlp.util.thaiwordcheck import is_native_thai
 from pythainlp.util.time import thai_time, thaiword_to_time, time_to_thaiword
 from pythainlp.util.trie import Trie, dict_trie
 from pythainlp.util.wordtonum import thaiword_to_num, text_to_num, words_to_num
-from pythainlp.util.syllable import sound_syllable
+from pythainlp.util.syllable import sound_syllable, tone_detector, syllable_lenght, syllable_open_close_detector

--- a/pythainlp/util/__init__.py
+++ b/pythainlp/util/__init__.py
@@ -45,7 +45,7 @@ __all__ = [
     "tone_detector",
     "words_to_num",
     "sound_syllable",
-    "syllable_lenght",
+    "syllable_length",
     "syllable_open_close_detector",
 ]
 
@@ -93,4 +93,4 @@ from pythainlp.util.thaiwordcheck import is_native_thai
 from pythainlp.util.time import thai_time, thaiword_to_time, time_to_thaiword
 from pythainlp.util.trie import Trie, dict_trie
 from pythainlp.util.wordtonum import thaiword_to_num, text_to_num, words_to_num
-from pythainlp.util.syllable import sound_syllable, tone_detector, syllable_lenght, syllable_open_close_detector
+from pythainlp.util.syllable import sound_syllable, tone_detector, syllable_length, syllable_open_close_detector

--- a/pythainlp/util/__init__.py
+++ b/pythainlp/util/__init__.py
@@ -93,4 +93,9 @@ from pythainlp.util.thaiwordcheck import is_native_thai
 from pythainlp.util.time import thai_time, thaiword_to_time, time_to_thaiword
 from pythainlp.util.trie import Trie, dict_trie
 from pythainlp.util.wordtonum import thaiword_to_num, text_to_num, words_to_num
-from pythainlp.util.syllable import sound_syllable, tone_detector, syllable_length, syllable_open_close_detector
+from pythainlp.util.syllable import (
+    sound_syllable,
+    tone_detector,
+    syllable_length,
+    syllable_open_close_detector,
+)

--- a/pythainlp/util/__init__.py
+++ b/pythainlp/util/__init__.py
@@ -37,6 +37,7 @@ __all__ = [
     "thai_strftime",
     "thai_time",
     "thai_to_eng",
+    "thai_word_tone_detector",
     "thaiword_to_date",
     "thaiword_to_num",
     "thaiword_to_time",
@@ -88,6 +89,7 @@ from pythainlp.util.thai import (
     display_thai_char,
     isthai,
     isthaichar,
+    thai_word_tone_detector,
 )
 from pythainlp.util.thaiwordcheck import is_native_thai
 from pythainlp.util.time import thai_time, thaiword_to_time, time_to_thaiword

--- a/pythainlp/util/syllable.py
+++ b/pythainlp/util/syllable.py
@@ -3,7 +3,7 @@
 Syllable tools
 """
 import re
-from pythainlp import thai_consonants, thai_tonemarks, thai_vowels
+from pythainlp import thai_consonants, thai_tonemarks
 
 spelling_class = {
     "กง": list("ง"),

--- a/pythainlp/util/syllable.py
+++ b/pythainlp/util/syllable.py
@@ -163,12 +163,12 @@ def syllable_open_close_detector(syllable: str) -> str:
 
 def syllable_length(syllable: str) -> str:
     """
-    Thai syllable lenght
+    Thai syllable length
 
-    This function is use for find syllable's lenght. (long or short)
+    This function is use for find syllable's length. (long or short)
 
     :param str syllable: Thai syllable
-    :return: syllable's lenght (long or short)
+    :return: syllable's length (long or short)
     :rtype: str
 
     :Example:

--- a/pythainlp/util/syllable.py
+++ b/pythainlp/util/syllable.py
@@ -134,9 +134,26 @@ def sound_syllable(syllable: str) -> str:
 
 
 def syllable_open_close_detector(syllable: str) -> str:
-    # TODO
-    # พยางค์เปิด - พยางค์ปิด
-    # return open / close
+    """
+    Thai syllable open/close detector
+
+    This function is use for find Thai syllable that open or closed sound.
+
+    :param str syllable: Thai syllable
+    :return: open / close
+    :rtype: str
+
+    :Example:
+    ::
+
+        from pythainlp.util import syllable_open_close_detector
+
+        print(syllable_open_close_detector("มาก"))
+        # output: close
+
+        print(syllable_open_close_detector("คะ"))
+        # output: open
+    """
     consonants = [i for i in syllable if i in list(thai_consonants)]
     if len(consonants) < 2:
         return "open"
@@ -146,8 +163,26 @@ def syllable_open_close_detector(syllable: str) -> str:
 
 
 def syllable_lenght(syllable: str) -> str:
-    # พยางค์เสียงสั้น เสียงยาส
-    # return short / long
+    """
+    Thai syllable lenght
+
+    This function is use for find syllable's lenght. (long or short)
+
+    :param str syllable: Thai syllable
+    :return: syllable's lenght (long or short)
+    :rtype: str
+
+    :Example:
+    ::
+
+        from pythainlp.util import syllable_lenght
+
+        print(syllable_lenght("มาก"))
+        # output: long
+
+        print(syllable_lenght("คะ"))
+        # output: short
+    """
     consonants = [i for i in syllable if i in list(thai_consonants)]
     if len(consonants) < 3 and any((c in set(short)) for c in syllable):
         return "short"
@@ -165,7 +200,7 @@ def _tone_mark_detector(syllable: str) -> str:
         return tone_mark[0]
 
 
-def check_sonorant_syllable(syllable: str) -> bool:
+def _check_sonorant_syllable(syllable: str) -> bool:
     _sonorant = [i for i in syllable if i in thai_low_sonorants]
     consonants = [i for i in syllable if i in list(thai_consonants)]
     if _sonorant[-1] == consonants[-2]:
@@ -178,6 +213,21 @@ def check_sonorant_syllable(syllable: str) -> bool:
 def tone_detector(syllable: str) -> str:
     """
     Thai tone detector for syllables
+
+    :param str syllable: Thai syllable
+    :return: syllable's tone (l, m, h, r, f or empty if it cannot detector)
+    :rtype: str
+
+    :Example:
+    ::
+
+        from pythainlp.util import tone_detector
+
+        print(tone_detector("มา"))
+        # output: m
+
+        print(tone_detector("ไม้"))
+        # output: h
     """
     s = sound_syllable(syllable)
     # get consonants
@@ -190,7 +240,7 @@ def tone_detector(syllable: str) -> str:
     # r for store value
     r = ""
     if len(consonants) > 1 and (initial_consonant == "อ" or initial_consonant == "ห"):
-        two_consonants = check_sonorant_syllable(syllable)
+        two_consonants = _check_sonorant_syllable(syllable)
         if initial_consonant == "อ" and two_consonants and s == "live" and tone_mark == "่":
             r = "l"
         elif initial_consonant == "อ" and two_consonants and s == "dead":

--- a/pythainlp/util/syllable.py
+++ b/pythainlp/util/syllable.py
@@ -3,7 +3,8 @@
 Syllable tools
 """
 import re
-from pythainlp import thai_consonants, thai_tonemarks
+from typing import Tuple
+from pythainlp import thai_consonants, thai_tonemarks, thai_vowels
 
 spelling_class = {
     "กง": list("ง"),
@@ -145,10 +146,15 @@ def syllable_open_close_detector(syllable: str) -> str:
 
 
 def syllable_lenght(syllable: str) -> str:
-    # TODO
     # พยางค์เสียงสั้น เสียงยาส
     # return short / long
-    pass
+    consonants = [i for i in syllable if i in list(thai_consonants)]
+    if len(consonants) < 3 and any((c in set(short)) for c in syllable):
+        return "short"
+    elif bool(re_short.search(syllable)):
+        return "short"
+    else:
+        return "long"
 
 
 def _tone_mark_detector(syllable: str) -> str:
@@ -159,10 +165,20 @@ def _tone_mark_detector(syllable: str) -> str:
         return tone_mark[0]
 
 
-def tone_detector(syllable):
-    # TODO
-    # H + open close พวหนี้
-    # F close long
+def check_sonorant_syllable(syllable: str)->bool:
+    _sonorant = [i for i in syllable if i in thai_low_sonorants]
+    consonants = [i for i in syllable if i in list(thai_consonants)]
+    if _sonorant[-1] == consonants[-2]:
+        return True
+    elif _sonorant[-1] == consonants[-1]:
+        return True
+    return False
+
+
+def tone_detector(syllable: str)->str:
+    """
+    Thai tone detector for syllables
+    """
     s = sound_syllable(syllable)
     # get consonants
     consonants = [i for i in syllable if i in list(thai_consonants)]
@@ -171,20 +187,22 @@ def tone_detector(syllable):
     syllable_check= syllable_open_close_detector(syllable)
     syllable_check_lenght = syllable_lenght(syllable)
     initial_consonant_type = thai_initial_consonant_to_type[initial_consonant]
-    # low
+    # r for store value
     r = ""
     if len(consonants) > 1 and (initial_consonant =="อ" or initial_consonant == "ห"):
-        two_consonants = consonants[1]
-        if initial_consonant =="อ" and two_consonants in thai_low_sonorants and s == "dead":
+        two_consonants = check_sonorant_syllable(syllable)
+        if initial_consonant =="อ" and two_consonants and s == "live" and tone_mark == "่":
             r = "l"
-        elif initial_consonant =="อ" and two_consonants in thai_low_sonorants and s == "live" and tone_mark == "่":
+        elif initial_consonant =="อ" and two_consonants and s == "dead":
             r = "l"
-        elif initial_consonant =="ห" and two_consonants in thai_low_sonorants and s == "dead":
+        elif initial_consonant =="ห" and two_consonants and s == "live" and tone_mark == "่":
             r = "l"
-        elif initial_consonant =="ห" and two_consonants in thai_low_sonorants and s == "live" and tone_mark == "่":
-            r = "l"
-        elif initial_consonant =="ห" and two_consonants in thai_low_sonorants and s == "live":
+        elif initial_consonant =="ห" and two_consonants and s == "live" and tone_mark == "้":
             r = "f"
+        elif initial_consonant =="ห" and two_consonants and s == "dead":
+            r = "l"
+        elif initial_consonant =="ห" and two_consonants and s == "live":
+            r = "r"
     elif initial_consonant_type == "low" and syllable_check_lenght == "short" and syllable_check == "close" and s == "dead":
         r = "h"
     elif initial_consonant_type == "low" and syllable_check_lenght == "long" and syllable_check == "close" and s == "dead":
@@ -217,4 +235,4 @@ def tone_detector(syllable):
         r = "m"
     elif initial_consonant_type == "high" and s == "live":
         r = "r"
-    return r,initial_consonant,initial_consonant_type,s,tone_mark,syllable_check,syllable_check_lenght
+    return r

--- a/pythainlp/util/syllable.py
+++ b/pythainlp/util/syllable.py
@@ -50,7 +50,7 @@ thai_initial_consonant_type = {
     "high": thai_high_aspirates+thai_high_irregular
 }
 thai_initial_consonant_to_type = {}
-for k,v in thai_initial_consonant_type.items():
+for k, v in thai_initial_consonant_type.items():
     for i in v:
         thai_initial_consonant_to_type[i] = k
 
@@ -238,25 +238,57 @@ def tone_detector(syllable: str) -> str:
     initial_consonant_type = thai_initial_consonant_to_type[initial_consonant]
     # r for store value
     r = ""
-    if len(consonants) > 1 and (initial_consonant == "อ" or initial_consonant == "ห"):
+    if (
+        len(consonants) > 1
+        and (initial_consonant == "อ" or initial_consonant == "ห")
+    ):
         two_consonants = _check_sonorant_syllable(syllable)
-        if initial_consonant == "อ" and two_consonants and s == "live" and tone_mark == "่":
+        if (
+            initial_consonant == "อ"
+            and two_consonants
+            and s == "live"
+            and tone_mark == "่"
+        ):
             r = "l"
         elif initial_consonant == "อ" and two_consonants and s == "dead":
             r = "l"
-        elif initial_consonant == "ห" and two_consonants and s == "live" and tone_mark == "่":
+        elif (
+            initial_consonant == "ห"
+            and two_consonants
+            and s == "live"
+            and tone_mark == "่"
+        ):
             r = "l"
-        elif initial_consonant == "ห" and two_consonants and s == "live" and tone_mark == "้":
+        elif (
+            initial_consonant == "ห"
+            and two_consonants
+            and s == "live"
+            and tone_mark == "้"
+        ):
             r = "f"
         elif initial_consonant == "ห" and two_consonants and s == "dead":
             r = "l"
         elif initial_consonant == "ห" and two_consonants and s == "live":
             r = "r"
-    elif initial_consonant_type == "low" and syllable_check_lenght == "short" and syllable_check == "close" and s == "dead":
+    elif (
+        initial_consonant_type == "low"
+        and syllable_check_lenght == "short"
+        and syllable_check == "close"
+        and s == "dead"
+    ):
         r = "h"
-    elif initial_consonant_type == "low" and syllable_check_lenght == "long" and syllable_check == "close" and s == "dead":
+    elif (
+        initial_consonant_type == "low"
+        and syllable_check_lenght == "long"
+        and syllable_check == "close"
+        and s == "dead"
+    ):
         r = "f"
-    elif initial_consonant_type == "low" and syllable_check_lenght == "short" and syllable_check == "open":
+    elif (
+        initial_consonant_type == "low"
+        and syllable_check_lenght == "short"
+        and syllable_check == "open"
+    ):
         r = "h"
     elif initial_consonant_type == "high" and s == "live" and tone_mark == "่":
         r = "l"

--- a/pythainlp/util/syllable.py
+++ b/pythainlp/util/syllable.py
@@ -242,33 +242,33 @@ def tone_detector(syllable: str) -> str:
         len(consonants) > 1
         and (initial_consonant == "อ" or initial_consonant == "ห")
     ):
-        two_consonants = _check_sonorant_syllable(syllable)
+        consonant_ending = _check_sonorant_syllable(syllable)
         if (
             initial_consonant == "อ"
-            and two_consonants
+            and consonant_ending
             and s == "live"
             and tone_mark == "่"
         ):
             r = "l"
-        elif initial_consonant == "อ" and two_consonants and s == "dead":
+        elif initial_consonant == "อ" and consonant_ending and s == "dead":
             r = "l"
         elif (
             initial_consonant == "ห"
-            and two_consonants
+            and consonant_ending
             and s == "live"
             and tone_mark == "่"
         ):
             r = "l"
         elif (
             initial_consonant == "ห"
-            and two_consonants
+            and consonant_ending
             and s == "live"
             and tone_mark == "้"
         ):
             r = "f"
-        elif initial_consonant == "ห" and two_consonants and s == "dead":
+        elif initial_consonant == "ห" and consonant_ending and s == "dead":
             r = "l"
-        elif initial_consonant == "ห" and two_consonants and s == "live":
+        elif initial_consonant == "ห" and consonant_ending and s == "live":
             r = "r"
     elif (
         initial_consonant_type == "low"

--- a/pythainlp/util/syllable.py
+++ b/pythainlp/util/syllable.py
@@ -3,7 +3,6 @@
 Syllable tools
 """
 import re
-from typing import Tuple
 from pythainlp import thai_consonants, thai_tonemarks, thai_vowels
 
 spelling_class = {

--- a/pythainlp/util/syllable.py
+++ b/pythainlp/util/syllable.py
@@ -161,7 +161,7 @@ def syllable_open_close_detector(syllable: str) -> str:
     return "close"
 
 
-def syllable_lenght(syllable: str) -> str:
+def syllable_length(syllable: str) -> str:
     """
     Thai syllable lenght
 
@@ -174,12 +174,12 @@ def syllable_lenght(syllable: str) -> str:
     :Example:
     ::
 
-        from pythainlp.util import syllable_lenght
+        from pythainlp.util import syllable_length
 
-        print(syllable_lenght("มาก"))
+        print(syllable_length("มาก"))
         # output: long
 
-        print(syllable_lenght("คะ"))
+        print(syllable_length("คะ"))
         # output: short
     """
     consonants = [i for i in syllable if i in list(thai_consonants)]
@@ -234,7 +234,7 @@ def tone_detector(syllable: str) -> str:
     initial_consonant = consonants[0]
     tone_mark = _tone_mark_detector(syllable)
     syllable_check = syllable_open_close_detector(syllable)
-    syllable_check_lenght = syllable_lenght(syllable)
+    syllable_check_lenght = syllable_length(syllable)
     initial_consonant_type = thai_initial_consonant_to_type[initial_consonant]
     # r for store value
     r = ""

--- a/pythainlp/util/syllable.py
+++ b/pythainlp/util/syllable.py
@@ -46,9 +46,9 @@ thai_mid_plains = list("กจดตบปอฎฏ")
 thai_high_aspirates = list("ขฉถผฝสห")
 thai_high_irregular = list("ศษฃฐ")
 thai_initial_consonant_type = {
-    "low":thai_low_sonorants+thai_low_aspirates+thai_low_irregular,
-    "mid":thai_mid_plains,
-    "high":thai_high_aspirates+thai_high_irregular
+    "low": thai_low_sonorants+thai_low_aspirates+thai_low_irregular,
+    "mid": thai_mid_plains,
+    "high": thai_high_aspirates+thai_high_irregular
 }
 thai_initial_consonant_to_type = {}
 for k,v in thai_initial_consonant_type.items():
@@ -165,7 +165,7 @@ def _tone_mark_detector(syllable: str) -> str:
         return tone_mark[0]
 
 
-def check_sonorant_syllable(syllable: str)->bool:
+def check_sonorant_syllable(syllable: str) -> bool:
     _sonorant = [i for i in syllable if i in thai_low_sonorants]
     consonants = [i for i in syllable if i in list(thai_consonants)]
     if _sonorant[-1] == consonants[-2]:
@@ -175,7 +175,7 @@ def check_sonorant_syllable(syllable: str)->bool:
     return False
 
 
-def tone_detector(syllable: str)->str:
+def tone_detector(syllable: str) -> str:
     """
     Thai tone detector for syllables
     """
@@ -184,24 +184,24 @@ def tone_detector(syllable: str)->str:
     consonants = [i for i in syllable if i in list(thai_consonants)]
     initial_consonant = consonants[0]
     tone_mark = _tone_mark_detector(syllable)
-    syllable_check= syllable_open_close_detector(syllable)
+    syllable_check = syllable_open_close_detector(syllable)
     syllable_check_lenght = syllable_lenght(syllable)
     initial_consonant_type = thai_initial_consonant_to_type[initial_consonant]
     # r for store value
     r = ""
-    if len(consonants) > 1 and (initial_consonant =="อ" or initial_consonant == "ห"):
+    if len(consonants) > 1 and (initial_consonant == "อ" or initial_consonant == "ห"):
         two_consonants = check_sonorant_syllable(syllable)
-        if initial_consonant =="อ" and two_consonants and s == "live" and tone_mark == "่":
+        if initial_consonant == "อ" and two_consonants and s == "live" and tone_mark == "่":
             r = "l"
-        elif initial_consonant =="อ" and two_consonants and s == "dead":
+        elif initial_consonant == "อ" and two_consonants and s == "dead":
             r = "l"
-        elif initial_consonant =="ห" and two_consonants and s == "live" and tone_mark == "่":
+        elif initial_consonant == "ห" and two_consonants and s == "live" and tone_mark == "่":
             r = "l"
-        elif initial_consonant =="ห" and two_consonants and s == "live" and tone_mark == "้":
+        elif initial_consonant == "ห" and two_consonants and s == "live" and tone_mark == "้":
             r = "f"
-        elif initial_consonant =="ห" and two_consonants and s == "dead":
+        elif initial_consonant == "ห" and two_consonants and s == "dead":
             r = "l"
-        elif initial_consonant =="ห" and two_consonants and s == "live":
+        elif initial_consonant == "ห" and two_consonants and s == "live":
             r = "r"
     elif initial_consonant_type == "low" and syllable_check_lenght == "short" and syllable_check == "close" and s == "dead":
         r = "h"

--- a/pythainlp/util/syllable.py
+++ b/pythainlp/util/syllable.py
@@ -3,7 +3,7 @@
 Syllable tools
 """
 import re
-from pythainlp import thai_consonants
+from pythainlp import thai_consonants, thai_tonemarks
 
 spelling_class = {
     "กง": list("ง"),
@@ -35,6 +35,25 @@ for i in ["กง", "กน", "กม", "เกย", "เกอว"]:
     _check_1.extend(spelling_class[i])
 # these spelling consonant are dead syllable.
 _check_2 = spelling_class["กก"]+spelling_class["กบ"]+spelling_class["กด"]
+
+thai_low_sonorants = list("งนมยรลว")
+thai_low_aspirates = list("คชซทพฟฮ")
+thai_low_irregular = list("ฆญณธภฅฌฑฒฬ")
+
+thai_mid_plains = list("กจดตบปอฎฏ")
+
+thai_high_aspirates = list("ขฉถผฝสห")
+thai_high_irregular = list("ศษฃฐ")
+thai_initial_consonant_type = {
+    "low":thai_low_sonorants+thai_low_aspirates+thai_low_irregular,
+    "mid":thai_mid_plains,
+    "high":thai_high_aspirates+thai_high_irregular
+}
+thai_initial_consonant_to_type = {}
+for k,v in thai_initial_consonant_type.items():
+    for i in v:
+        thai_initial_consonant_to_type[i] = k
+
 
 
 def sound_syllable(syllable: str) -> str:
@@ -111,3 +130,91 @@ def sound_syllable(syllable: str) -> str:
         return "dead"
     else:
         return "dead"
+
+
+def syllable_open_close_detector(syllable: str) -> str:
+    # TODO
+    # พยางค์เปิด - พยางค์ปิด
+    # return open / close
+    consonants = [i for i in syllable if i in list(thai_consonants)]
+    if len(consonants) < 2:
+        return "open"
+    elif len(consonants) == 2 and consonants[-1] == "อ":
+        return "open"
+    return "close"
+
+
+def syllable_lenght(syllable: str) -> str:
+    # TODO
+    # พยางค์เสียงสั้น เสียงยาส
+    # return short / long
+    pass
+
+
+def _tone_mark_detector(syllable: str) -> str:
+    tone_mark = [i for i in syllable if i in list(thai_tonemarks)]
+    if tone_mark == []:
+        return ""
+    else:
+        return tone_mark[0]
+
+
+def tone_detector(syllable):
+    # TODO
+    # H + open close พวหนี้
+    # F close long
+    s = sound_syllable(syllable)
+    # get consonants
+    consonants = [i for i in syllable if i in list(thai_consonants)]
+    initial_consonant = consonants[0]
+    tone_mark = _tone_mark_detector(syllable)
+    syllable_check= syllable_open_close_detector(syllable)
+    syllable_check_lenght = syllable_lenght(syllable)
+    initial_consonant_type = thai_initial_consonant_to_type[initial_consonant]
+    # low
+    r = ""
+    if len(consonants) > 1 and (initial_consonant =="อ" or initial_consonant == "ห"):
+        two_consonants = consonants[1]
+        if initial_consonant =="อ" and two_consonants in thai_low_sonorants and s == "dead":
+            r = "l"
+        elif initial_consonant =="อ" and two_consonants in thai_low_sonorants and s == "live" and tone_mark == "่":
+            r = "l"
+        elif initial_consonant =="ห" and two_consonants in thai_low_sonorants and s == "dead":
+            r = "l"
+        elif initial_consonant =="ห" and two_consonants in thai_low_sonorants and s == "live" and tone_mark == "่":
+            r = "l"
+        elif initial_consonant =="ห" and two_consonants in thai_low_sonorants and s == "live":
+            r = "f"
+    elif initial_consonant_type == "low" and syllable_check_lenght == "short" and syllable_check == "close" and s == "dead":
+        r = "h"
+    elif initial_consonant_type == "low" and syllable_check_lenght == "long" and syllable_check == "close" and s == "dead":
+        r = "f"
+    elif initial_consonant_type == "low" and syllable_check_lenght == "short" and syllable_check == "open":
+        r = "h"
+    elif initial_consonant_type == "high" and s == "live" and tone_mark == "่":
+        r = "l"
+    elif initial_consonant_type == "mid" and s == "live" and tone_mark == "่":
+        r = "l"
+    elif initial_consonant_type == "low" and tone_mark == "้":
+        r = "h"
+    elif initial_consonant_type == "mid" and tone_mark == "๋":
+        r = "r"
+    elif initial_consonant_type == "mid" and tone_mark == "๊":
+        r = "h"
+    elif initial_consonant_type == "low" and tone_mark == "่":
+        r = "f"
+    elif initial_consonant_type == "mid" and tone_mark == "้":
+        r = "f"
+    elif initial_consonant_type == "high" and tone_mark == "้":
+        r = "f"
+    elif initial_consonant_type == "mid" and s == "dead":
+        r = "l"
+    elif initial_consonant_type == "high" and s == "dead":
+        r = "l"
+    elif initial_consonant_type == "low" and s == "live":
+        r = "m"
+    elif initial_consonant_type == "mid" and s == "live":
+        r = "m"
+    elif initial_consonant_type == "high" and s == "live":
+        r = "r"
+    return r,initial_consonant,initial_consonant_type,s,tone_mark,syllable_check,syllable_check_lenght

--- a/pythainlp/util/thai.py
+++ b/pythainlp/util/thai.py
@@ -41,7 +41,7 @@ def isthaichar(ch: str) -> bool:
 
 def isthai(text: str, ignore_chars: str = ".") -> bool:
     """Check if every characters in a string are Thai character.
-from pythainlp.util import thai_word_tone_detector
+
     :param text: input text
     :type text: str
     :param ignore_chars: characters to be ignored, defaults to "."

--- a/pythainlp/util/thai.py
+++ b/pythainlp/util/thai.py
@@ -181,4 +181,4 @@ def thai_word_tone_detector(word: str) -> Tuple[str, str]:
         # output: [('มือ', 'm'), ('ถือ', 'r')]
     """
     _pronunciate = pronunciate(word).split('-')
-    return [(i, tone_detector(i.replace('หฺ','ห'))) for i in _pronunciate]
+    return [(i, tone_detector(i.replace('หฺ', 'ห'))) for i in _pronunciate]

--- a/pythainlp/util/thai.py
+++ b/pythainlp/util/thai.py
@@ -164,10 +164,10 @@ def thai_word_tone_detector(word: str) -> Tuple[str, str]:
     It use pythainlp.transliterate.pronunciate for convert word to\
         pronunciation.
 
-    :param str syllable: Thai word.
+    :param str word: Thai word.
     :return: Thai pronunciation with tone each syllables.\
         (l, m, h, r, f or empty if it cannot detector)
-    :rtype: str
+    :rtype: Tuple[str, str]
 
     :Example:
     ::

--- a/pythainlp/util/thai.py
+++ b/pythainlp/util/thai.py
@@ -3,8 +3,11 @@
 Check if it is Thai text
 """
 import string
+from typing import Tuple
 
 from pythainlp import thai_above_vowels, thai_tonemarks
+from pythainlp.transliterate import pronunciate
+from pythainlp.util.syllable import tone_detector
 
 _DEFAULT_IGNORE_CHARS = string.whitespace + string.digits + string.punctuation
 _TH_FIRST_CHAR_ASCII = 3584
@@ -38,7 +41,7 @@ def isthaichar(ch: str) -> bool:
 
 def isthai(text: str, ignore_chars: str = ".") -> bool:
     """Check if every characters in a string are Thai character.
-
+from pythainlp.util import thai_word_tone_detector
     :param text: input text
     :type text: str
     :param ignore_chars: characters to be ignored, defaults to "."
@@ -152,3 +155,30 @@ def display_thai_char(ch: str) -> str:
         return "_" + ch
     else:
         return ch
+
+
+def thai_word_tone_detector(word: str) -> Tuple[str, str]:
+    """
+    Thai tone detector for word.
+
+    It use pythainlp.transliterate.pronunciate for convert word to\
+        pronunciation.
+
+    :param str syllable: Thai word.
+    :return: Thai pronunciation with tone each syllables.\
+        (l, m, h, r, f or empty if it cannot detector)
+    :rtype: str
+
+    :Example:
+    ::
+
+        from pythainlp.util import thai_word_tone_detector
+
+        print(thai_word_tone_detector("คนดี"))
+        # output: [('คน', 'm'), ('ดี', 'm')]
+
+        print(thai_word_tone_detector("มือถือ"))
+        # output: [('มือ', 'm'), ('ถือ', 'r')]
+    """
+    _pronunciate = pronunciate(word).split('-')
+    return [(i, tone_detector(i.replace('หฺ','ห'))) for i in _pronunciate]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -49,7 +49,7 @@ from pythainlp.util import (
     text_to_num,
     words_to_num,
     sound_syllable,
-    syllable_lenght,
+    syllable_length,
     syllable_open_close_detector,
     tone_detector,
 )
@@ -734,3 +734,11 @@ class TestUtilPackage(unittest.TestCase):
         ]
         for i,j in data:
             self.assertEqual(tone_detector(j), i)
+
+    def test_syllable_length(self):
+        self.assertEqual(syllable_length("มาก"), "long")
+        self.assertEqual(syllable_length("คะ"), "short")
+    
+    def test_syllable_open_close_detector(self):
+        self.assertEqual(syllable_open_close_detector("มาก"), "close")
+        self.assertEqual(syllable_open_close_detector("คะ"), "open")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -210,7 +210,7 @@ class TestUtilPackage(unittest.TestCase):
             thai_keyboard_dist("๘", "๙"), thai_keyboard_dist("๙", "๐")
         )
         with self.assertRaises(ValueError):
-            thai_keyboard_dist("ພ","พ")
+            thai_keyboard_dist("ພ", "พ")
 
     # ### pythainlp.util.date
 
@@ -709,36 +709,36 @@ class TestUtilPackage(unittest.TestCase):
 
     def test_tone_detector(self):
         data = [
-            ("l","กด"),
-            ("l","ต่อ"),
-            ("l","ฉาก"),
-            ("l","ใส่"),
-            ("l","อยาก"),
-            ("l","อยู่"),
-            ("l","หนวก"),
-            ("l","ใหม่"),
-            ("m","ควาย"),
-            ("m","ไป"),
-            ("h","คะ"),
-            ("h","วัด"),
-            ("h","ไม้"),
-            ("h","โต๊ะ"),
-            ("r","เขา"),
-            ("r","ก๋ง"),
-            ("r","หญิง"),
-            ("f","มาก"),
-            ("f","ใช่"),
-            ("f","ไหม้"),
-            ("f","ต้น"),
-            ("f","ผู้"),
+            ("l", "กด"),
+            ("l", "ต่อ"),
+            ("l", "ฉาก"),
+            ("l", "ใส่"),
+            ("l", "อยาก"),
+            ("l", "อยู่"),
+            ("l", "หนวก"),
+            ("l", "ใหม่"),
+            ("m", "ควาย"),
+            ("m", "ไป"),
+            ("h", "คะ"),
+            ("h", "วัด"),
+            ("h", "ไม้"),
+            ("h", "โต๊ะ"),
+            ("r", "เขา"),
+            ("r", "ก๋ง"),
+            ("r", "หญิง"),
+            ("f", "มาก"),
+            ("f", "ใช่"),
+            ("f", "ไหม้"),
+            ("f", "ต้น"),
+            ("f", "ผู้"),
         ]
-        for i,j in data:
+        for i, j in data:
             self.assertEqual(tone_detector(j), i)
 
     def test_syllable_length(self):
         self.assertEqual(syllable_length("มาก"), "long")
         self.assertEqual(syllable_length("คะ"), "short")
-    
+
     def test_syllable_open_close_detector(self):
         self.assertEqual(syllable_open_close_detector("มาก"), "close")
         self.assertEqual(syllable_open_close_detector("คะ"), "open")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -49,6 +49,9 @@ from pythainlp.util import (
     text_to_num,
     words_to_num,
     sound_syllable,
+    syllable_lenght,
+    syllable_open_close_detector,
+    tone_detector,
 )
 
 
@@ -703,3 +706,31 @@ class TestUtilPackage(unittest.TestCase):
         ]
         for i, j in test:
             self.assertEqual(sound_syllable(i), j)
+
+    def test_tone_detector(self):
+        data = [
+            ("l","กด"),
+            ("l","ต่อ"),
+            ("l","ฉาก"),
+            ("l","ใส่"),
+            ("l","อยาก"),
+            ("l","อยู่"),
+            ("l","หนวก"),
+            ("l","ใหม่"),
+            ("m","ควาย"),
+            ("m","ไป"),
+            ("h","คะ"),
+            ("h","วัด"),
+            ("h","ไม้"),
+            ("h","โต๊ะ"),
+            ("r","เขา"),
+            ("r","ก๋ง"),
+            ("r","หญิง"),
+            ("f","มาก"),
+            ("f","ใช่"),
+            ("f","ไหม้"),
+            ("f","ต้น"),
+            ("f","ผู้"),
+        ]
+        for i,j in data:
+            self.assertEqual(tone_detector(j), i)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -52,6 +52,7 @@ from pythainlp.util import (
     syllable_length,
     syllable_open_close_detector,
     tone_detector,
+    thai_word_tone_detector,
 )
 
 
@@ -742,3 +743,10 @@ class TestUtilPackage(unittest.TestCase):
     def test_syllable_open_close_detector(self):
         self.assertEqual(syllable_open_close_detector("มาก"), "close")
         self.assertEqual(syllable_open_close_detector("คะ"), "open")
+
+    def test_thai_word_tone_detector(self):
+        self.assertIsNotNone(thai_word_tone_detector("คนดี"))
+        self.assertEqual(
+            thai_word_tone_detector("ราคา"),
+            [('รา', 'm'), ('คา', 'm')]
+        )


### PR DESCRIPTION
This is tone detector for Thai syllables. It can output the tone.

I write by [thai-language.com/ref/tone-rules](http://www.thai-language.com/ref/tone-rules) documentation.

Fix #63

This is include
- `syllable_length` - This function is use for find syllable's length. (long or short)
```python
from pythainlp.util import sound_syllable

print(sound_syllable("มา"))
# output: live

print(sound_syllable("เลข"))
# output: dead
```
- `tone_detector` - Thai tone detector for syllables
```python
from pythainlp.util import tone_detector

print(tone_detector("มา"))
# output: m

print(tone_detector("ไม้"))
# output: h
```
- `syllable_open_close_detector` - This function is use for find Thai syllable that open or closed sound.
```python
from pythainlp.util import syllable_open_close_detector

print(syllable_open_close_detector("มาก"))
# output: close

print(syllable_open_close_detector("คะ"))
# output: open
```
- `thai_word_tone_detector` - Thai tone detector for word.
 ```python
from pythainlp.util import thai_word_tone_detector

print(thai_word_tone_detector("มือถือ"))
# output: [('มือ', 'm'), ('ถือ', 'r')]

print(thai_word_tone_detector("ราคา"))
# output: [('รา', 'm'), ('คา', 'm')]
```

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test
