### PR TITLE
Remove TinyDB as a dependency

### DIFF
--- a/docker_requirements.txt
+++ b/docker_requirements.txt
@@ -2,7 +2,6 @@ PyYAML==5.4
 numpy==1.22.*
 python-crfsuite==0.9.7
 requests==2.25.*
-tinydb==4.3.*
 gensim==4.0.*
 nltk==3.6.6
 emoji==0.5.2

--- a/pythainlp/corpus/__init__.py
+++ b/pythainlp/corpus/__init__.py
@@ -33,7 +33,6 @@ __all__ = [
 import os
 
 from pythainlp.tools import get_full_data_path, get_pythainlp_path
-from tinydb import TinyDB
 
 # Remote and local corpus databases
 
@@ -54,7 +53,7 @@ _CORPUS_DB_PATH = get_full_data_path(_CORPUS_DB_FILENAME)
 
 # create a local corpus database if it does not already exist
 if not os.path.exists(_CORPUS_DB_PATH) and _CHECK_MODE != "1":
-    TinyDB(_CORPUS_DB_PATH).close()
+    open(_CORPUS_DB_PATH, "w", encoding="utf_8").close()
 
 
 def corpus_path() -> str:

--- a/pythainlp/corpus/__init__.py
+++ b/pythainlp/corpus/__init__.py
@@ -53,7 +53,8 @@ _CORPUS_DB_PATH = get_full_data_path(_CORPUS_DB_FILENAME)
 
 # create a local corpus database if it does not already exist
 if not os.path.exists(_CORPUS_DB_PATH) and _CHECK_MODE != "1":
-    open(_CORPUS_DB_PATH, "w", encoding="utf_8").close()
+    with open(_CORPUS_DB_PATH, "w", encoding="utf-8") as f:
+        f.write(r'{"_default": {}}')
 
 
 def corpus_path() -> str:

--- a/pythainlp/corpus/core.py
+++ b/pythainlp/corpus/core.py
@@ -47,7 +47,7 @@ def get_corpus_db_detail(name: str, version: str = None) -> dict:
     :return: details about a corpus
     :rtype: dict
     """
-    with open(corpus_db_path(), "r", encoding="utf_8") as f:
+    with open(corpus_db_path(), "r", encoding="utf-8") as f:
         local_db = json.load(f)
 
     if version is None:
@@ -378,7 +378,7 @@ def download(
 
     # check if corpus is available
     if name in corpus_db:
-        with open(corpus_db_path(), "r", encoding="utf_8") as f:
+        with open(corpus_db_path(), "r", encoding="utf-8") as f:
             local_db = json.load(f)
 
         corpus = corpus_db[name]
@@ -437,14 +437,17 @@ def download(
                     zip.extractall(path=get_full_data_path(foldername))
 
             if found:
-                local_db['_default'][found]["version"] = version
-                local_db['_default'][found]["filename"] = file_name
-                local_db['_default'][found]["is_folder"] = is_folder
-                local_db['_default'][found]["foldername"] = foldername
+                local_db["_default"][found]["version"] = version
+                local_db["_default"][found]["filename"] = file_name
+                local_db["_default"][found]["is_folder"] = is_folder
+                local_db["_default"][found]["foldername"] = foldername
             else:
                 # This awkward behavior is for backward-compatibility with
                 # database files generated previously using TinyDB
-                corpus_no = max((int(no) for no in local_db["_default"])) + 1
+                if local_db["_default"]:
+                    corpus_no = max((int(no) for no in local_db["_default"])) + 1
+                else:
+                    corpus_no = 1
                 local_db["_default"][str(corpus_no)] = {
                     "name": name,
                     "version": version,
@@ -453,8 +456,8 @@ def download(
                     "foldername": foldername
                 }
 
-            with open(corpus_db_path(), "w", encoding="utf_8") as f:
-                json.dump(local_db, f)
+            with open(corpus_db_path(), "w", encoding="utf-8") as f:
+                json.dump(local_db, f, ensure_ascii=False)
         else:
             current_ver = local_db['_default'][found]["version"]
 
@@ -501,7 +504,7 @@ def remove(name: str) -> bool:
     if _CHECK_MODE == "1":
         print("PyThaiNLP is read-only mode. It can't remove corpus.")
         return False
-    with open(corpus_db_path(), "r", encoding="utf_8") as f:
+    with open(corpus_db_path(), "r", encoding="utf-8") as f:
         db = json.load(f)
     data = [
         corpus for corpus in db["_default"].values() if corpus["name"] == name
@@ -517,8 +520,8 @@ def remove(name: str) -> bool:
         for i, corpus in db["_default"].copy().items():
             if corpus["name"] == name:
                 del db['_default'][i]
-        with open(corpus_db_path(), 'w', encoding='utf_8') as f:
-            json.dump(db, f)
+        with open(corpus_db_path(), 'w', encoding='utf-8') as f:
+            json.dump(db, f, ensure_ascii=False)
         return True
 
     return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ PyYAML==5.4
 numpy==1.22.*
 python-crfsuite==0.9.*
 requests==2.25.*
-tinydb==4.3.*

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ See https://github.com/PyThaiNLP/pythainlp for installation options.
 
 requirements = [
     "requests>=2.22.0",
-    "tinydb>=3.0",
 ]
 
 extras = {


### PR DESCRIPTION
### What does this changes

This PR removes `TinyDB` as a dependency.

### What was wrong

`TinyDB` is an unnecessary external dependency.

### How this fixes it

Remove `TinyDB` as a dependency and use `json` in the Python standard library instead.

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [X] Passed code styles and structures
- [x] Passed code linting checks and unit test
