### PR TITLE
Add word_detokenize

### DIFF
--- a/docs/api/tokenize.rst
+++ b/docs/api/tokenize.rst
@@ -12,6 +12,7 @@ Modules
 .. autofunction:: sent_tokenize
 .. autofunction:: subword_tokenize
 .. autofunction:: word_tokenize
+.. autofunction:: word_detokenize
 .. autoclass:: Tokenizer
    :members:
 

--- a/notebooks/word_detokenize.ipynb
+++ b/notebooks/word_detokenize.ipynb
@@ -1,0 +1,147 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pythainlp.tokenize import word_detokenize"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'ผมเลี้ยง 5 ตัว'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "word_detokenize([\"ผม\",\"เลี้ยง\",\"5\",\"ตัว\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[['ผม', 'เลี้ยง', ' ', '5', ' ', 'ตัว']]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "word_detokenize([\"ผม\",\"เลี้ยง\",\" \",\"5\",\"ตัว\"],\"list\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'ผมเลี้ยง 5 5 ตัว'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "word_detokenize([\"ผม\",\"เลี้ยง\",\"5\",\"5\",\"ตัว\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'ภาษาไทยหรือภาษาไทยกลางเป็นภาษาในกลุ่มภาษาไทซึ่งเป็นกลุ่มย่อยของตระกูลภาษาขร้า - ไท และเป็นภาษาราชการและภาษาประจำชาติของประเทศไทย'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "word_detokenize(['ภาษาไทย', 'หรือ', 'ภาษาไทย', 'กลาง', 'เป็น', 'ภาษา', 'ใน', 'กลุ่ม', 'ภาษา', 'ไท', 'ซึ่ง', 'เป็น', 'กลุ่มย่อย', 'ของ', 'ตระกูล', 'ภาษา', 'ข', 'ร้า', '-', 'ไท', 'และ', 'เป็น', 'ภาษาราชการ', 'และ', 'ภาษาประจำชาติ', 'ของ', 'ประเทศ', 'ไทย'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'ผมเลี้ยง 5 5 ตัว ๆ คนดี'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "word_detokenize([\"ผม\",\"เลี้ยง\",\"5\",\"5\",\"ตัว\",\"ๆ\",\"คน\",\"ดี\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.12 ('base')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "48b90c76b600d2ec6cf3e350b23a5df9176e3eef7b22ad90377f14c1de9c1bf6"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pythainlp/tokenize/__init__.py
+++ b/pythainlp/tokenize/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "sent_tokenize",
     "subword_tokenize",
     "word_tokenize",
+    "word_detokenize"
 ]
 
 from pythainlp.corpus import thai_syllables, thai_words
@@ -31,6 +32,7 @@ from pythainlp.tokenize.core import (
     sent_tokenize,
     subword_tokenize,
     word_tokenize,
+    word_detokenize,
 )
 
 from pythainlp.corpus import get_corpus as _get_corpus

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -81,7 +81,9 @@ def word_detokenize(segments: Union[List[List[str]], List[str]], output: str = "
                         _list_sents.append(" ")
                         _add_index.append(j)
                     else:
-                        pass
+                        _add_index.append(j)
+                elif w.isspace():
+                    _add_index.append(j)
                 elif j-1 in _add_index:
                     _list_sents.append(" ")
             _list_sents.append(w)

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -63,6 +63,8 @@ def word_detokenize(segments: Union[List[List[str]], List[str]], output: str = "
     for i, s in enumerate(segments):
         _list_sents = []
         _add_index = []
+        _space_index = []
+        _mark_index = []
         for j, w in enumerate(s):
             if j > 0:
                 # previous word
@@ -83,12 +85,10 @@ def word_detokenize(segments: Union[List[List[str]], List[str]], output: str = "
                 elif w == "ๆ":
                     if not p_w.isspace():
                         _list_sents.append(" ")
-                        _add_index.append(j)
-                    else:
-                        _add_index.append(j)
-                elif w.isspace():
-                    _add_index.append(j)
-                elif j-1 in _add_index:
+                    _mark_index.append(j)
+                elif w.isspace() and j-1 not in _space_index:
+                    _space_index.append(j)
+                elif j-1 in _mark_index:
                     _list_sents.append(" ")
             _list_sents.append(w)
         _list_all.append(_list_sents)

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -46,10 +46,7 @@ def clause_tokenize(doc: List[str]) -> List[List[str]]:
     return segment(doc)
 
 
-def word_detokenize(
-    segments: Union[List[List[str]],
-    List[str]],
-    output: str = "str") -> Union[str, List[str]]:
+def word_detokenize(segments: Union[List[List[str]], List[str]], output: str = "str") -> Union[str, List[str]]:
     """
     Word detokenizer.
 

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -46,7 +46,11 @@ def clause_tokenize(doc: List[str]) -> List[List[str]]:
     return segment(doc)
 
 
-def word_detokenize(segments: Union[List[List[str]], List[str]], output: str = "str") -> Union[str, List[str]]:
+def word_detokenize(
+    segments: Union[List[List[str]],
+    List[str]],
+    output: str = "str"
+) -> Union[str, List[str]]:
     """
     Word detokenizer.
 
@@ -68,7 +72,11 @@ def word_detokenize(segments: Union[List[List[str]], List[str]], output: str = "
                 # previous word
                 p_w = s[j-1]
                 # if w is number or other language and not be space
-                if w[0] not in thai_characters and not w.isspace() and not p_w.isspace():
+                if (
+                    w[0] not in thai_characters
+                    and not w.isspace()
+                    and not p_w.isspace()
+                ):
                     _list_sents.append(" ")
                     _add_index.append(j)
                 # if previous word is number or other language and not be space

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -14,6 +14,7 @@ from pythainlp.tokenize import (
     DEFAULT_WORD_DICT_TRIE,
     DEFAULT_WORD_TOKENIZE_ENGINE,
 )
+from pythainlp import thai_characters
 from pythainlp.util.trie import Trie, dict_trie
 
 
@@ -43,6 +44,39 @@ def clause_tokenize(doc: List[str]) -> List[List[str]]:
     from pythainlp.tokenize.crfcls import segment
 
     return segment(doc)
+
+
+def word_detokenize(segments: Union[List[List[str]], List[str]], output: str="str") -> str:
+    _list_all = []
+    if isinstance(segments[0], str):
+        segments = [segments]
+    for i, s in enumerate(segments):
+        _list_sents = []
+        _add_index = []
+        for j, w in enumerate(s):
+            if j > 0:
+                # previous word
+                p_w = s[j-1]
+                # if w is number or other language and not be space (previous word and now word)
+                if w[0] not in thai_characters and w.isspace() != True and p_w.isspace() != True:
+                    _list_sents.append(" ")
+                    _add_index.append(j)
+                # if previous word is number or other language and not be space
+                elif p_w[0] not in thai_characters and p_w.isspace() != True:
+                    _list_sents.append(" ")
+                    _add_index.append(j)
+            _list_sents.append(w)
+        _list_all.append(_list_sents)
+    if output == "list":
+        return _list_all
+    else:
+        _text = []
+        for i in _list_all:
+            _temp = ""
+            for j in i:
+                _temp+=j
+            _text.append(_temp)
+        return ' '.join(_text)
 
 
 def word_tokenize(

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -46,7 +46,17 @@ def clause_tokenize(doc: List[str]) -> List[List[str]]:
     return segment(doc)
 
 
-def word_detokenize(segments: Union[List[List[str]], List[str]], output: str="str") -> str:
+def word_detokenize(segments: Union[List[List[str]], List[str]], output: str="str") -> Union[str,List[str]]:
+    """
+    Word detokenizer.
+
+    This function will detokenize the list word in each sentence to text.
+
+    :param str segments: List sentences with list words.
+    :param str output: the output type (str or list)
+    :return: the thai text
+    :rtype: Union[str,List[str]]
+    """
     _list_all = []
     if isinstance(segments[0], str):
         segments = [segments]
@@ -65,6 +75,15 @@ def word_detokenize(segments: Union[List[List[str]], List[str]], output: str="st
                 elif p_w[0] not in thai_characters and p_w.isspace() != True:
                     _list_sents.append(" ")
                     _add_index.append(j)
+                # if word is Thai iteration mark
+                elif w == "ๆ":
+                    if not p_w.isspace():
+                        _list_sents.append(" ")
+                        _add_index.append(j)
+                    else:
+                        pass
+                elif j-1 in _add_index:
+                    _list_sents.append(" ")
             _list_sents.append(w)
         _list_all.append(_list_sents)
     if output == "list":
@@ -97,7 +116,7 @@ def word_tokenize(
                                  for end of phrase in Thai.
                                  Otherwise, whitespaces are omitted.
     :return: list of words
-    :rtype: list[str]
+    :rtype: List[str]
     **Options for engine**
         * *newmm* (default) - dictionary-based, Maximum Matching +
           Thai Character Cluster

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -46,7 +46,7 @@ def clause_tokenize(doc: List[str]) -> List[List[str]]:
     return segment(doc)
 
 
-def word_detokenize(segments: Union[List[List[str]], List[str]], output: str="str") -> Union[str,List[str]]:
+def word_detokenize(segments: Union[List[List[str]], List[str]], output: str = "str") -> Union[str, List[str]]:
     """
     Word detokenizer.
 
@@ -67,12 +67,12 @@ def word_detokenize(segments: Union[List[List[str]], List[str]], output: str="st
             if j > 0:
                 # previous word
                 p_w = s[j-1]
-                # if w is number or other language and not be space (previous word and now word)
-                if w[0] not in thai_characters and w.isspace() != True and p_w.isspace() != True:
+                # if w is number or other language and not be space
+                if w[0] not in thai_characters and not w.isspace() and not p_w.isspace():
                     _list_sents.append(" ")
                     _add_index.append(j)
                 # if previous word is number or other language and not be space
-                elif p_w[0] not in thai_characters and p_w.isspace() != True:
+                elif p_w[0] not in thai_characters and not p_w.isspace():
                     _list_sents.append(" ")
                     _add_index.append(j)
                 # if word is Thai iteration mark
@@ -93,7 +93,7 @@ def word_detokenize(segments: Union[List[List[str]], List[str]], output: str="st
         for i in _list_all:
             _temp = ""
             for j in i:
-                _temp+=j
+                _temp += j
             _text.append(_temp)
         return ' '.join(_text)
 

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -49,8 +49,7 @@ def clause_tokenize(doc: List[str]) -> List[List[str]]:
 def word_detokenize(
     segments: Union[List[List[str]],
     List[str]],
-    output: str = "str"
-) -> Union[str, List[str]]:
+    output: str = "str") -> Union[str, List[str]]:
     """
     Word detokenizer.
 

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -644,17 +644,19 @@ class TestTokenizePackage(unittest.TestCase):
 
     def test_word_detokenize(self):
         self.assertEqual(
-            word_detokenize(["ผม","เลี้ยง","5","ตัว"]),
+            word_detokenize(["ผม", "เลี้ยง", "5", "ตัว"]),
             "ผมเลี้ยง 5 ตัว"
         )
         self.assertEqual(word_detokenize(
-            ["ผม","เลี้ยง"," ","5","ตัว"],"list"),
+            ["ผม", "เลี้ยง", " ", "5", "ตัว"], "list"),
             [["ผม", "เลี้ยง", " ", "5", " ", "ตัว"]]
         )
         self.assertEqual(
-            word_detokenize(["ผม","เลี้ยง","5","5","ตัว","ๆ","คน","ดี"]),
+            word_detokenize(
+                ["ผม", "เลี้ยง", "5", "5", "ตัว", "ๆ", "คน", "ดี"]
+            ),
             "ผมเลี้ยง 55 ตัว ๆ คนดี"
         )
         self.assertTrue(
-            isinstance(word_detokenize(["ผม","เลี้ยง","5","ตัว"]),str)
+            isinstance(word_detokenize(["ผม", "เลี้ยง", "5", "ตัว"]), str)
         )

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -653,10 +653,14 @@ class TestTokenizePackage(unittest.TestCase):
         )
         self.assertEqual(
             word_detokenize(
-                ["ผม", "เลี้ยง", "5", "5", "ตัว", "ๆ", "คน", "ดี"]
+                ["ผม", "เลี้ยง", "5", "10", "ตัว", "ๆ", "คน", "ดี"]
             ),
-            "ผมเลี้ยง 55 ตัว ๆ คนดี"
+            "ผมเลี้ยง 5 10 ตัว ๆ คนดี"
         )
         self.assertTrue(
             isinstance(word_detokenize(["ผม", "เลี้ยง", "5", "ตัว"]), str)
+        )
+        self.assertEqual(
+            word_detokenize(["ม่ายย", " ", "ผม", "เลี้ยง", "5", "ตัว"]),
+            "ม่ายย ผมเลี้ยง 5 ตัว"
         )

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -22,6 +22,7 @@ from pythainlp.tokenize import (
     sefr_cut,
     tltk,
     oskut,
+    word_detokenize,
 )
 from pythainlp.tokenize import clause_tokenize as sent_clause_tokenize
 from pythainlp.util import dict_trie
@@ -639,4 +640,21 @@ class TestTokenizePackage(unittest.TestCase):
         )
         self.assertIsNotNone(
             oskut.segment("ฉันรักภาษาไทยเพราะฉันเป็นคนไทย", engine="scads"),
+        )
+
+    def test_word_detokenize(self):
+        self.assertEqual(
+            word_detokenize(["ผม","เลี้ยง","5","ตัว"]),
+            "ผมเลี้ยง 5 ตัว"
+        )
+        self.assertEqual(word_detokenize(
+            ["ผม","เลี้ยง"," ","5","ตัว"],"list"),
+            [["ผม", "เลี้ยง", " ", "5", " ", "ตัว"]]
+        )
+        self.assertEqual(
+            word_detokenize(["ผม","เลี้ยง","5","5","ตัว","ๆ","คน","ดี"]),
+            "ผมเลี้ยง 55 ตัว ๆ คนดี"
+        )
+        self.assertTrue(
+            isinstance(word_detokenize(["ผม","เลี้ยง","5","ตัว"]),str)
         )

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -657,6 +657,12 @@ class TestTokenizePackage(unittest.TestCase):
             ),
             "ผมเลี้ยง 5 10 ตัว ๆ คนดี"
         )
+        self.assertEqual(
+            word_detokenize(
+                ["ผม", "เลี้ยง", "5", "ตัว", " ", "ๆ", "คน", "ดี"]
+            ),
+            "ผมเลี้ยง 5 ตัว ๆ คนดี"
+        )
         self.assertTrue(
             isinstance(word_detokenize(["ผม", "เลี้ยง", "5", "ตัว"]), str)
         )


### PR DESCRIPTION
This pull request will add `word_detokenize` and resolves #696

`word_detokenize` is Thai word detokenizer that merge list to string with whitespace.

Rules:

- [x] Add whitespace between number/other language and Thai words.
- [x] Add whitespace between ๆ (Thai iteration mark) and Thai words

Example
```python
from pythainlp.tokenize import word_detokenize

word_detokenize(["ผม","เลี้ยง","5","ตัว"]) # output: 'ผมเลี้ยง 5 ตัว'
word_detokenize(["ผม","เลี้ยง"," ","5","ตัว"],"list") # output: [['ผม', 'เลี้ยง', ' ', '5', ' ', 'ตัว']]
```

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test
