### PR TITLE
Fix/broken numeric data format (#652)

### DIFF
--- a/pythainlp/tokenize/_utils.py
+++ b/pythainlp/tokenize/_utils.py
@@ -9,21 +9,20 @@ from typing import List, Callable
 _DIGITS_WITH_SEPARATOR = re.compile(r"(\d+(\.|\,|:))+\d+")
 
 
-def postprocess_word_tokenize(segments: List[str]) -> List[str]:
+def apply_postprocessors(
+        segments: List[str], 
+        postprocessors: Callable[[List[str]], List[str]]
+    ) -> List[str]:
     """
-    A list of callables to apply on a raw word segmentation result.
+    A list of callables to apply on a raw segmentation result.
     """
-    post_processors: Callable[[List[str]], List[str]] = [
-        _fix_broken_numeric_data_format
-    ]
-
-    for func in post_processors:
+    for func in postprocessors:
         segments = func(segments)
 
     return segments
 
 
-def _fix_broken_numeric_data_format(segments: List[str]) -> List[str]:
+def fix_broken_numeric_data_format(segments: List[str]) -> List[str]:
     """
     Fix well-known numeric formats that are over-tokenized.
     The numeric formats are numbers separated by either ":", ",", or ".".

--- a/pythainlp/tokenize/_utils.py
+++ b/pythainlp/tokenize/_utils.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""
+Utility functions for tokenize module.
+"""
+
+import re
+from typing import List, Callable
+
+_DIGITS_WITH_SEPARATOR = re.compile(r"(\d+(\.|\,|:))+\d+")
+
+
+def postprocess_word_tokenize(segments: List[str]) -> List[str]:
+    """
+    A list of callables to apply on a raw word segmentation result.
+    """
+    post_processors: Callable[[List[str]], List[str]] = [
+        _fix_broken_numeric_data_format
+    ]
+
+    for func in post_processors:
+        segments = func(segments)
+
+    return segments
+
+
+def _fix_broken_numeric_data_format(segments: List[str]) -> List[str]:
+    """
+    Fix well-known numeric formats that are over-tokenized.
+    The numeric formats are numbers separated by either ":", ",", or ".".
+    such as time, decimal number, comma-added number, and IP address.
+
+    :param List[str] segments: result from word tokenizer
+    :return: a list of fixed tokens
+    :rtype: List[str]
+
+    :Example:
+        text = ['ขณะ', 'นี้', 'เวลา', ' ', '12', ':', '00น', ' ', 'อัตรา',
+                'แลกเปลี่ยน', ' ', '1', ',', '234', '.', '5', ' ', 'baht/zeny']
+        _fix_broken_digits(text)
+        # output:
+        # ['ขณะ', 'นี้', 'เวลา', ' ', '12:00น', ' ', 'อัตรา', 'แลกเปลี่ยน', ' ', '1,234.5', ' ', 'baht/zeny']
+
+        text = ['IP', ' ', 'address', ' ', 'ของ', 'คุณ', 'คือ', ' ', '127', '.', '0', '.', '0', '.', '1', ' ', 'ครับ']
+        _fix_broken_digits(text)
+        # output:
+        # ['IP', ' ', 'address', ' ', 'ของ', 'คุณ', 'คือ', ' ', '127.0.0.1', ' ', 'ครับ']
+    """
+    original = "".join(segments)
+    matching_results = _DIGITS_WITH_SEPARATOR.finditer(original)
+    tokens_joined = []
+    pos = 0
+    segment_idx = 0
+
+    match = next(matching_results, None)
+    while segment_idx < len(segments) and match:
+        is_span_beginning = pos >= match.start()
+        token = segments[segment_idx]
+        if is_span_beginning:
+            connected_token = ""
+            while pos < match.end() and segment_idx < len(segments):
+                connected_token += segments[segment_idx]
+                pos += len(segments[segment_idx])
+                segment_idx += 1
+
+            tokens_joined.append(connected_token)
+            match = next(matching_results, None)
+        else:
+            tokens_joined.append(token)
+            segment_idx += 1
+            pos += len(token)
+    tokens_joined += segments[segment_idx:]
+    return tokens_joined

--- a/pythainlp/tokenize/_utils.py
+++ b/pythainlp/tokenize/_utils.py
@@ -22,7 +22,7 @@ def apply_postprocessors(
     return segments
 
 
-def fix_broken_numeric_data_format(segments: List[str]) -> List[str]:
+def fix_numeric_data_format(segments: List[str]) -> List[str]:
     """
     Fix well-known numeric formats that are over-tokenized.
     The numeric formats are numbers separated by either ":", ",", or ".".
@@ -35,12 +35,12 @@ def fix_broken_numeric_data_format(segments: List[str]) -> List[str]:
     :Example:
         text = ['ขณะ', 'นี้', 'เวลา', ' ', '12', ':', '00น', ' ', 'อัตรา',
                 'แลกเปลี่ยน', ' ', '1', ',', '234', '.', '5', ' ', 'baht/zeny']
-        _fix_broken_digits(text)
+        fix_numeric_data_format(text)
         # output:
         # ['ขณะ', 'นี้', 'เวลา', ' ', '12:00น', ' ', 'อัตรา', 'แลกเปลี่ยน', ' ', '1,234.5', ' ', 'baht/zeny']
 
         text = ['IP', ' ', 'address', ' ', 'ของ', 'คุณ', 'คือ', ' ', '127', '.', '0', '.', '0', '.', '1', ' ', 'ครับ']
-        _fix_broken_digits(text)
+        fix_numeric_data_format(text)
         # output:
         # ['IP', ' ', 'address', ' ', 'ของ', 'คุณ', 'คือ', ' ', '127.0.0.1', ' ', 'ครับ']
     """

--- a/pythainlp/tokenize/_utils.py
+++ b/pythainlp/tokenize/_utils.py
@@ -33,14 +33,14 @@ def fix_numeric_data_format(segments: List[str]) -> List[str]:
     :rtype: List[str]
 
     :Example:
-        text = ['ขณะ', 'นี้', 'เวลา', ' ', '12', ':', '00น', ' ', 'อัตรา',
+        tokens = ['ขณะ', 'นี้', 'เวลา', ' ', '12', ':', '00น', ' ', 'อัตรา',
                 'แลกเปลี่ยน', ' ', '1', ',', '234', '.', '5', ' ', 'baht/zeny']
-        fix_numeric_data_format(text)
+        fix_numeric_data_format(tokens)
         # output:
         # ['ขณะ', 'นี้', 'เวลา', ' ', '12:00น', ' ', 'อัตรา', 'แลกเปลี่ยน', ' ', '1,234.5', ' ', 'baht/zeny']
 
-        text = ['IP', ' ', 'address', ' ', 'ของ', 'คุณ', 'คือ', ' ', '127', '.', '0', '.', '0', '.', '1', ' ', 'ครับ']
-        fix_numeric_data_format(text)
+        tokens = ['IP', ' ', 'address', ' ', 'ของ', 'คุณ', 'คือ', ' ', '127', '.', '0', '.', '0', '.', '1', ' ', 'ครับ']
+        fix_numeric_data_format(tokens)
         # output:
         # ['IP', ' ', 'address', ' ', 'ของ', 'คุณ', 'คือ', ' ', '127.0.0.1', ' ', 'ครับ']
     """
@@ -69,3 +69,20 @@ def fix_numeric_data_format(segments: List[str]) -> List[str]:
             pos += len(token)
     tokens_joined += segments[segment_idx:]
     return tokens_joined
+
+
+def strip_whitespace(segments: List[str]) -> List[str]:
+    """
+    Strip whitespace(s) off each token and remove whitespace tokens.
+    :param List[str] segments: result from word tokenizer
+    :return: a list of tokens
+    :rtype: List[str]
+
+    :Example:
+        tokens = [" ", "วันนี้ ", "เวลา ", "19.00น"]
+        strip_whitespace(tokens)
+        # ["วันนี้", "เวลา", "19.00น"]
+
+    """
+    segments = [token.strip(" ") for token in segments if token.strip(" ")]
+    return segments

--- a/pythainlp/tokenize/_utils.py
+++ b/pythainlp/tokenize/_utils.py
@@ -21,10 +21,10 @@ def apply_postprocessors(
     return segments
 
 
-def fix_numeric_data_format(segments: List[str]) -> List[str]:
+def rejoin_formatted_num(segments: List[str]) -> List[str]:
     """
-    Fix well-known numeric formats that are over-tokenized.
-    The numeric formats are numbers separated by either ":", ",", or ".".
+    Rejoin well-known formatted numeric that are over-tokenized.
+    The formatted numeric are numbers separated by ":", ",", or ".",
     such as time, decimal number, comma-added number, and IP address.
 
     :param List[str] segments: result from word tokenizer
@@ -34,12 +34,12 @@ def fix_numeric_data_format(segments: List[str]) -> List[str]:
     :Example:
         tokens = ['ขณะ', 'นี้', 'เวลา', ' ', '12', ':', '00น', ' ', 'อัตรา',
                 'แลกเปลี่ยน', ' ', '1', ',', '234', '.', '5', ' ', 'baht/zeny']
-        fix_numeric_data_format(tokens)
+        rejoin_formatted_num(tokens)
         # output:
         # ['ขณะ', 'นี้', 'เวลา', ' ', '12:00น', ' ', 'อัตรา', 'แลกเปลี่ยน', ' ', '1,234.5', ' ', 'baht/zeny']
 
         tokens = ['IP', ' ', 'address', ' ', 'ของ', 'คุณ', 'คือ', ' ', '127', '.', '0', '.', '0', '.', '1', ' ', 'ครับ']
-        fix_numeric_data_format(tokens)
+        rejoin_formatted_num(tokens)
         # output:
         # ['IP', ' ', 'address', ' ', 'ของ', 'คุณ', 'คือ', ' ', '127.0.0.1', ' ', 'ครับ']
     """

--- a/pythainlp/tokenize/_utils.py
+++ b/pythainlp/tokenize/_utils.py
@@ -6,13 +6,12 @@ Utility functions for tokenize module.
 import re
 from typing import List, Callable
 
-_DIGITS_WITH_SEPARATOR = re.compile(r"(\d+(\.|\,|:))+\d+")
+_DIGITS_WITH_SEPARATOR = re.compile(r"(\d+[\.\,:])+\d+")
 
 
 def apply_postprocessors(
-        segments: List[str], 
-        postprocessors: Callable[[List[str]], List[str]]
-    ) -> List[str]:
+    segments: List[str], postprocessors: Callable[[List[str]], List[str]]
+) -> List[str]:
     """
     A list of callables to apply on a raw segmentation result.
     """

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -133,39 +133,46 @@ def word_tokenize(
                                  for end of phrase in Thai.
                                  Otherwise, whitespaces are omitted.
     :param bool join_broken_num: True to rejoin formatted numeric that could be wrongly separated.
-                                 Otherwise, formatted numeric could be separated.
+                                 Otherwise, formatted numeric could be wrongly separated.
 
     :return: list of words
     :rtype: List[str]
     **Options for engine**
-        * *newmm* (default) - dictionary-based, Maximum Matching +
-          Thai Character Cluster
-        * *newmm-safe* - newmm, with a mechanism to help avoid long
-          processing time for text with continuous ambiguous breaking points
-        * *mm* or *multi_cut* - dictionary-based, Maximum Matching.
-        * *nlpo3* - Python binding for nlpO3. It is newmm engine in Rust.
-        * *longest* - dictionary-based, Longest Matching
-        * *icu* - wrapper for ICU (International Components for Unicode,
-          using PyICU), dictionary-based
         * *attacut* - wrapper for
           `AttaCut <https://github.com/PyThaiNLP/attacut>`_.,
           learning-based approach
         * *deepcut* - wrapper for
           `DeepCut <https://github.com/rkcosmos/deepcut>`_,
           learning-based approach
-        * *nercut* - Dictionary-based maximal matching word segmentation,
+        * *icu* - wrapper for a word tokenizer in
+          `PyICU <https://gitlab.pyicu.org/main/pyicu>`_.,
+          from ICU (International Components for Unicode),
+          dictionary-based          
+        * *longest* - dictionary-based, longest matching
+        * *mm* - "multi-cut", dictionary-based, maximum matching
+        * *nercut* - dictionary-based, maximal matching,
           constrained with Thai Character Cluster (TCC) boundaries,
-          and combining tokens that are parts of the same named-entity.
-        * *sefr_cut* - wrapper for
-          `SEFR CUT <https://github.com/mrpeerat/SEFR_CUT>`_.,
-        * *tltk* - wrapper for
-          `TLTK <https://pypi.org/project/tltk/>`_.,
+          combining tokens that are parts of the same named-entity
+        * *newmm* (default) - "new multi-cut",
+          dictionary-based, maximum matching,
+          constrained with Thai Character Cluster (TCC) boundaries
+        * *newmm-safe* - newmm, with a mechanism to avoid long
+          processing time for text with continuous ambiguous breaking points
+        * *nlpo3* - wrapper for a word tokenizer in
+          `nlpO3 <https://github.com/PyThaiNLP/nlpo3>`_.,
+          newmm adaptation in Rust (2.5x faster)
         * *oskut* - wrapper for
           `OSKut <https://github.com/mrpeerat/OSKut>`_.,
-
+          Out-of-domain StacKed cut for Word Segmentation
+        * *sefr_cut* - wrapper for
+          `SEFR CUT <https://github.com/mrpeerat/SEFR_CUT>`_.,
+          Stacked Ensemble Filter and Refine for Word Segmentation
+        * *tltk* - wrapper for
+          `TLTK <https://pypi.org/project/tltk/>`_.,
+           maximum collocation approach
     :Note:
         - The **custom_dict** parameter only works for \
-          *newmm*, *longest*, and *deepcut* engine.
+          *deepcut*, *longest*, *newmm*, and *newmm-safe* engines.
     :Example:
 
     Tokenize text with different tokenizer::
@@ -329,12 +336,12 @@ def sent_tokenize(
     :rtype: list[str]
     **Options for engine**
         * *crfcut* - (default) split by CRF trained on TED dataset
+        * *thaisum* - The implementation of sentence segmentator from \
+            Nakhun Chumpolsathien, 2020
+        * *tltk* - split by `TLTK <https://pypi.org/project/tltk/>`_.,
         * *whitespace+newline* - split by whitespaces and newline.
         * *whitespace* - split by whitespaces. Specifiaclly, with \
                          :class:`regex` pattern  ``r" +"``
-        * *tltk* - split by `TLTK <https://pypi.org/project/tltk/>`_.,
-        * *thaisum* - The implementation of sentence segmentator from \
-            Nakhun Chumpolsathien, 2020
     :Example:
 
     Split the text based on *whitespace*::
@@ -440,13 +447,12 @@ def subword_tokenize(
     :return: list of subwords
     :rtype: list[str]
     **Options for engine**
-        * *tcc* (default) -  Thai Character Cluster (Theeramunkong et al. 2000)
-        * *etcc* - Enhanced Thai Character Cluster (Inrut et al. 2001)
-        * *wangchanberta* - SentencePiece from wangchanberta model.
         * *dict* - newmm word tokenizer with a syllable dictionary
+        * *etcc* - Enhanced Thai Character Cluster (Inrut et al. 2001)
         * *ssg* - CRF syllable segmenter for Thai
+        * *tcc* (default) - Thai Character Cluster (Theeramunkong et al. 2000)
         * *tltk* - syllable tokenizer from tltk
-
+        * *wangchanberta* - SentencePiece from wangchanberta model
     :Example:
 
     Tokenize text into subword based on *tcc*::

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -15,7 +15,7 @@ from pythainlp.tokenize import (
 )
 from pythainlp.tokenize._utils import (
     apply_postprocessors,
-    fix_numeric_data_format,
+    rejoin_formatted_num,
     strip_whitespace,
 )
 from pythainlp.util.trie import Trie, dict_trie
@@ -119,7 +119,7 @@ def word_tokenize(
     custom_dict: Trie = None,
     engine: str = DEFAULT_WORD_TOKENIZE_ENGINE,
     keep_whitespace: bool = True,
-    join_broken_numeric_format: bool = True,
+    join_broken_num: bool = True,
 ) -> List[str]:
     """
     Word tokenizer.
@@ -132,7 +132,7 @@ def word_tokenize(
     :param bool keep_whitespace: True to keep whitespaces, a common mark
                                  for end of phrase in Thai.
                                  Otherwise, whitespaces are omitted.
-    :param bool join_broken_numeric_format: True to ensure that tokens in numeric format are not separated. See examples below for more details.
+    :param bool join_broken_num: True to ensure that tokens in numeric format are not separated. See examples below for more details.
                                             
     :return: list of words
     :rtype: List[str]
@@ -190,11 +190,11 @@ def word_tokenize(
         word_tokenize(text, engine="newmm", keep_whitespace=False)
         # output: ['วรรณกรรม', 'ภาพวาด', 'และ', 'การแสดง', 'งิ้ว']
 
-    Always join broken numeric tokens (e.g. time, decimals, IP address) are not separated::
+    Join broken formatted numeric tokens (e.g. time, decimals, IP address)::
 
         text = "ยอดเงิน1,234.56บาท19:32น จาก127.0.0.1"
 
-        word_tokenize(text, join_broken_numeric_format=True)
+        word_tokenize(text, join_broken_num=True)
         # output:
         # ['ยอดเงิน', '1,234.56', 'บาท', '19:32น', ' ', 'จาก', '127.0.0.1']
 
@@ -298,8 +298,8 @@ def word_tokenize(
         )
 
     postprocessors = []
-    if join_broken_numeric_format:
-        postprocessors.append(fix_numeric_data_format)
+    if join_broken_num:
+        postprocessors.append(rejoin_formatted_num)
 
     if not keep_whitespace:
         postprocessors.append(strip_whitespace)
@@ -594,7 +594,7 @@ class Tokenizer:
         custom_dict: Union[Trie, Iterable[str], str] = None,
         engine: str = "newmm",
         keep_whitespace: bool = True,
-        join_broken_numeric_format: bool = True,
+        join_broken_num: bool = True,
     ):
         """
         Initialize tokenizer object.
@@ -621,7 +621,7 @@ class Tokenizer:
                 % self.__engine
             )
         self.__keep_whitespace = keep_whitespace
-        self.__join_broken_numeric_format = join_broken_numeric_format
+        self.__join_broken_num = join_broken_num
 
     def word_tokenize(self, text: str) -> List[str]:
         """
@@ -636,7 +636,7 @@ class Tokenizer:
             custom_dict=self.__trie_dict,
             engine=self.__engine,
             keep_whitespace=self.__keep_whitespace,
-            join_broken_numeric_format=self.__join_broken_numeric_format,
+            join_broken_num=self.__join_broken_num,
         )
 
     def set_tokenize_engine(self, engine: str) -> None:

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -499,7 +499,9 @@ def subword_tokenize(
         words = word_tokenize(text)
         for word in words:
             segments.extend(
-                word_tokenize(text=word, custom_dict=DEFAULT_SYLLABLE_DICT_TRIE)
+                word_tokenize(
+                    text=word, custom_dict=DEFAULT_SYLLABLE_DICT_TRIE
+                )
             )
     elif engine == "ssg":
         from pythainlp.tokenize.ssg import segment

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -13,7 +13,7 @@ from pythainlp.tokenize import (
     DEFAULT_WORD_DICT_TRIE,
     DEFAULT_WORD_TOKENIZE_ENGINE,
 )
-from pythainlp.tokenize._utils import apply_postprocessors, fix_broken_numeric_data_format
+from pythainlp.tokenize._utils import apply_postprocessors, fix_numeric_data_format, strip_whitespace
 from pythainlp.util.trie import Trie, dict_trie
 
 
@@ -295,12 +295,12 @@ def word_tokenize(
 
     postprocessors = []
     if join_broken_numeric_format:
-        postprocessors.append(fix_broken_numeric_data_format)
+        postprocessors.append(fix_numeric_data_format)
+    
+    if not keep_whitespace:
+        postprocessors.append(strip_whitespace)
 
     segments = apply_postprocessors(segments, postprocessors)
-
-    if not keep_whitespace:
-        segments = [token.strip(" ") for token in segments if token.strip(" ")]
 
     return segments
 
@@ -402,7 +402,7 @@ def sent_tokenize(
         )
 
     if not keep_whitespace:
-        segments = [token.strip(" ") for token in segments if token.strip(" ")]
+        segments = strip_whitespace(segments)
 
     return segments
 
@@ -513,7 +513,7 @@ def subword_tokenize(
         segments = segment(text)
 
     if not keep_whitespace:
-        segments = [token.strip(" ") for token in segments if token.strip(" ")]
+        segments = strip_whitespace(segments)
 
     return segments
 
@@ -590,6 +590,7 @@ class Tokenizer:
         custom_dict: Union[Trie, Iterable[str], str] = None,
         engine: str = "newmm",
         keep_whitespace: bool = True,
+        join_broken_numeric_format: bool = True
     ):
         """
         Initialize tokenizer object.
@@ -616,6 +617,7 @@ class Tokenizer:
                 % self.__engine
             )
         self.__keep_whitespace = keep_whitespace
+        self.__join_broken_numeric_format = join_broken_numeric_format
 
     def word_tokenize(self, text: str) -> List[str]:
         """
@@ -630,6 +632,7 @@ class Tokenizer:
             custom_dict=self.__trie_dict,
             engine=self.__engine,
             keep_whitespace=self.__keep_whitespace,
+            join_broken_numeric_format=self.__join_broken_numeric_format
         )
 
     def set_tokenize_engine(self, engine: str) -> None:

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -132,8 +132,9 @@ def word_tokenize(
     :param bool keep_whitespace: True to keep whitespaces, a common mark
                                  for end of phrase in Thai.
                                  Otherwise, whitespaces are omitted.
-    :param bool join_broken_num: True to ensure that tokens in numeric format are not separated. See examples below for more details.
-                                            
+    :param bool join_broken_num: True to rejoin formatted numeric that could be wrongly separated.
+                                 Otherwise, formatted numeric could be separated.
+
     :return: list of words
     :rtype: List[str]
     **Options for engine**
@@ -163,8 +164,8 @@ def word_tokenize(
           `OSKut <https://github.com/mrpeerat/OSKut>`_.,
 
     :Note:
-        - The parameter **custom_dict** can be provided as an argument \
-          only for *newmm*, *longest*, and *deepcut* engine.
+        - The **custom_dict** parameter only works for \
+          *newmm*, *longest*, and *deepcut* engine.
     :Example:
 
     Tokenize text with different tokenizer::
@@ -189,17 +190,19 @@ def word_tokenize(
 
         word_tokenize(text, engine="newmm", keep_whitespace=False)
         # output: ['วรรณกรรม', 'ภาพวาด', 'และ', 'การแสดง', 'งิ้ว']
+        
+    Join broken formatted numeric (e.g. time, decimals, IP address)::
 
-    Join broken formatted numeric tokens (e.g. time, decimals, IP address)::
+        text = "เงิน1,234บาท19:32น 127.0.0.1"
 
-        text = "ยอดเงิน1,234.56บาท19:32น จาก127.0.0.1"
-
-        word_tokenize(text, join_broken_num=True)
+        word_tokenize(text, engine="attacut", join_broken_num=False)
         # output:
-        # ['ยอดเงิน', '1,234.56', 'บาท', '19:32น', ' ', 'จาก', '127.0.0.1']
+        # ['เงิน', '1', ',', '234', 'บาท', '19', ':', '32น', ' ',
+        #  '127', '.', '0', '.', '0', '.', '1']
 
-        word_tokenize(text, engine="newmm", keep_whitespace=False)
-        # output: ['วรรณกรรม', 'ภาพวาด', 'และ', 'การแสดง', 'งิ้ว']
+        word_tokenize(text, engine="attacut", join_broken_num=True)
+        # output:
+        # ['เงิน', '1,234', 'บาท', '19:32น', ' ', '127.0.0.1']
 
     Tokenize with default and custom dictionary::
 
@@ -221,8 +224,8 @@ def word_tokenize(
 
         word_tokenize(text, engine="newmm", custom_dict=trie))
         # output:
-        # ['ชินโซ', ' ', 'อาเบะ',
-        #   ' ', 'เกิด', ' ', '21', ' ', 'กันยายน']
+        # ['ชินโซ', ' ', 'อาเบะ', ' ',
+        #  'เกิด', ' ', '21', ' ', 'กันยายน']
     """
     if not text or not isinstance(text, str):
         return []

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -13,6 +13,7 @@ from pythainlp.tokenize import (
     DEFAULT_WORD_DICT_TRIE,
     DEFAULT_WORD_TOKENIZE_ENGINE,
 )
+from pythainlp.tokenize._utils import postprocess_word_tokenize
 from pythainlp.util.trie import Trie, dict_trie
 
 
@@ -47,7 +48,9 @@ def clause_tokenize(doc: List[str]) -> List[List[str]]:
     return segment(doc)
 
 
-def word_detokenize(segments: Union[List[List[str]], List[str]], output: str = "str") -> Union[str, List[str]]:
+def word_detokenize(
+    segments: Union[List[List[str]], List[str]], output: str = "str"
+) -> Union[str, List[str]]:
     """
     Word detokenizer.
 
@@ -62,6 +65,7 @@ def word_detokenize(segments: Union[List[List[str]], List[str]], output: str = "
     if isinstance(segments[0], str):
         segments = [segments]
     from pythainlp import thai_characters
+
     for i, s in enumerate(segments):
         _list_sents = []
         _add_index = []
@@ -70,7 +74,7 @@ def word_detokenize(segments: Union[List[List[str]], List[str]], output: str = "
         for j, w in enumerate(s):
             if j > 0:
                 # previous word
-                p_w = s[j-1]
+                p_w = s[j - 1]
                 # if w is number or other language and not be space
                 if (
                     w[0] not in thai_characters
@@ -88,9 +92,9 @@ def word_detokenize(segments: Union[List[List[str]], List[str]], output: str = "
                     if not p_w.isspace():
                         _list_sents.append(" ")
                     _mark_index.append(j)
-                elif w.isspace() and j-1 not in _space_index:
+                elif w.isspace() and j - 1 not in _space_index:
                     _space_index.append(j)
-                elif j-1 in _mark_index:
+                elif j - 1 in _mark_index:
                     _list_sents.append(" ")
             _list_sents.append(w)
         _list_all.append(_list_sents)
@@ -103,7 +107,7 @@ def word_detokenize(segments: Union[List[List[str]], List[str]], output: str = "
             for j in i:
                 _temp += j
             _text.append(_temp)
-        return ' '.join(_text)
+        return " ".join(_text)
 
 
 def word_tokenize(
@@ -257,6 +261,7 @@ def word_tokenize(
         segments = segment(text)
     elif engine == "nlpo3":
         from pythainlp.tokenize.nlpo3 import segment
+
         if isinstance(custom_dict, str):
             segments = segment(text, custom_dict=custom_dict)
         elif not isinstance(custom_dict, str) and custom_dict is not None:
@@ -273,6 +278,8 @@ def word_tokenize(
             f"""Tokenizer \"{engine}\" not found.
             It might be a typo; if not, please consult our document."""
         )
+
+    segments = postprocess_word_tokenize(segments)
 
     if not keep_whitespace:
         segments = [token.strip(" ") for token in segments if token.strip(" ")]
@@ -364,7 +371,10 @@ def sent_tokenize(
 
         segments = segment(text)
     elif engine == "thaisum":
-        from pythainlp.tokenize.thaisumcut import ThaiSentenceSegmentor as segmentor
+        from pythainlp.tokenize.thaisumcut import (
+            ThaiSentenceSegmentor as segmentor,
+        )
+
         segment = segmentor()
         segments = segment.split_into_sentences(text)
     else:
@@ -584,7 +594,8 @@ class Tokenizer:
             raise NotImplementedError(
                 """
                 The Tokenizer class is not support %s for custom tokenizer
-                """ % self.__engine
+                """
+                % self.__engine
             )
         self.__keep_whitespace = keep_whitespace
 

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -13,7 +13,11 @@ from pythainlp.tokenize import (
     DEFAULT_WORD_DICT_TRIE,
     DEFAULT_WORD_TOKENIZE_ENGINE,
 )
-from pythainlp.tokenize._utils import apply_postprocessors, fix_numeric_data_format, strip_whitespace
+from pythainlp.tokenize._utils import (
+    apply_postprocessors,
+    fix_numeric_data_format,
+    strip_whitespace,
+)
 from pythainlp.util.trie import Trie, dict_trie
 
 
@@ -115,7 +119,7 @@ def word_tokenize(
     custom_dict: Trie = None,
     engine: str = DEFAULT_WORD_TOKENIZE_ENGINE,
     keep_whitespace: bool = True,
-    join_broken_numeric_format: bool = True
+    join_broken_numeric_format: bool = True,
 ) -> List[str]:
     """
     Word tokenizer.
@@ -296,7 +300,7 @@ def word_tokenize(
     postprocessors = []
     if join_broken_numeric_format:
         postprocessors.append(fix_numeric_data_format)
-    
+
     if not keep_whitespace:
         postprocessors.append(strip_whitespace)
 
@@ -495,9 +499,7 @@ def subword_tokenize(
         words = word_tokenize(text)
         for word in words:
             segments.extend(
-                word_tokenize(
-                    text=word, custom_dict=DEFAULT_SYLLABLE_DICT_TRIE
-                )
+                word_tokenize(text=word, custom_dict=DEFAULT_SYLLABLE_DICT_TRIE)
             )
     elif engine == "ssg":
         from pythainlp.tokenize.ssg import segment
@@ -590,7 +592,7 @@ class Tokenizer:
         custom_dict: Union[Trie, Iterable[str], str] = None,
         engine: str = "newmm",
         keep_whitespace: bool = True,
-        join_broken_numeric_format: bool = True
+        join_broken_numeric_format: bool = True,
     ):
         """
         Initialize tokenizer object.
@@ -632,7 +634,7 @@ class Tokenizer:
             custom_dict=self.__trie_dict,
             engine=self.__engine,
             keep_whitespace=self.__keep_whitespace,
-            join_broken_numeric_format=self.__join_broken_numeric_format
+            join_broken_numeric_format=self.__join_broken_numeric_format,
         )
 
     def set_tokenize_engine(self, engine: str) -> None:

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -730,14 +730,14 @@ class TestTokenizePackage(unittest.TestCase):
             self.assertIn("2.5:1", tokens)
             self.assertIn("5:2", tokens)
 
-        # try turning off `join_broken_numeric_format`
+        # try turning off `join_broken_num`
         engine = "attacut"
         self.assertNotIn(
             "127.0.0.1",
             word_tokenize(
                 "ไอพีของคุณคือ 127.0.0.1 ครับ",
                 engine=engine,
-                join_broken_numeric_format=False,
+                join_broken_num=False,
             ),
         )
         self.assertNotIn(
@@ -745,6 +745,6 @@ class TestTokenizePackage(unittest.TestCase):
             word_tokenize(
                 "รางวัลมูลค่า 1,234,567.89 บาท",
                 engine=engine,
-                join_broken_numeric_format=False,
+                join_broken_num=False,
             ),
         )

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -235,8 +235,7 @@ class TestTokenizePackage(unittest.TestCase):
             + " จึงใคร่ขออภัยในความบกพร่องทั้งปวงมา ณ ที่นี้"
         )
         sent_3_toks = [
-            "(1) บทความนี้ผู้เขียนสังเคราะห์ขึ้นมา"
-            + "จากผลงานวิจัยที่เคยทำมาในอดีต ",
+            "(1) บทความนี้ผู้เขียนสังเคราะห์ขึ้นมา" + "จากผลงานวิจัยที่เคยทำมาในอดีต ",
             "มิได้ทำการศึกษาค้นคว้าใหม่อย่างกว้างขวางแต่อย่างใด ",
             "จึงใคร่ขออภัยในความบกพร่องทั้งปวงมา ณ ที่นี้",
         ]
@@ -322,20 +321,12 @@ class TestTokenizePackage(unittest.TestCase):
     def test_subword_tokenize(self):
         self.assertEqual(subword_tokenize(None), [])
         self.assertEqual(subword_tokenize(""), [])
-        self.assertIsInstance(
-            subword_tokenize("สวัสดีดาวอังคาร", engine="tcc"), list
-        )
-        self.assertFalse(
-            "า" in subword_tokenize("สวัสดีดาวอังคาร", engine="tcc")
-        )
+        self.assertIsInstance(subword_tokenize("สวัสดีดาวอังคาร", engine="tcc"), list)
+        self.assertFalse("า" in subword_tokenize("สวัสดีดาวอังคาร", engine="tcc"))
         self.assertEqual(subword_tokenize(None, engine="etcc"), [])
         self.assertEqual(subword_tokenize("", engine="etcc"), [])
-        self.assertIsInstance(
-            subword_tokenize("สวัสดิีดาวอังคาร", engine="etcc"), list
-        )
-        self.assertFalse(
-            "า" in subword_tokenize("สวัสดีดาวอังคาร", engine="etcc")
-        )
+        self.assertIsInstance(subword_tokenize("สวัสดิีดาวอังคาร", engine="etcc"), list)
+        self.assertFalse("า" in subword_tokenize("สวัสดีดาวอังคาร", engine="etcc"))
         self.assertIsInstance(subword_tokenize("โควิด19", engine="etcc"), list)
         self.assertEqual(subword_tokenize(None, engine="wangchanberta"), [])
         self.assertEqual(subword_tokenize("", engine="wangchanberta"), [])
@@ -345,9 +336,7 @@ class TestTokenizePackage(unittest.TestCase):
         self.assertFalse(
             "า" in subword_tokenize("สวัสดีดาวอังคาร", engine="wangchanberta")
         )
-        self.assertIsInstance(
-            subword_tokenize("โควิด19", engine="wangchanberta"), list
-        )
+        self.assertIsInstance(subword_tokenize("โควิด19", engine="wangchanberta"), list)
         self.assertFalse(
             " " in subword_tokenize("พันธมิตร ชา นม", keep_whitespace=False)
         )
@@ -355,30 +344,20 @@ class TestTokenizePackage(unittest.TestCase):
             subword_tokenize("สวัสดีชาวโลก", engine="dict"),
             ["สวัส", "ดี", "ชาว", "โลก"],
         )
-        self.assertFalse(
-            "า" in subword_tokenize("สวัสดีชาวโลก", engine="dict")
-        )
+        self.assertFalse("า" in subword_tokenize("สวัสดีชาวโลก", engine="dict"))
         self.assertEqual(subword_tokenize(None, engine="ssg"), [])
         self.assertEqual(
             subword_tokenize("แมวกินปลา", engine="ssg"), ["แมว", "กิน", "ปลา"]
         )
-        self.assertTrue(
-            "ดาว" in subword_tokenize("สวัสดีดาวอังคาร", engine="ssg")
-        )
-        self.assertFalse(
-            "า" in subword_tokenize("สวัสดีดาวอังคาร", engine="ssg")
-        )
+        self.assertTrue("ดาว" in subword_tokenize("สวัสดีดาวอังคาร", engine="ssg"))
+        self.assertFalse("า" in subword_tokenize("สวัสดีดาวอังคาร", engine="ssg"))
         self.assertFalse(
             " " in subword_tokenize("พันธมิตร ชา นม", keep_whitespace=False)
         )
         self.assertEqual(subword_tokenize(None, engine="tltk"), [])
         self.assertEqual(subword_tokenize("", engine="tltk"), [])
-        self.assertIsInstance(
-            subword_tokenize("สวัสดิีดาวอังคาร", engine="tltk"), list
-        )
-        self.assertFalse(
-            "า" in subword_tokenize("สวัสดีดาวอังคาร", engine="tltk")
-        )
+        self.assertIsInstance(subword_tokenize("สวัสดิีดาวอังคาร", engine="tltk"), list)
+        self.assertFalse("า" in subword_tokenize("สวัสดีดาวอังคาร", engine="tltk"))
         self.assertIsInstance(subword_tokenize("โควิด19", engine="tltk"), list)
         with self.assertRaises(ValueError):
             subword_tokenize("นกแก้ว", engine="XX")  # engine does not exist
@@ -404,9 +383,7 @@ class TestTokenizePackage(unittest.TestCase):
         with self.assertRaises(ValueError):
             word_tokenize("หมอนทอง", engine="XX")  # engine does not exist
 
-        self.assertTrue(
-            "ไฟ" in word_tokenize("รถไฟฟ้า", custom_dict=dict_trie(["ไฟ"]))
-        )
+        self.assertTrue("ไฟ" in word_tokenize("รถไฟฟ้า", custom_dict=dict_trie(["ไฟ"])))
 
     def test_attacut(self):
         self.assertEqual(attacut.segment(None), [])
@@ -416,15 +393,11 @@ class TestTokenizePackage(unittest.TestCase):
             ["ฉัน", "รัก", "ภาษา", "ไทย", "เพราะ", "ฉัน", "เป็น", "คน", "ไทย"],
         )
         self.assertEqual(
-            attacut.segment(
-                "ฉันรักภาษาไทยเพราะฉันเป็นคนไทย", model="attacut-sc"
-            ),
+            attacut.segment("ฉันรักภาษาไทยเพราะฉันเป็นคนไทย", model="attacut-sc"),
             ["ฉัน", "รัก", "ภาษา", "ไทย", "เพราะ", "ฉัน", "เป็น", "คน", "ไทย"],
         )
         self.assertIsNotNone(
-            attacut.segment(
-                "ฉันรักภาษาไทยเพราะฉันเป็นคนไทย", model="attacut-c"
-            )
+            attacut.segment("ฉันรักภาษาไทยเพราะฉันเป็นคนไทย", model="attacut-c")
         )
 
     def test_deepcut(self):
@@ -434,9 +407,7 @@ class TestTokenizePackage(unittest.TestCase):
         self.assertIsNotNone(deepcut.segment("ทดสอบ", ["ทด", "สอบ"]))
         self.assertIsNotNone(word_tokenize("ทดสอบ", engine="deepcut"))
         self.assertIsNotNone(
-            word_tokenize(
-                "ทดสอบ", engine="deepcut", custom_dict=DEFAULT_WORD_DICT_TRIE
-            )
+            word_tokenize("ทดสอบ", engine="deepcut", custom_dict=DEFAULT_WORD_DICT_TRIE)
         )
 
     def test_etcc(self):
@@ -468,18 +439,7 @@ class TestTokenizePackage(unittest.TestCase):
         self.assertEqual(tltk.segment(""), [])
         self.assertEqual(
             tltk.syllable_tokenize("ฉันรักภาษาไทยเพราะฉันเป็นคนไทย"),
-            [
-                "ฉัน",
-                "รัก",
-                "ภา",
-                "ษา",
-                "ไทย",
-                "เพราะ",
-                "ฉัน",
-                "เป็น",
-                "คน",
-                "ไทย",
-            ],
+            ["ฉัน", "รัก", "ภา", "ษา", "ไทย", "เพราะ", "ฉัน", "เป็น", "คน", "ไทย"],
         )
         self.assertEqual(tltk.syllable_tokenize(None), [])
         self.assertEqual(tltk.syllable_tokenize(""), [])
@@ -487,9 +447,7 @@ class TestTokenizePackage(unittest.TestCase):
     def test_longest(self):
         self.assertEqual(longest.segment(None), [])
         self.assertEqual(longest.segment(""), [])
-        self.assertIsInstance(
-            longest.segment("กรุงเทพฯมากๆเพราโพาง BKKฯ"), list
-        )
+        self.assertIsInstance(longest.segment("กรุงเทพฯมากๆเพราโพาง BKKฯ"), list)
         self.assertEqual(
             word_tokenize("ฉันรักภาษาไทยเพราะฉันเป็นคนไทย", engine="longest"),
             ["ฉัน", "รัก", "ภาษาไทย", "เพราะ", "ฉัน", "เป็น", "คนไทย"],
@@ -537,9 +495,7 @@ class TestTokenizePackage(unittest.TestCase):
 
         self.assertIsNotNone(multi_cut.mmcut("ทดสอบ"))
 
-        self.assertIsNotNone(
-            multi_cut.find_all_segment("รถไฟฟ้ากรุงเทพมหานครBTS")
-        )
+        self.assertIsNotNone(multi_cut.find_all_segment("รถไฟฟ้ากรุงเทพมหานครBTS"))
         self.assertEqual(multi_cut.find_all_segment(None), [])
 
     def test_newmm(self):
@@ -581,13 +537,9 @@ class TestTokenizePackage(unittest.TestCase):
             word_tokenize("จุ๋มง่วงนอนยัง", engine="newmm"),
             ["จุ๋ม", "ง่วงนอน", "ยัง"],
         )
+        self.assertEqual(word_tokenize("จุ๋มง่วง", engine="newmm"), ["จุ๋ม", "ง่วง"])
         self.assertEqual(
-            word_tokenize("จุ๋มง่วง", engine="newmm"), ["จุ๋ม", "ง่วง"]
-        )
-        self.assertEqual(
-            word_tokenize(
-                "จุ๋ม   ง่วง", engine="newmm", keep_whitespace=False
-            ),
+            word_tokenize("จุ๋ม   ง่วง", engine="newmm", keep_whitespace=False),
             ["จุ๋ม", "ง่วง"],
         )
         self.assertFalse(
@@ -599,23 +551,13 @@ class TestTokenizePackage(unittest.TestCase):
         )
 
     def test_newmm_longtext(self):
-        self.assertIsInstance(
-            word_tokenize(self.long_text, engine="newmm"), list
-        )
-        self.assertIsInstance(
-            word_tokenize(self.long_text, engine="newmm-safe"), list
-        )
+        self.assertIsInstance(word_tokenize(self.long_text, engine="newmm"), list)
+        self.assertIsInstance(word_tokenize(self.long_text, engine="newmm-safe"), list)
 
     def test_newmm_dangertext(self):
-        self.assertIsInstance(
-            word_tokenize(self.danger_text1, engine="newmm"), list
-        )
-        self.assertIsInstance(
-            word_tokenize(self.danger_text2, engine="newmm"), list
-        )
-        self.assertIsInstance(
-            word_tokenize(self.danger_text3, engine="newmm"), list
-        )
+        self.assertIsInstance(word_tokenize(self.danger_text1, engine="newmm"), list)
+        self.assertIsInstance(word_tokenize(self.danger_text2, engine="newmm"), list)
+        self.assertIsInstance(word_tokenize(self.danger_text3, engine="newmm"), list)
         self.assertIsInstance(
             word_tokenize(self.danger_text1, engine="newmm-safe"), list
         )
@@ -642,16 +584,12 @@ class TestTokenizePackage(unittest.TestCase):
     def test_ssg(self):
         self.assertEqual(ssg.segment(None), [])
         self.assertEqual(ssg.segment(""), [])
-        self.assertTrue(
-            "ดาว" in subword_tokenize("สวัสดีดาวอังคาร", engine="ssg")
-        )
+        self.assertTrue("ดาว" in subword_tokenize("สวัสดีดาวอังคาร", engine="ssg"))
 
     def test_tcc(self):
         self.assertEqual(tcc.segment(None), [])
         self.assertEqual(tcc.segment(""), [])
-        self.assertEqual(
-            tcc.segment("ประเทศไทย"), ["ป", "ระ", "เท", "ศ", "ไท", "ย"]
-        )
+        self.assertEqual(tcc.segment("ประเทศไทย"), ["ป", "ระ", "เท", "ศ", "ไท", "ย"])
         self.assertEqual(list(tcc.tcc("")), [])
         self.assertEqual(tcc.tcc_pos(""), set())
 
@@ -684,20 +622,14 @@ class TestTokenizePackage(unittest.TestCase):
             [["ผม", "เลี้ยง", " ", "5", " ", "ตัว"]],
         )
         self.assertEqual(
-            word_detokenize(
-                ["ผม", "เลี้ยง", "5", "10", "ตัว", "ๆ", "คน", "ดี"]
-            ),
+            word_detokenize(["ผม", "เลี้ยง", "5", "10", "ตัว", "ๆ", "คน", "ดี"]),
             "ผมเลี้ยง 5 10 ตัว ๆ คนดี",
         )
         self.assertEqual(
-            word_detokenize(
-                ["ผม", "เลี้ยง", "5", "ตัว", " ", "ๆ", "คน", "ดี"]
-            ),
+            word_detokenize(["ผม", "เลี้ยง", "5", "ตัว", " ", "ๆ", "คน", "ดี"]),
             "ผมเลี้ยง 5 ตัว ๆ คนดี",
         )
-        self.assertTrue(
-            isinstance(word_detokenize(["ผม", "เลี้ยง", "5", "ตัว"]), str)
-        )
+        self.assertTrue(isinstance(word_detokenize(["ผม", "เลี้ยง", "5", "ตัว"]), str))
         self.assertEqual(
             word_detokenize(["ม่ายย", " ", "ผม", "เลี้ยง", "5", "ตัว"]),
             "ม่ายย ผมเลี้ยง 5 ตัว",
@@ -712,9 +644,7 @@ class TestTokenizePackage(unittest.TestCase):
                 word_tokenize("ไอพีของคุณคือ 127.0.0.1 ครับ", engine=engine),
             )
 
-            tokens = word_tokenize(
-                "เวลา 12:12pm มีโปรโมชั่น 11.11", engine=engine
-            )
+            tokens = word_tokenize("เวลา 12:12pm มีโปรโมชั่น 11.11", engine=engine)
             self.assertTrue(
                 any([value in tokens for value in ["12:12pm", "12:12"]]),
                 msg=f"{engine}: {tokens}",
@@ -729,3 +659,22 @@ class TestTokenizePackage(unittest.TestCase):
             tokens = word_tokenize("อัตราส่วน 2.5:1 คือ 5:2", engine=engine)
             self.assertIn("2.5:1", tokens)
             self.assertIn("5:2", tokens)
+
+        # try turning off `join_broken_numeric_format`
+        engine = "attacut"
+        self.assertNotIn(
+            "127.0.0.1",
+            word_tokenize(
+                "ไอพีของคุณคือ 127.0.0.1 ครับ",
+                engine=engine,
+                join_broken_numeric_format=False,
+            ),
+        )
+        self.assertNotIn(
+            "1,234,567.89",
+            word_tokenize(
+                "รางวัลมูลค่า 1,234,567.89 บาท",
+                engine=engine,
+                join_broken_numeric_format=False,
+            ),
+        )

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -235,7 +235,8 @@ class TestTokenizePackage(unittest.TestCase):
             + " จึงใคร่ขออภัยในความบกพร่องทั้งปวงมา ณ ที่นี้"
         )
         sent_3_toks = [
-            "(1) บทความนี้ผู้เขียนสังเคราะห์ขึ้นมา" + "จากผลงานวิจัยที่เคยทำมาในอดีต ",
+            "(1) บทความนี้ผู้เขียนสังเคราะห์ขึ้นมา"
+            + "จากผลงานวิจัยที่เคยทำมาในอดีต ",
             "มิได้ทำการศึกษาค้นคว้าใหม่อย่างกว้างขวางแต่อย่างใด ",
             "จึงใคร่ขออภัยในความบกพร่องทั้งปวงมา ณ ที่นี้",
         ]
@@ -321,12 +322,20 @@ class TestTokenizePackage(unittest.TestCase):
     def test_subword_tokenize(self):
         self.assertEqual(subword_tokenize(None), [])
         self.assertEqual(subword_tokenize(""), [])
-        self.assertIsInstance(subword_tokenize("สวัสดีดาวอังคาร", engine="tcc"), list)
-        self.assertFalse("า" in subword_tokenize("สวัสดีดาวอังคาร", engine="tcc"))
+        self.assertIsInstance(
+            subword_tokenize("สวัสดีดาวอังคาร", engine="tcc"), list
+        )
+        self.assertFalse(
+            "า" in subword_tokenize("สวัสดีดาวอังคาร", engine="tcc")
+        )
         self.assertEqual(subword_tokenize(None, engine="etcc"), [])
         self.assertEqual(subword_tokenize("", engine="etcc"), [])
-        self.assertIsInstance(subword_tokenize("สวัสดิีดาวอังคาร", engine="etcc"), list)
-        self.assertFalse("า" in subword_tokenize("สวัสดีดาวอังคาร", engine="etcc"))
+        self.assertIsInstance(
+            subword_tokenize("สวัสดิีดาวอังคาร", engine="etcc"), list
+        )
+        self.assertFalse(
+            "า" in subword_tokenize("สวัสดีดาวอังคาร", engine="etcc")
+        )
         self.assertIsInstance(subword_tokenize("โควิด19", engine="etcc"), list)
         self.assertEqual(subword_tokenize(None, engine="wangchanberta"), [])
         self.assertEqual(subword_tokenize("", engine="wangchanberta"), [])
@@ -336,7 +345,9 @@ class TestTokenizePackage(unittest.TestCase):
         self.assertFalse(
             "า" in subword_tokenize("สวัสดีดาวอังคาร", engine="wangchanberta")
         )
-        self.assertIsInstance(subword_tokenize("โควิด19", engine="wangchanberta"), list)
+        self.assertIsInstance(
+            subword_tokenize("โควิด19", engine="wangchanberta"), list
+        )
         self.assertFalse(
             " " in subword_tokenize("พันธมิตร ชา นม", keep_whitespace=False)
         )
@@ -344,20 +355,30 @@ class TestTokenizePackage(unittest.TestCase):
             subword_tokenize("สวัสดีชาวโลก", engine="dict"),
             ["สวัส", "ดี", "ชาว", "โลก"],
         )
-        self.assertFalse("า" in subword_tokenize("สวัสดีชาวโลก", engine="dict"))
+        self.assertFalse(
+            "า" in subword_tokenize("สวัสดีชาวโลก", engine="dict")
+        )
         self.assertEqual(subword_tokenize(None, engine="ssg"), [])
         self.assertEqual(
             subword_tokenize("แมวกินปลา", engine="ssg"), ["แมว", "กิน", "ปลา"]
         )
-        self.assertTrue("ดาว" in subword_tokenize("สวัสดีดาวอังคาร", engine="ssg"))
-        self.assertFalse("า" in subword_tokenize("สวัสดีดาวอังคาร", engine="ssg"))
+        self.assertTrue(
+            "ดาว" in subword_tokenize("สวัสดีดาวอังคาร", engine="ssg")
+        )
+        self.assertFalse(
+            "า" in subword_tokenize("สวัสดีดาวอังคาร", engine="ssg")
+        )
         self.assertFalse(
             " " in subword_tokenize("พันธมิตร ชา นม", keep_whitespace=False)
         )
         self.assertEqual(subword_tokenize(None, engine="tltk"), [])
         self.assertEqual(subword_tokenize("", engine="tltk"), [])
-        self.assertIsInstance(subword_tokenize("สวัสดิีดาวอังคาร", engine="tltk"), list)
-        self.assertFalse("า" in subword_tokenize("สวัสดีดาวอังคาร", engine="tltk"))
+        self.assertIsInstance(
+            subword_tokenize("สวัสดิีดาวอังคาร", engine="tltk"), list
+        )
+        self.assertFalse(
+            "า" in subword_tokenize("สวัสดีดาวอังคาร", engine="tltk")
+        )
         self.assertIsInstance(subword_tokenize("โควิด19", engine="tltk"), list)
         with self.assertRaises(ValueError):
             subword_tokenize("นกแก้ว", engine="XX")  # engine does not exist
@@ -383,7 +404,9 @@ class TestTokenizePackage(unittest.TestCase):
         with self.assertRaises(ValueError):
             word_tokenize("หมอนทอง", engine="XX")  # engine does not exist
 
-        self.assertTrue("ไฟ" in word_tokenize("รถไฟฟ้า", custom_dict=dict_trie(["ไฟ"])))
+        self.assertTrue(
+            "ไฟ" in word_tokenize("รถไฟฟ้า", custom_dict=dict_trie(["ไฟ"]))
+        )
 
     def test_attacut(self):
         self.assertEqual(attacut.segment(None), [])
@@ -393,11 +416,15 @@ class TestTokenizePackage(unittest.TestCase):
             ["ฉัน", "รัก", "ภาษา", "ไทย", "เพราะ", "ฉัน", "เป็น", "คน", "ไทย"],
         )
         self.assertEqual(
-            attacut.segment("ฉันรักภาษาไทยเพราะฉันเป็นคนไทย", model="attacut-sc"),
+            attacut.segment(
+                "ฉันรักภาษาไทยเพราะฉันเป็นคนไทย", model="attacut-sc"
+            ),
             ["ฉัน", "รัก", "ภาษา", "ไทย", "เพราะ", "ฉัน", "เป็น", "คน", "ไทย"],
         )
         self.assertIsNotNone(
-            attacut.segment("ฉันรักภาษาไทยเพราะฉันเป็นคนไทย", model="attacut-c")
+            attacut.segment(
+                "ฉันรักภาษาไทยเพราะฉันเป็นคนไทย", model="attacut-c"
+            )
         )
 
     def test_deepcut(self):
@@ -407,7 +434,9 @@ class TestTokenizePackage(unittest.TestCase):
         self.assertIsNotNone(deepcut.segment("ทดสอบ", ["ทด", "สอบ"]))
         self.assertIsNotNone(word_tokenize("ทดสอบ", engine="deepcut"))
         self.assertIsNotNone(
-            word_tokenize("ทดสอบ", engine="deepcut", custom_dict=DEFAULT_WORD_DICT_TRIE)
+            word_tokenize(
+                "ทดสอบ", engine="deepcut", custom_dict=DEFAULT_WORD_DICT_TRIE
+            )
         )
 
     def test_etcc(self):
@@ -439,7 +468,18 @@ class TestTokenizePackage(unittest.TestCase):
         self.assertEqual(tltk.segment(""), [])
         self.assertEqual(
             tltk.syllable_tokenize("ฉันรักภาษาไทยเพราะฉันเป็นคนไทย"),
-            ["ฉัน", "รัก", "ภา", "ษา", "ไทย", "เพราะ", "ฉัน", "เป็น", "คน", "ไทย"],
+            [
+                "ฉัน",
+                "รัก",
+                "ภา",
+                "ษา",
+                "ไทย",
+                "เพราะ",
+                "ฉัน",
+                "เป็น",
+                "คน",
+                "ไทย",
+            ],
         )
         self.assertEqual(tltk.syllable_tokenize(None), [])
         self.assertEqual(tltk.syllable_tokenize(""), [])
@@ -447,7 +487,9 @@ class TestTokenizePackage(unittest.TestCase):
     def test_longest(self):
         self.assertEqual(longest.segment(None), [])
         self.assertEqual(longest.segment(""), [])
-        self.assertIsInstance(longest.segment("กรุงเทพฯมากๆเพราโพาง BKKฯ"), list)
+        self.assertIsInstance(
+            longest.segment("กรุงเทพฯมากๆเพราโพาง BKKฯ"), list
+        )
         self.assertEqual(
             word_tokenize("ฉันรักภาษาไทยเพราะฉันเป็นคนไทย", engine="longest"),
             ["ฉัน", "รัก", "ภาษาไทย", "เพราะ", "ฉัน", "เป็น", "คนไทย"],
@@ -495,7 +537,9 @@ class TestTokenizePackage(unittest.TestCase):
 
         self.assertIsNotNone(multi_cut.mmcut("ทดสอบ"))
 
-        self.assertIsNotNone(multi_cut.find_all_segment("รถไฟฟ้ากรุงเทพมหานครBTS"))
+        self.assertIsNotNone(
+            multi_cut.find_all_segment("รถไฟฟ้ากรุงเทพมหานครBTS")
+        )
         self.assertEqual(multi_cut.find_all_segment(None), [])
 
     def test_newmm(self):
@@ -537,9 +581,13 @@ class TestTokenizePackage(unittest.TestCase):
             word_tokenize("จุ๋มง่วงนอนยัง", engine="newmm"),
             ["จุ๋ม", "ง่วงนอน", "ยัง"],
         )
-        self.assertEqual(word_tokenize("จุ๋มง่วง", engine="newmm"), ["จุ๋ม", "ง่วง"])
         self.assertEqual(
-            word_tokenize("จุ๋ม   ง่วง", engine="newmm", keep_whitespace=False),
+            word_tokenize("จุ๋มง่วง", engine="newmm"), ["จุ๋ม", "ง่วง"]
+        )
+        self.assertEqual(
+            word_tokenize(
+                "จุ๋ม   ง่วง", engine="newmm", keep_whitespace=False
+            ),
             ["จุ๋ม", "ง่วง"],
         )
         self.assertFalse(
@@ -551,13 +599,23 @@ class TestTokenizePackage(unittest.TestCase):
         )
 
     def test_newmm_longtext(self):
-        self.assertIsInstance(word_tokenize(self.long_text, engine="newmm"), list)
-        self.assertIsInstance(word_tokenize(self.long_text, engine="newmm-safe"), list)
+        self.assertIsInstance(
+            word_tokenize(self.long_text, engine="newmm"), list
+        )
+        self.assertIsInstance(
+            word_tokenize(self.long_text, engine="newmm-safe"), list
+        )
 
     def test_newmm_dangertext(self):
-        self.assertIsInstance(word_tokenize(self.danger_text1, engine="newmm"), list)
-        self.assertIsInstance(word_tokenize(self.danger_text2, engine="newmm"), list)
-        self.assertIsInstance(word_tokenize(self.danger_text3, engine="newmm"), list)
+        self.assertIsInstance(
+            word_tokenize(self.danger_text1, engine="newmm"), list
+        )
+        self.assertIsInstance(
+            word_tokenize(self.danger_text2, engine="newmm"), list
+        )
+        self.assertIsInstance(
+            word_tokenize(self.danger_text3, engine="newmm"), list
+        )
         self.assertIsInstance(
             word_tokenize(self.danger_text1, engine="newmm-safe"), list
         )
@@ -584,12 +642,16 @@ class TestTokenizePackage(unittest.TestCase):
     def test_ssg(self):
         self.assertEqual(ssg.segment(None), [])
         self.assertEqual(ssg.segment(""), [])
-        self.assertTrue("ดาว" in subword_tokenize("สวัสดีดาวอังคาร", engine="ssg"))
+        self.assertTrue(
+            "ดาว" in subword_tokenize("สวัสดีดาวอังคาร", engine="ssg")
+        )
 
     def test_tcc(self):
         self.assertEqual(tcc.segment(None), [])
         self.assertEqual(tcc.segment(""), [])
-        self.assertEqual(tcc.segment("ประเทศไทย"), ["ป", "ระ", "เท", "ศ", "ไท", "ย"])
+        self.assertEqual(
+            tcc.segment("ประเทศไทย"), ["ป", "ระ", "เท", "ศ", "ไท", "ย"]
+        )
         self.assertEqual(list(tcc.tcc("")), [])
         self.assertEqual(tcc.tcc_pos(""), set())
 
@@ -622,14 +684,20 @@ class TestTokenizePackage(unittest.TestCase):
             [["ผม", "เลี้ยง", " ", "5", " ", "ตัว"]],
         )
         self.assertEqual(
-            word_detokenize(["ผม", "เลี้ยง", "5", "10", "ตัว", "ๆ", "คน", "ดี"]),
+            word_detokenize(
+                ["ผม", "เลี้ยง", "5", "10", "ตัว", "ๆ", "คน", "ดี"]
+            ),
             "ผมเลี้ยง 5 10 ตัว ๆ คนดี",
         )
         self.assertEqual(
-            word_detokenize(["ผม", "เลี้ยง", "5", "ตัว", " ", "ๆ", "คน", "ดี"]),
+            word_detokenize(
+                ["ผม", "เลี้ยง", "5", "ตัว", " ", "ๆ", "คน", "ดี"]
+            ),
             "ผมเลี้ยง 5 ตัว ๆ คนดี",
         )
-        self.assertTrue(isinstance(word_detokenize(["ผม", "เลี้ยง", "5", "ตัว"]), str))
+        self.assertTrue(
+            isinstance(word_detokenize(["ผม", "เลี้ยง", "5", "ตัว"]), str)
+        )
         self.assertEqual(
             word_detokenize(["ม่ายย", " ", "ผม", "เลี้ยง", "5", "ตัว"]),
             "ม่ายย ผมเลี้ยง 5 ตัว",
@@ -644,7 +712,9 @@ class TestTokenizePackage(unittest.TestCase):
                 word_tokenize("ไอพีของคุณคือ 127.0.0.1 ครับ", engine=engine),
             )
 
-            tokens = word_tokenize("เวลา 12:12pm มีโปรโมชั่น 11.11", engine=engine)
+            tokens = word_tokenize(
+                "เวลา 12:12pm มีโปรโมชั่น 11.11", engine=engine
+            )
             self.assertTrue(
                 any([value in tokens for value in ["12:12pm", "12:12"]]),
                 msg=f"{engine}: {tokens}",

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -242,48 +242,78 @@ class TestTokenizePackage(unittest.TestCase):
         ]
 
         self.assertEqual(
-            sent_tokenize(sent_1, engine="crfcut"), sent_1_toks,
+            sent_tokenize(sent_1, engine="crfcut"),
+            sent_1_toks,
         )
         self.assertEqual(
-            sent_tokenize(sent_2, engine="crfcut"), sent_2_toks,
+            sent_tokenize(sent_2, engine="crfcut"),
+            sent_2_toks,
         )
         self.assertEqual(
-            sent_tokenize(sent_3, engine="crfcut"), sent_3_toks,
+            sent_tokenize(sent_3, engine="crfcut"),
+            sent_3_toks,
         )
         self.assertEqual(
-            sent_tokenize(sent_1), sent_1_toks,
+            sent_tokenize(sent_1),
+            sent_1_toks,
         )
         self.assertEqual(
-            sent_tokenize(sent_2), sent_2_toks,
+            sent_tokenize(sent_2),
+            sent_2_toks,
         )
         self.assertEqual(
-            sent_tokenize(sent_3), sent_3_toks,
+            sent_tokenize(sent_3),
+            sent_3_toks,
         )
         self.assertIsNotNone(
-            sent_tokenize(sent_1, keep_whitespace=False, engine="whitespace",),
+            sent_tokenize(
+                sent_1,
+                keep_whitespace=False,
+                engine="whitespace",
+            ),
         )
         self.assertIsNotNone(
-            sent_tokenize(sent_1, engine="tltk",),
+            sent_tokenize(
+                sent_1,
+                engine="tltk",
+            ),
         )
         self.assertIsNotNone(
-            sent_tokenize(sent_2, engine="tltk",),
+            sent_tokenize(
+                sent_2,
+                engine="tltk",
+            ),
         )
         self.assertIsNotNone(
-            sent_tokenize(sent_3, engine="tltk",),
+            sent_tokenize(
+                sent_3,
+                engine="tltk",
+            ),
         )
         self.assertIsNotNone(
-            sent_tokenize(sent_1, engine="thaisum",),
+            sent_tokenize(
+                sent_1,
+                engine="thaisum",
+            ),
         )
         self.assertIsNotNone(
-            sent_tokenize(sent_2, engine="thaisum",),
+            sent_tokenize(
+                sent_2,
+                engine="thaisum",
+            ),
         )
         self.assertIsNotNone(
-            sent_tokenize(sent_3, engine="thaisum",),
+            sent_tokenize(
+                sent_3,
+                engine="thaisum",
+            ),
         )
         self.assertFalse(
             " "
             in sent_tokenize(
-                sent_1, engine="whitespace", keep_whitespace=False,
+                sent_1,
+                engine="whitespace",
+                keep_whitespace=False,
             )
         )
         with self.assertRaises(ValueError):
@@ -322,9 +352,12 @@ class TestTokenizePackage(unittest.TestCase):
             " " in subword_tokenize("พันธมิตร ชา นม", keep_whitespace=False)
         )
         self.assertEqual(
-            subword_tokenize("สวัสดีชาวโลก", engine="dict"), ["สวัส", "ดี", "ชาว", "โลก"]
+            subword_tokenize("สวัสดีชาวโลก", engine="dict"),
+            ["สวัส", "ดี", "ชาว", "โลก"],
         )
-        self.assertFalse("า" in subword_tokenize("สวัสดีชาวโลก", engine="dict"))
+        self.assertFalse(
+            "า" in subword_tokenize("สวัสดีชาวโลก", engine="dict")
+        )
         self.assertEqual(subword_tokenize(None, engine="ssg"), [])
         self.assertEqual(
             subword_tokenize("แมวกินปลา", engine="ssg"), ["แมว", "กิน", "ปลา"]
@@ -346,9 +379,7 @@ class TestTokenizePackage(unittest.TestCase):
         self.assertFalse(
             "า" in subword_tokenize("สวัสดีดาวอังคาร", engine="tltk")
         )
-        self.assertIsInstance(
-            subword_tokenize("โควิด19", engine="tltk"), list
-        )
+        self.assertIsInstance(subword_tokenize("โควิด19", engine="tltk"), list)
         with self.assertRaises(ValueError):
             subword_tokenize("นกแก้ว", engine="XX")  # engine does not exist
 
@@ -436,20 +467,18 @@ class TestTokenizePackage(unittest.TestCase):
         self.assertEqual(tltk.segment(None), [])
         self.assertEqual(tltk.segment(""), [])
         self.assertEqual(
-            tltk.syllable_tokenize(
-                "ฉันรักภาษาไทยเพราะฉันเป็นคนไทย"
-            ),
+            tltk.syllable_tokenize("ฉันรักภาษาไทยเพราะฉันเป็นคนไทย"),
             [
-                'ฉัน',
-                'รัก',
-                'ภา',
-                'ษา',
-                'ไทย',
-                'เพราะ',
-                'ฉัน',
-                'เป็น',
-                'คน',
-                'ไทย'
+                "ฉัน",
+                "รัก",
+                "ภา",
+                "ษา",
+                "ไทย",
+                "เพราะ",
+                "ฉัน",
+                "เป็น",
+                "คน",
+                "ไทย",
             ],
         )
         self.assertEqual(tltk.syllable_tokenize(None), [])
@@ -471,7 +500,8 @@ class TestTokenizePackage(unittest.TestCase):
             ["ปวด", "เฉียบพลัน"],
         )
         self.assertEqual(
-            longest_tokenizer.word_tokenize("เฉียบพลัน"), ["เฉียบพลัน"],
+            longest_tokenizer.word_tokenize("เฉียบพลัน"),
+            ["เฉียบพลัน"],
         )
 
     def test_mm(self):
@@ -486,15 +516,15 @@ class TestTokenizePackage(unittest.TestCase):
         )
         self.assertEqual(
             word_tokenize("19...", engine="mm"),
-            ['19', '...'],
+            ["19", "..."],
         )
         self.assertEqual(
             word_tokenize("19.", engine="mm"),
-            ['19', '.'],
+            ["19", "."],
         )
         self.assertEqual(
             word_tokenize("19.84", engine="mm"),
-            ['19.84'],
+            ["19.84"],
         )
         self.assertEqual(
             word_tokenize("127.0.0.1", engine="mm"),
@@ -502,7 +532,7 @@ class TestTokenizePackage(unittest.TestCase):
         )
         self.assertEqual(
             word_tokenize("USD1,984.42", engine="mm"),
-            ['USD', '1,984.42'],
+            ["USD", "1,984.42"],
         )
 
         self.assertIsNotNone(multi_cut.mmcut("ทดสอบ"))
@@ -521,15 +551,15 @@ class TestTokenizePackage(unittest.TestCase):
         )
         self.assertEqual(
             word_tokenize("19...", engine="newmm"),
-            ['19', '...'],
+            ["19", "..."],
         )
         self.assertEqual(
             word_tokenize("19.", engine="newmm"),
-            ['19', '.'],
+            ["19", "."],
         )
         self.assertEqual(
             word_tokenize("19.84", engine="newmm"),
-            ['19.84'],
+            ["19.84"],
         )
         self.assertEqual(
             word_tokenize("127.0.0.1", engine="newmm"),
@@ -537,7 +567,7 @@ class TestTokenizePackage(unittest.TestCase):
         )
         self.assertEqual(
             word_tokenize("USD1,984.42", engine="newmm"),
-            ['USD', '1,984.42'],
+            ["USD", "1,984.42"],
         )
         self.assertEqual(
             word_tokenize(
@@ -561,7 +591,11 @@ class TestTokenizePackage(unittest.TestCase):
             ["จุ๋ม", "ง่วง"],
         )
         self.assertFalse(
-            " " in word_tokenize("จุ๋มง่วง", keep_whitespace=False,)
+            " "
+            in word_tokenize(
+                "จุ๋มง่วง",
+                keep_whitespace=False,
+            )
         )
 
     def test_newmm_longtext(self):
@@ -596,13 +630,12 @@ class TestTokenizePackage(unittest.TestCase):
         self.assertEqual(nercut.segment(None), [])
         self.assertEqual(nercut.segment(""), [])
         self.assertIsNotNone(nercut.segment("ทดสอบ"))
-        self.assertEqual(nercut.segment("ทันแน่ๆ"), ['ทัน', 'แน่ๆ'])
-        self.assertEqual(nercut.segment("%1ครั้ง"), ['%', '1', 'ครั้ง'])
-        self.assertEqual(nercut.segment("ทุ๊กกโคนน"), ['ทุ๊กกโคนน'])
-        self.assertEqual(nercut.segment("อือหือ"), ['อือหือ'])
+        self.assertEqual(nercut.segment("ทันแน่ๆ"), ["ทัน", "แน่ๆ"])
+        self.assertEqual(nercut.segment("%1ครั้ง"), ["%", "1", "ครั้ง"])
+        self.assertEqual(nercut.segment("ทุ๊กกโคนน"), ["ทุ๊กกโคนน"])
+        self.assertEqual(nercut.segment("อือหือ"), ["อือหือ"])
         self.assertEqual(
-            nercut.segment("อย่าลืมอัพการ์ดนะจ๊ะ"),
-            ['อย่าลืมอัพการ์ดนะจ๊ะ']
+            nercut.segment("อย่าลืมอัพการ์ดนะจ๊ะ"), ["อย่าลืมอัพการ์ดนะจ๊ะ"]
         )
         self.assertIsNotNone(word_tokenize("ทดสอบ", engine="nercut"))
 
@@ -644,29 +677,55 @@ class TestTokenizePackage(unittest.TestCase):
 
     def test_word_detokenize(self):
         self.assertEqual(
-            word_detokenize(["ผม", "เลี้ยง", "5", "ตัว"]),
-            "ผมเลี้ยง 5 ตัว"
+            word_detokenize(["ผม", "เลี้ยง", "5", "ตัว"]), "ผมเลี้ยง 5 ตัว"
         )
-        self.assertEqual(word_detokenize(
-            ["ผม", "เลี้ยง", " ", "5", "ตัว"], "list"),
-            [["ผม", "เลี้ยง", " ", "5", " ", "ตัว"]]
+        self.assertEqual(
+            word_detokenize(["ผม", "เลี้ยง", " ", "5", "ตัว"], "list"),
+            [["ผม", "เลี้ยง", " ", "5", " ", "ตัว"]],
         )
         self.assertEqual(
             word_detokenize(
                 ["ผม", "เลี้ยง", "5", "10", "ตัว", "ๆ", "คน", "ดี"]
             ),
-            "ผมเลี้ยง 5 10 ตัว ๆ คนดี"
+            "ผมเลี้ยง 5 10 ตัว ๆ คนดี",
         )
         self.assertEqual(
             word_detokenize(
                 ["ผม", "เลี้ยง", "5", "ตัว", " ", "ๆ", "คน", "ดี"]
             ),
-            "ผมเลี้ยง 5 ตัว ๆ คนดี"
+            "ผมเลี้ยง 5 ตัว ๆ คนดี",
         )
         self.assertTrue(
             isinstance(word_detokenize(["ผม", "เลี้ยง", "5", "ตัว"]), str)
         )
         self.assertEqual(
             word_detokenize(["ม่ายย", " ", "ผม", "เลี้ยง", "5", "ตัว"]),
-            "ม่ายย ผมเลี้ยง 5 ตัว"
+            "ม่ายย ผมเลี้ยง 5 ตัว",
         )
+
+    def test_numeric_data_format(self):
+        engines = ["attacut", "deepcut", "newmm", "sefr_cut"]
+
+        for engine in engines:
+            self.assertIn(
+                "127.0.0.1",
+                word_tokenize("ไอพีของคุณคือ 127.0.0.1 ครับ", engine=engine),
+            )
+
+            tokens = word_tokenize(
+                "เวลา 12:12pm มีโปรโมชั่น 11.11", engine=engine
+            )
+            self.assertTrue(
+                any([value in tokens for value in ["12:12pm", "12:12"]]),
+                msg=f"{engine}: {tokens}",
+            )
+            self.assertIn("11.11", tokens)
+
+            self.assertIn(
+                "1,234,567.89",
+                word_tokenize("รางวัลมูลค่า 1,234,567.89 บาท", engine=engine),
+            )
+
+            tokens = word_tokenize("อัตราส่วน 2.5:1 คือ 5:2", engine=engine)
+            self.assertIn("2.5:1", tokens)
+            self.assertIn("5:2", tokens)


### PR DESCRIPTION
### What does this changes

Fix incorrectly word_tokenize-d  numeric data formats such as time, comma-separated numbers, decimal number, and ip address.

### What was wrong

For some tokenizers (esp. neural nets), numbers separated with symbols (. , :) are tokenized into multiple parts. They should be atomic.

**Example**:
```
"12:34pm" -> ["12", ":", "34pm"]
```

### How this fixes it

Postprocess the tokenized tokens with regular expression.
`r"(\d+[\.\,:])+\d+"`: digits followed by either ".,:" once, possibly repeated, and ended with digits.

Fixes #652 

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [O] Passed code styles and structures
- [O] Passed code linting checks and unit test
