### PR TITLE
Feature/integrate transliteration dictionary (#681)

### DIFF
--- a/pythainlp/corpus/th_en_translit.py
+++ b/pythainlp/corpus/th_en_translit.py
@@ -2,8 +2,8 @@
 """
 Thai-English Transliteratation Dictionary v1.4
 
-Wannaphong Phatthiyaphaibun. (2022). 
-wannaphong/thai-english-transliteration-dictionary: v1.4 (v1.4). 
+Wannaphong Phatthiyaphaibun. (2022).
+wannaphong/thai-english-transliteration-dictionary: v1.4 (v1.4).
 Zenodo. https://doi.org/10.5281/zenodo.6716672
 """
 

--- a/pythainlp/corpus/th_en_translit.py
+++ b/pythainlp/corpus/th_en_translit.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""
+Thai-English Transliteratation Dictionary v1.4
+
+Wannaphong Phatthiyaphaibun. (2022). 
+wannaphong/thai-english-transliteration-dictionary: v1.4 (v1.4). 
+Zenodo. https://doi.org/10.5281/zenodo.6716672
+"""
+
+__all__ = [
+    "get_transliteration_dict",
+    "TRANSLITERATE_EN",
+    "TRANSLITERATE_FOLLOW_RTSG",
+]
+
+from collections import defaultdict
+
+from pythainlp.corpus import path_pythainlp_corpus
+
+_FILE_NAME = "th_en_transliteration_v1.4.tsv"
+TRANSLITERATE_EN = "en"
+TRANSLITERATE_FOLLOW_RTSG = "follow_rtsg"
+
+
+def get_transliteration_dict() -> defaultdict:
+    """
+    Get transliteration dictionary for Thai to English.
+
+    The returned dict is defaultdict[str, defaultdict[List[str], List[Optional[bool]]]] format.
+    """
+    path = path_pythainlp_corpus(_FILE_NAME)
+    if not path:
+        raise FileNotFoundError(
+            f"Unable to load transliteration dictionary. "
+            f"{_FILE_NAME} is not found under pythainlp/corpus."
+        )
+
+    # use list, one word can have multiple transliterations.
+    trans_dict = defaultdict(
+        lambda: {TRANSLITERATE_EN: [], TRANSLITERATE_FOLLOW_RTSG: []}
+    )
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            # assume first row contains column names, skipped.
+            for line in f.readlines()[1:]:
+                stripped = line.strip()
+                if stripped:
+                    th, *en_checked = stripped.split("\t")
+                    # replace in-between whitespaces to prevent mismatch results from different tokenizers.
+                    # e.g. "บอยแบนด์"
+                    # route 1: "บอยแบนด์" -> ["บอย", "แบนด์"] -> ["boy", "band"] -> "boyband"
+                    # route 2: "บอยแบนด์" -> [""บอยแบนด์""] -> ["boy band"] -> "boy band"
+                    en_translit = en_checked[0].replace(" ", "")
+                    trans_dict[th][TRANSLITERATE_EN].append(en_translit)
+                    en_follow_rtgs = (
+                        bool(en_checked[1]) if len(en_checked) == 2 else None
+                    )
+                    trans_dict[th][TRANSLITERATE_FOLLOW_RTSG].append(
+                        en_follow_rtgs
+                    )
+
+    except ValueError:
+        raise ValueError(
+            f"Unable to parse {_FILE_NAME}."
+            f"Make sure it is a 3-column tab-separated file with header."
+        )
+    else:
+        return trans_dict
+
+
+TRANSLITERATE_DICT = get_transliteration_dict()

--- a/pythainlp/corpus/th_en_transliteration_v1.4.tsv
+++ b/pythainlp/corpus/th_en_transliteration_v1.4.tsv
@@ -1,0 +1,3869 @@
+th	en	check
+กรอสซูลาร์	grossular	True
+กรอสซูลาไรต์	grossularite	True
+กราฟ	graph	True
+กราฟิก	graphic	True
+กรีนชีกต์	greencheeked	True
+กรีนอกไคต์	greenockite	True
+กรีนโอ๊ก	green oak	True
+กรุ๊ป	group	
+กรูป	group	True
+กรูเนอไรต์	grunerite	True
+กลอโคดอต	glaucodot	True
+กลอโคเฟน	glaucophane	True
+กลอโคโครไอต์	glaucochroite	True
+กลอโคไนต์	glauconite	True
+กลาสโกว	glasgow	
+กลาเซอไรต์	glaserite	True
+กลูโคส	glucose	True
+กวาร์	guar	True
+กวาร์กัม	guar gum	True
+กอร์มาไนต์	gormanite	True
+กอล์ฟ	golf	True
+กะรัต	carat	True
+กะรัต	karat	True
+กัดมันไดต์	gudmandite	True
+กัปตัน	captain	True
+กัฟฟี่	guffy	
+กัฟเวอร์แนนซ์	governance	True
+การ์ด	card	True
+การ์ตูน	cartoon	True
+การ์เนต	garnet	True
+การ์เนียไรต์	garnierite	True
+กาลิเลโอ กาลิเลอิ	galileo galilei	
+กาลิเลโอกาลิเล	galileo galilei	
+กาลีนา	galena	True
+กาห์ไนต์	gahnite	True
+กาเบียล	gabriel	
+กาแลกซี่	galaxy	
+กาแลกไซต์	galaxite	True
+กาแล็กซี	galaxy	True
+กาแล็กโทส	galactose	True
+กาโดลิไนต์	gadolinite	True
+กำมะถัน	sulphur	True
+กิบบ์ไซต์	gibbsite	True
+กิฟต์	gift	True
+กิฟต์เซต	gift set	True
+กิฟต์เวาเชอร์	gift voucher	True
+กิมมิก	gimmick	True
+กิโล	kilo	
+กิโลเฮิรตซ์	kilohertz	True
+กิโลไซเกิล	kilocycle	True
+กีตาร์	guitar	True
+กีย์เซอไรต์	geyserite	True
+กุ๊ก	cook	True
+กูด	good	True
+กูบลิไนต์	gublinite	True
+กูเกิล	google	True
+กูเกิลทอล์ค	google talk	
+กูเกิลเทร็นดส์	google trends	True
+กูเกิลแมป	google maps	
+กูเกิลโครม	google chrome	
+กูเกิลไดรฟ์	google drive	
+กูเกิ้ล	google	
+ก๊อซ	gauze	True
+ก๊อบปี้	copy	True
+ก๊อปปี้	copy	
+ก๊าซ	gas	
+ครอนิเคิล	chronicle	True
+ครัวซองต์	croissant	True
+คราฟต์	craft	True
+คริซาลิส	chrysalis	True
+คริปทอน	krypton	True
+คริปทอมีเลน	cryptomelane	True
+คริปโต	crypto	False
+คริปโตเคอร์เรนซี	cryptocurrency	False
+คริปโตเคอเรนซี่	cryptocurrency	False
+คริปโท	crypto	True
+คริปโทเคอร์เรนซี	cryptocurrency	True
+คริส	chris	True
+คริสตัล	crystal	True
+คริสต์มาส	christmas	True
+คริสมาสต์	christmas	
+คริสโทบาไลต์	cristobalite	True
+คริแซนทิมัม	chrysanthemum	True
+คริแซนเทมัม	chrysanthemum	True
+คริโซคอลลา	chrysocolla	True
+คริโซเบริล	chrysoberyl	True
+คริโซเพรส	chrysoprase	True
+คริโซไทล์	chrysotile	True
+คริโซไลต์	chrysolite	True
+ครีม	cream	True
+ครีเอต	create	True
+ครีเอทีฟส์คอมมอนส์	creative commons	
+ครีไดต์	creedite	True
+คลอราพาไทต์	chlorapatite	True
+คลอราร์จิไรต์	chlorargyrite	True
+คลอริทอยด์	chloritoid	True
+คลอรีน	chlorine	True
+คลอว์	claw	True
+คลอส	clause	True
+คลอแรสโทไรต์	chlorastrolite	True
+คลอแอนไทต์	chloanthite	True
+คลอโรฟอร์ม	chloroform	True
+คลอโรฟิลล์	chlorophyll	True
+คลอไรต์	chlorite	True
+คลัตช์	clutch	True
+คลับ	club	
+คลับเฮาส์	club house	True
+คลามิเดีย	chlamidia	True
+คลาริเน็ต	clarinet	True
+คลาร์ก	clerk	True
+คลาวด์	cloud	
+คลาส	class	True
+คลาสซี	classy	True
+คลาสรูม	classroom	True
+คลาสสิก	classic	True
+คลาสเมต	classmate	True
+คลิก	click	True
+คลิง	cling	True
+คลิงก์	clink	True
+คลินช์	clinch	True
+คลินิก	clinic	True
+คลิป	clip	True
+คลิปบอร์ด	clipboard	True
+คลิปเปอร์	clipper	True
+คลิฟ	cliff	True
+คลิฟฟอร์ไดต์	cliffordite	True
+คลิฟฟ์	cliff	True
+คลิฟฟ์	cliffe	True
+คลิ๊ก	click	False
+คลีก	clique	True
+คลีน	clean	True
+คลีนเนอร์	cleaner	True
+คลีฟ	cleave	True
+คลีฟแลนไดต์	cleavelandite	True
+คลีเช	cliché	True
+ควอตซ์	quartz	True
+ควอนตัม	quantum	True
+ควอรันทีน	quarantine	True
+ควินิน	quinine	True
+คอนกรีต	concrete	True
+คอนเซปต์	concept	True
+คอนเซ็ปต์	concept	
+คอนเดนเซอร์	condenser	True
+คอนเทนต์	content	
+คอนเนลไลต์	connellite	True
+คอนเน็กชัน	connection	True
+คอนเสิร์ต	concert	True
+คอนแท็กต์เซนเตอร์	contact center	True
+คอนแท็กต์เลนส์	contact lens	True
+คอนโด	condo	
+คอนโดมิเนียม	condominium	True
+คอนโดรไดต์	chondrodite	True
+คอปเปอร์	copper	True
+คอฟดอร์สไกต์	kovdorskite	True
+คอฟดอร์สไกต์คอฟดอร์สไกต์	kovdorskite	True
+คอฟฟีช็อป	coffee shop	True
+คอฟฟี่	coffee	False
+คอมป์ซอกนาทัส	compsognathus	True
+คอมพลีต	complete	True
+คอมพิวเตอร์	computer	True
+คอมมานโด	commando	True
+คอมมิวนิตี	community	True
+คอมมิวนิสต์	communism	True
+คอมเมดี้	comedy	
+คอมเมนต์	comment	True
+คอมเมนท์	comment	True
+คอมเม้น	comment	False
+คอมเม้นท์	comment	False
+คอมแพกต์ดิสก์	compact disc	True
+คอรอยด์	choroid	True
+คอรันดัม	corundum	True
+คอรัปชั่น	corruption	
+คอรัล	choral	True
+คอรัส	chorus	True
+คอริสเตอร์	chorister	True
+คอริโทซอรัส	corythosaurus	True
+คอร์ด	chord	True
+คอร์ดิไลต์	cordylite	True
+คอร์ติซอล	cortisol	True
+คอร์นวอลไลต์	cornwallite	True
+คอร์นเฟลกส์	cornflakes	True
+คอร์รัปชัน	corruption	True
+คอร์ส	course	
+คอร์เคเชี่ยน	caucasian	
+คอร์เดต	chordate	True
+คอร์เดียไรต์	cordierite	True
+คอร์เนอรูพีน	kornerupine	True
+คอร์เนไทต์	cornetite	True
+คอล	call	True
+คอลดรอน	caldron	True
+คอลดรอน	cauldron	True
+คอลลาเจน	collagen	True
+คอลลินไซต์	collinsite	True
+คอลลิเกทิฟ	colligative	True
+คอลัมนิสต์	columnist	True
+คอลัมน์	column	True
+คอลเซนเตอร์	call center	True
+คอลเซนเตอร์	call centre	True
+คอลเลกชัน	collection	True
+คอลเล็กชัน	collection	True
+คอลแลบ	collab	True
+คอลโลฟาไนต์	collophanite	True
+คอลโลเฟน	collophane	True
+คอส	cause	True
+คอสติกโซดา	caustic soda	True
+คอเคซอยด์	caucasoid	True
+คอเคเซียน	caucasian	
+คอเมดี	comedy	True
+คอเลสเตอรอล	cholesterol	True
+คอโรนาไดต์	coronadite	True
+คัพเค้ก	cup cake	
+คัฟเวอร์	cover	True
+คัมมิงโทไนต์	cummingtonite	True
+คัมแบค	comeback	
+คัมแบล็ค	come black	
+คัมแบ็ค	comeback	
+คัลเจอร์	culture	
+คัลเชอร์	culture	True
+คาทอลิก	catholic	True
+คานต์	can't	True
+คาบาซา	cabasa	True
+คาปูชิโน่	cappuccino	False
+คามีเลียน	chameleon	True
+คาราวาน	caravan	True
+คาราเมล	caramel	True
+คาริสมา	charisma	True
+คาร์	car	True
+คาร์คัส	carcass	True
+คาร์ซิก	carsick	True
+คาร์ซีต	car seat	True
+คาร์ดามัม	cardamom	True
+คาร์ดามัม	cardamum	True
+คาร์ดิกัน	cardigan	True
+คาร์ดินัล	cardinal	True
+คาร์ดิแกน	cardigan	
+คาร์ดิแอ็ก	cardiac	True
+คาร์ดีโอ	cardio	True
+คาร์ต	cart	True
+คาร์ตอน	carton	True
+คาร์นัลไลต์	carnallite	True
+คาร์นิวอร์	carnivore	True
+คาร์นิวัล	carnival	True
+คาร์นีเลียน	carnelian	True
+คาร์บอน	carbon	True
+คาร์บอนมอนอกไซด์	carbon monoxide	True
+คาร์บอนิก	carbonic	True
+คาร์บอนไดออกไซด์	carbon dioxide	True
+คาร์บอย	carboy	True
+คาร์บอลิก	carbolic	True
+คาร์บอเนต	carbonate	True
+คาร์บังเคิล	carbuncle	True
+คาร์บีน	carbine	True
+คาร์บูเรเตอร์	carburetor	True
+คาร์ป	carp	True
+คาร์ป	crap	True
+คาร์พิต	carpet	True
+คาร์พินเตอร์	carpenter	True
+คาร์ฟ	carve	True
+คาร์เทล	cartel	True
+คาร์เนชัน	carnation	True
+คาร์เนต์	carnet	True
+คาร์เนเลียน	carnelian	True
+คาร์เพนเตอร์	carpenter	True
+คาร์เพ็ต	carpet	True
+คาร์เลทอไนต์	carletonite	True
+คาร์โก	cargo	True
+คาร์โนทอรัส	carnotaurus	True
+คาร์โนไทต์	carnotite	True
+คาร์โบนารา	carbonara	True
+คาร์โบรันดัม	carborundum	True
+คาร์โบไฮเดรต	carbohydrate	True
+คาร์ไบด์	carbide	True
+คาร์ไบน์	carbine	True
+คาร์ไมน์	carmine	True
+คาลซิโดนี	chalcedony	True
+คาลดรอน	caldron	True
+คาลดรอน	cauldron	True
+คาลาไมน์	calamine	True
+คาลิปโซ	calypso	True
+คาลีไบต์	chalybite	True
+คาลแคนไทต์	chalcanthite	True
+คาลโคซิเดอไรต์	chalcosiderie	True
+คาลโคฟาไนต์	chalcophanite	True
+คาลโคฟิลไลต์	chalcophyllite	True
+คาลโคไซต์	chalcocite	True
+คาลโคไพไรต์	chalcopyrite	True
+คาล์ฟ	calf	True
+คาล์ม	calm	True
+คาสก์	cask	True
+คาสติง	casting	True
+คาสต์	cast	True
+คาสเตอร์	castor	True
+คาห์ไนต์	cahnite	True
+คาเดอร์	cadre	True
+คาเฟ	cafe	True
+คาเฟ	café	True
+คาเฟอิก	caffeic	True
+คาเฟอีน	caffeine	
+คาเฟ่	cafe	False
+คาแทสโตรฟี	catastrophe	True
+คาแรกเตอร์	character	False
+คาโลเมล	calomel	True
+คิก	kick	True
+คิดเวลไลต์	kidwellite	True
+คินเดิล	kindle	
+คิว	queue	True
+คิวบาไนต์	cubanite	True
+คิวอาร์โค้ด	qr code	
+คิวไพรต์	cuprite	True
+คิเมอรา	chimaera	True
+คิเมอรา	chimera	True
+คิโนไอต์	kinoite	True
+คีย์บอร์ด	keyboard	True
+คีย์เวิร์ด	keyword	
+คีวี	kiwi	True
+คีออสก์	kiosk	
+คีเซลกูห์	kieselguh	True
+คีเซไรต์	kieserite	True
+คีเลชัน	chelation	True
+คีเลต	chelate	True
+คุกกี้	cookie	True
+คุตนอฮอไรต์	kutnohorite	True
+คุนไซต์	kunzite	True
+คุร์นาคอไวต์	kurnakovite	True
+คุลาไนต์	kulanite	True
+คูเมนไจต์	cumengeite	True
+คูเรียม	curium	True
+คูไกต์	cookeite	True
+ค็อกคัส	coccus	True
+ค็อกเทล	cocktail	True
+จอร์จ	george	
+จอร์จ วอชิงตัน	george washington	
+จอร์ดาไนต์	jordanite	True
+จอห์น	john	
+จัดจ์ คลาร์ก	judge clerk	
+จัมป์	jump	True
+จัมป์ซูต	jumpsuit	True
+จััมป์	jump	True
+จาคอบไซต์	jacobsite	True
+จาซินท์	jacinth	True
+จาร์กอน	jargon	True
+จาร์กูน	jargoon	True
+จาวา	java	True
+จาวาสคริปต์	javascript	
+จาโรไซต์	jarosite	True
+จิงเกิลสติก	jingle stick	True
+จีพียู	gpu	True
+จีโอบาซิลลัส สเตียโรเทอร์โมฟิลัส	geobacillus stearothermophilus	True
+จุมลา	joomla	
+จูมล่า	joomla	
+จ็อกกิง	jogging	True
+ชมิตเทอไรต์	schmitterrite	True
+ชอน	sean	True
+ชอป	chop	True
+ชอป	shop	True
+ชอปปิง	shopping	True
+ชอมป์	chomp	True
+ชอยซ์	choice	True
+ชอร์	chore	True
+ชอร์ต	short	
+ชอร์ตโน้ต	shortnote	True
+ชอร์ล	schorl	True
+ชอร์ไทต์	shortite	True
+ชอร์ไลต์	schorlite	True
+ชอล์ก	chalk	True
+ชะแล็ก	shellac	True
+ชังกี	chunky	True
+ชังก์	chunk	True
+ชัต	shut	True
+ชัตดาวน์	shutdown	True
+ชัตนีย์	chutney	True
+ชัตเตอร์	shutter	True
+ชันเตอร์	chunter	True
+ชับ	chub	True
+ชับบี	chubby	True
+ชัฟ	chuff	True
+ชัม	chum	True
+ชัมป์	chump	True
+ชัมมี	chummy	True
+ชัวร์	sure	
+ชานต์	chant	True
+ชาร์	char	True
+ชาร์จ	charge	True
+ชาร์จเจอร์	charger	True
+ชาร์ด	chard	True
+ชาร์ต	chart	True
+ชาร์ม	charm	True
+ชาร์มมิง	charming	True
+ชาร์ลี	charlie	True
+ชาร์เตอร์	charter	True
+ชาร์โคล	charcoal	True
+ชาลส์	charles	True
+ชาโรไอต์	charoite	True
+ชิก	chic	True
+ชิก	chick	True
+ชิกกิน	chicken	True
+ชิกพี	chickpea	True
+ชิกเกน	chicken	True
+ชิคาโน	chicano	True
+ชิงก์	chink	True
+ชิงเกิล	shingle	True
+ชิตทาโคซอรัส	psittacosaurus	True
+ชิน	chin	True
+ชินชิลลา	chinchilla	True
+ชินุก	chinook	True
+ชิป	chip	True
+ชิป	ship	True
+ชิปมังก์	chipmunk	True
+ชิปเปอร์	chipper	True
+ชิฟฟอน	chiffon	True
+ชิมนีย์	chimney	True
+ชิมแปนซี	chimpanzee	True
+ชิมแพนซี	chimpanzee	True
+ชิล	chill	True
+ชิลลี	chilli	True
+ชิลลี	chilly	True
+ชิลล์	chill	True
+ชิลี	chili	True
+ชิลเดรน	children	True
+ชิลเดรไนต์	childrenite	True
+ชิลเลอร์	chiller	True
+ชิลแล็กซ์	chillax	True
+ชิวัลรี	chivalry	True
+ชิวาวา	chihuahua	True
+ชิเคน	chicane	True
+ชิเคอรี	chicory	True
+ชีก	cheek	True
+ชีต	cheat	True
+ชีตาห์	cheetah	True
+ชีป	cheap	True
+ชีฟ	chief	True
+ชีลด์	shield	True
+ชีส	cheese	True
+ชีสเค้ก	cheesecake	True
+ชีสเบอร์เกอร์	cheeseburger	True
+ชีไลต์	scheelite	True
+ชูครีม	choux cream	True
+ชูต	chute	True
+ชูส	choose	True
+ชูเพสตรี	choux pastry	True
+ช็อก	shock	True
+ช็อกโกเลต	chocolate	True
+ช็อกโกแลต	chocolate	True
+ช็องเรอ	genre	True
+ช็อป	chop	True
+ช็อป	shop	True
+ช็อปปิง	shopping	True
+ช็อปสติก	chopstick	True
+ช้อป	shop	
+ช้อปปิ้ง	shopping	
+ซอฟต์แวร์	software	True
+ซอยไซต์	zoisite	True
+ซอร์สโค้ด	source code	
+ซอร์เบต์	sorbet	True
+ซอส	sauce	True
+ซอสซูไรต์	saussurite	True
+ซัน	sun	True
+ซับสไกรบ์	subscribe	True
+ซับสไครบ์	subscribe	
+ซัปพอร์ต	support	True
+ซัพพลายเออร์	supplier	
+ซัพพอร์ต	support	
+ซัมซุง	samsung	
+ซัมเมอร์	summer	True
+ซัลฟา	sulpha	True
+ซัลเฟอร์	sulphur	True
+ซัลโฟเฮไลต์	sulphohalite	True
+ซัสเซไซต์	suaaexite	True
+ซาทินสปาร์	satin spar	True
+ซานตาคลอส	santa claus	
+ซานิดีน	sanidine	True
+ซาฟารี	safari	
+ซามาร์สไกต์	samarskite	True
+ซาร่า	zara	
+ซาร์ด	sard	True
+ซาร์ดีน	sardine	True
+ซาร์ทอไรต์	sartorite	True
+ซาร์โดนิกซ์	sardonyx	True
+ซาวนด์แทร็ก	soundtrack	True
+ซาวร์ครีม	sourcream	True
+ซาวอไรต์	tsavorite	True
+ซาแมเรียม	samarium	True
+ซาโพไนต์	saponite	True
+ซาไลต์	salite	True
+ซิกซ์แพ็ก	six pack	True
+ซิการ์	cigar	True
+ซิกาเร็ตต์	cigarette	True
+ซิกาแร็ต	cigarette	True
+ซิกเนเชอร์	signature	True
+ซิกแซ็ก	zigzag	True
+ซิคาดา	cicada	True
+ซิคาทริกซ์	cicatrix	True
+ซิงก์	zinc	True
+ซิงก์เบลนด์	zinc blende	True
+ซิงค์	sync	True
+ซิงเกิล	single	
+ซิงเกิลมัม	single mom	
+ซิงเกิ้ล	single	
+ซิงเกิ้ลมัม	single mom	
+ซิงเคไนต์	zinkenite	True
+ซิงไคต์	zinkite	True
+ซิงไซต์	zincite	True
+ซิติเซน	citizen	True
+ซิติเซนชิป	citizenship	True
+ซิตี	city	True
+ซิตเทิร์น	cittern	True
+ซิทคอม	sitcom	
+ซิทรอน	citron	True
+ซิทรัส	citrus	True
+ซิทริก	citric	True
+ซิทริน	citrine	True
+ซิทาเดล	citadel	True
+ซินคิไซต์	synchysite	True
+ซินช์	cinch	True
+ซินดี	cindy	True
+ซินนาบาร์	cinnabar	True
+ซินนามอน	cinnamon	True
+ซินน์วอลไดต์	zinwaldite	True
+ซินฮาไลต์	sinhalite	True
+ซินิมา	cinema	True
+ซินเจไนต์	syngenite	True
+ซินเดอร์	cinder	True
+ซิป	zip	True
+ซิป์เพไอต์	zippeite	True
+ซิฟิลิส	syphilis	True
+ซิมป์ซอไนต์	simpsonite	True
+ซิมพลิไซต์	symplesite	True
+ซิลลิมาไนต์	sillimanite	True
+ซิลวาไนต์	sylvanite	True
+ซิลิกา	silica	True
+ซิลิคอน	silicon	True
+ซิลเวอร์	silver	True
+ซิลไวต์	sylvite	True
+ซิวิก	civic	True
+ซิวิต	civet	True
+ซิวิล	civil	True
+ซิวิเลียน	civilian	True
+ซิวิไลซ์	civilize	True
+ซิวิไลเซชัน	civilization	True
+ซิสเติร์น	cistern	True
+ซิเคดา	cicada	True
+ซิเคทริกซ์	cicatrix	True
+ซิเดอไรต์	siderite	True
+ซิเทรต	citrate	True
+ซิเนมา	cinema	True
+ซิเลีย	cilia	
+ซิแลนโทร	cilantro	True
+ซิโทรเนลลา	citronella	True
+ซีซัน	season	True
+ซีซีทีวี	cctv	
+ซีดี	cd	True
+ซีดีรอม	cd rom	True
+ซีดีรอม	cd-rom	
+ซีดีอาร์	cd-r	True
+ซีต	seat	True
+ซีน	scene	True
+ซีนอน	xenon	True
+ซีบอร์เกียม	seaborgium	True
+ซีพิโอไลต์	sepiolite	True
+ซีพี เซเว่นอีเลฟเว่น	cp seven eleven	
+ซีพียู	cpu	True
+ซีฟูด	seafood	True
+ซีฟู้ด	seafood	
+ซีรอกซ์	xerox	True
+ซีรีส์	series	True
+ซีลส์	seals	True
+ซีลอไนต์	ceylonite	True
+ซีลิง	ceiling	True
+ซีลีเนียม	selenium	True
+ซีส	cease	True
+ซีอีโอ	ceo	
+ซีเกท	seagate	
+ซีเซียม	caesium	True
+ซีเมนต์	cement	True
+ซีเรีย	syria	
+ซีเรียม	cerium	True
+ซีเรียล	cereal	True
+ซีเลีย	celia	
+ซีเอฟโอ	cfo	
+ซีเอ็มเอส	cms	
+ซีโนเอสโตรเจน	xenoestrogen	
+ซีโนไทม์	xenotime	True
+ซีโอไลต์	zeolite	True
+ซีไรต์	cerite	True
+ซีไอเอ	cia	True
+ซีไอโอ	cio	
+ซุป	soup	True
+ซูจิไลต์	sugilite	True
+ซูซอไรต์	suzorite	True
+ซูพรีม	supreme	True
+ซูพรีโมเจมเบ	supremo djembe	True
+ซูเนอไรต์	zeunerite	True
+ซูเปอร์	super	True
+ซูเปอร์คอมพิวเตอร์	supercomputer	True
+ซูเปอร์มาร์เกต	supermarket	True
+ซูเปอร์มาร์เก็ต	supermarket	True
+ซูเปอร์สตาร์	superstar	True
+ซูเปอร์แมน	superman	
+ซูเมไบต์	tsumebite	True
+ซูแซนไนต์	susannite	True
+ซูแอไนต์	suanite	True
+ซูโครส	sucrose	True
+ซูโดบรูไคต์	pseudobrookite	True
+ซูโดมาลาไคต์	pseudomalachite	True
+ซูโดโบลีไอต์	pseudoboleite	True
+ซูโอลูไนต์	suolunite	True
+ซูไทต์	nsutite	True
+ซ็อกเกอร์	soccer	
+ซ็อกเก็ต	socket	
+ดรอป	drop	
+ดรอว์	draw	True
+ดรัม	drum	
+ดราฟต์	draft	True
+ดราม่า	drama	
+ดราไวต์	dravite	True
+ดริงก์	drink	True
+ดอกเตอร์	doctor	
+ดอร์เม้าส์	dormouse	
+ดอลลาร์	dollar	True
+ดอว์ซอไนต์	dawsonite	True
+ดัชเชส	duchess	
+ดันแดไซต์	dundasite	True
+ดับลิน	dublin	
+ดับเบิล	double	True
+ดับเบิลวอลูม	double volume	True
+ดัมบ์เบล	dumbbell	True
+ดัมป์	dump	True
+ดัมมี	dummy	
+ดานซ์	dance	True
+ดานเซอร์	dancer	True
+ดารามิน	daramin	
+ดาร์ก	dark	True
+ดาร์ท เวเดอร์	darth vader	
+ดาร์ธ เวเดอร์	darth vader	
+ดาร์มสตัดเทียม	darmstadtium	True
+ดาวน์	down	True
+ดาวน์ทาวน์	downtown	True
+ดาวน์โหลด	download	True
+ดาโทไลต์	datolite	True
+ดิกไคต์	dickite	True
+ดิจิตอล	digital	False
+ดิจิทัล	digital	True
+ดิลิเวอรี	delivery	True
+ดิสนีย์	disney	True
+ดิสนี่	disney	False
+ดิสเครไซต์	dyscrasite	True
+ดิสโกเทก	discotheque	True
+ดิสโพรเซียม	dysprosium	True
+ดิเบต	debate	True
+ดิไซน์	design	True
+ดิไซเนอร์	designer	True
+ดีซี	dc	True
+ดีต์ไซต์	dietzeite	True
+ดีท็อกซ์	detox	
+ดีบุก	tin	True
+ดีปเลิร์นนิง	deep learning	
+ดีป้า	depa	True
+ดีพ เลินนิ่ง	deep learning	
+ดีพ เลิร์นนิง	deep learning	
+ดีพเลินนิ่ง	deep learning	
+ดีพเลิร์นนิง	deep learning	
+ดีมันทอยด์	demantoid	True
+ดีล	deal	
+ดีวีดี	dvd	True
+ดีเจ	dj	True
+ดีเซล	diesel	True
+ดีเบต	debate	
+ดีเปรสชัน	depression	True
+ดีไซน์	design	True
+ดุบเนียม	dubnium	True
+ดุฟไทต์	duftite	True
+ดูมอร์เทอไรต์	dumortierite	True
+ดูเฟรไนต์	dufrenite	True
+ด็อกเตอร์	doctor	
+ตริโปลี	tripoli	True
+ตอร์ปิโด	torpedo	True
+ตัน	ton	True
+ติโม่ แวร์เนอร์	timo werner	
+ติ๊กต็อก	tiktok	
+ทรอปิกออฟแคปริคอร์น	tropic of capricorn	
+ทรอมโบน	trombone	True
+ทรัมเป็ต	trumpet	True
+ทรานซิสเตอร์	transistor	True
+ทริดิไมต์	tridymite	True
+ทริป	trip	
+ทรีตเมนต์	treatment	True
+ทรู	true	True
+ทรูคอฟฟี่	true coffee	
+ทวิตเตอร์	twitter	True
+ทวิสต์	twist	True
+ทวีดเลดดัม	tweedledum	
+ทวีต	tweet	
+ทองคำ	gold	True
+ทองแดง	copper	True
+ทอนซิล	tonsil	True
+ทอปปิก	topic	True
+ทอฟฟี่	toffee	True
+ทอฟฟี่เค้ก	toffee cake	True
+ทอม	tom	
+ทอมซอไนต์	thomsonite	True
+ทอร์นาโด	tornado	True
+ทอร์เบอร์ไนต์	torbernite	True
+ทอล์กโชว์	talk show	True
+ทอเรียม	thorium	True
+ทอเรียไนต์	thorianite	True
+ทอโรกุม์ไมต์	thorogummite	True
+ทอไรต์	thorite	True
+ทักซีโด	tuxedo	True
+ทังสเตน	tungsten	True
+ทับทิม	ruby	True
+ทัลก์	talc	True
+ทัวริสต์	tourist	True
+ทัวร์	tour	True
+ทัวร์มาลีน	tourmaline	True
+ทาฟ์ไฟต์	taaffeite	True
+ทาร์บุตไทต์	tarbuttite	True
+ทาวน์เฮาส์	townhouse	True
+ทิงเจอร์	tincture	True
+ทิชชู	tissue	True
+ทิน	tin	True
+ทินคัล	tincal	True
+ทินคัลโคไนต์	tincalconite	True
+ทินักไซต์	tinaksite	True
+ทิแรนโนซอรัสเร็กซ์	tyrannosaurus rex	True
+ทีซีดีซี	tcdc	
+ทีม	team	True
+ทีมเวิร์ก	team work	True
+ทียูยามูไนต์	tyuyamunite	True
+ทีลไลต์	teallite	True
+ทีวี	tv	True
+ทีวี ไดเร็ค	tv direct	True
+ทีออเรทิคัล	theoretical	True
+ทีเอ็นที	tnt	True
+ทูนา	tuna	True
+ทูริงไกต์	thuringite	True
+ทูเนลไลต์	tunellite	True
+ทูเลียม	thulium	True
+ทูไลต์	thulite	True
+ทไวไลท์	twilight	
+ท็อกซิก	toxic	
+ท็อปปิก	topic	False
+ท็อฟฟี่	toffee	
+นอจยาไกต์	nagyagite	True
+นอต	knot	True
+นอนโทรไนต์	nontronite	True
+นอยด์	noid	
+นอร์ทอีสต์	northeast	True
+นอร์ทูไพต์	northupite	True
+นอร์เบอร์ไกต์	norbergite	True
+นอร์เวย์	norway	
+นอไฟต์	knaufite	True
+นาซา	nasa	True
+นาซ่า	nasa	False
+นาร์ซาร์ซุไคต์	narsarsukite	True
+นาห์โคไลต์	nahcolite	True
+นาโทรคาลไซต์	natrochalcite	True
+นาโทรจาโรไซต์	natrojarosite	True
+นิกรอยด์	negroid	True
+นิกเกิล	nickel	True
+นิกเกไลน์	nickeline	True
+นิกโคไลต์	niccolite	True
+นินเทนโด	nintendo	
+นิว นอร์มัล	new normal	False
+นิวตรอน	neutron	True
+นิวนอร์มัล	new normal	True
+นิวยอร์ก	new york	
+นิวส์	news	True
+นิวเคลียร์	nuclear	True
+นิวเคลียส	nucleus	True
+นิโคติน	nicotine	True
+นิโครม	nichrome	True
+นีออน	neon	True
+นีโอดิเมียม	neodymium	True
+น็อกเอาต์	knock out	True
+บรอกโคลี	broccoli	True
+บรองโค	bronco	True
+บรอด	broad	True
+บรอดแบนด์	broadband	True
+บรอน	brawn	True
+บรอนซ์	bronze	True
+บรอนเซอร์	bronzer	
+บรอนไซต์	bronzite	True
+บรอยล์	broil	True
+บรอล	brawl	True
+บรอว์น	brawn	True
+บรอว์ล	brawl	True
+บรัช	brush	True
+บรันช์	brunch	True
+บรัฟ	bruv	True
+บรัมบี	brumby	True
+บรั่นดี	brandy	True
+บรา	bra	True
+บราซิเลียไนต์	brazilianite	True
+บรานช์	branch	True
+บราย	braai	True
+บราว	brow	True
+บราวนี	brownie	True
+บราวน์	brown	True
+บราวอยต์	bravoite	True
+บราวเซอร์	browser	
+บราส	brass	True
+บราโว	bravo	True
+บริก	brick	True
+บริก	brig	True
+บริกันด์	brigand	True
+บริกันทีน	brigantine	True
+บริง	bring	True
+บริงก์	brink	True
+บริดจ์	bridge	True
+บริล	brill	True
+บริลเลียนซ์	brilliance	True
+บริลเลียนต์	brilliant	True
+บริสกิต	brisket	True
+บริสก์	brisk	True
+บริเกด	brigade	True
+บรี	brie	True
+บรีช	breach	True
+บรีซ	breeze	True
+บรีด	breed	True
+บรีฟ	brief	True
+บรีฟเคส	briefcase	True
+บรีออช	brioche	True
+บรีโอ	brio	True
+บรุก	brook	True
+บรุม	broom	True
+บรูช	brooch	True
+บรูด	brood	True
+บรูต	brute	True
+บรูม	broom	True
+บรูม	brume	True
+บรูว์	brew	True
+บรูส	bruise	True
+บรูสเก็ตตา	bruschetta	True
+บรูเซอร์	bruiser	True
+บรูเนต	brunette	True
+บรูเน็ต	brunette	True
+บรูเวอรี	brewery	True
+บรูเวอร์	brewer	True
+บรูเออรี	brewery	True
+บรูเออร์	brewer	True
+บรูโน	bruno	True
+บรูไคต์	brookite	True
+บรูไซต์	brucite	True
+บร็อคโคลี่	broccoli	
+บลอนด์	blond	True
+บลอนด์	blonde	True
+บลอบ	blob	True
+บลัช	blush	True
+บลัด	blood	True
+บลัดดี	bloody	True
+บลัดสโตน	bloodstone	True
+บลันต์	blunt	True
+บลัฟ	bluff	True
+บลานช์	blanch	True
+บลาร์นีย์	blarney	True
+บลาสต์	blast	True
+บลิงก์	blink	True
+บลิงริง	bling ring	True
+บลิซเซิร์ด	blizzard	True
+บลิตซ์	blitz	True
+บลิป	blip	True
+บลิส	bliss	True
+บลิสเตอร์	blister	True
+บลีก	bleak	True
+บลีช	bleach	True
+บลีด	bleed	True
+บลีต	bleat	True
+บลีนี	blini	True
+บลีป	bleep	True
+บลู	blue	True
+บลูทูท	ฺbluetooth	True
+บลูทูธ	bluetooth	
+บลูพรินต์	blueprint	True
+บลูม	bloom	True
+บลูมเบิร์ก	bloomberg	True
+บลูเบร์รี	blueberry	True
+บลูเบอร์รี	blueberry	True
+บลูเรย์	blu-ray	
+บล็อก	bloc	True
+บล็อก	block	True
+บล็อก	blog	True
+บล็อกบัสเตอร์	blockbuster	True
+บล็อกเกอร์	blogger	True
+บล็อกโคลี่	broccoli	
+บล็อค	block	
+บล็อต	blot	True
+บล็อบ	blob	True
+บอกซิง	boxing	True
+บอกซ์	box	True
+บอง	bong	True
+บองก์	bonk	True
+บองก์บัสเตอร์	bonkbuster	True
+บองโก	bongo	True
+บอดี	body	True
+บอดีการ์ด	bodyguard	True
+บอดี้	body	
+บอดี้การ์ด	bodyguard	
+บอตเทิล	bottle	True
+บอนด์	bond	True
+บอนนิต	bonnet	True
+บอนบอน	bonbon	True
+บอนไฟเออร์	bonfire	True
+บอมบาร์ด	bombard	True
+บอมบาเดียร์	bombardier	True
+บอมบ์	bomb	True
+บอมแบสติก	bombastic	True
+บอย	boy	True
+บอยคอต	boycott	True
+บอยค็อต	boycott	True
+บอยล์	boil	True
+บอยเฟรนด์	boyfriend	True
+บอยเลอร์	boiler	True
+บอยแบนด์	boy band	
+บอราไซต์	boracite	True
+บอร์	boar	True
+บอร์ด	board	True
+บอร์น	bourne	True
+บอร์โนไนต์	bournonite	True
+บอร์โรว์	borrow	True
+บอร์ไนต์	bornite	True
+บอล	ball	True
+บอลซัม	balsam	True
+บอลซา	balsa	True
+บอลซี	ballsy	True
+บอลด์	bald	True
+บอลด์วิน	baldwin	True
+บอลรูม	ballroom	True
+บอส	boss	True
+บอสซาโนวา	bossa nova	True
+บอแรกซ์	borax	True
+บอแร็กซ์	borax	True
+บะซูกา	bazooka	True
+บะนอฟฟี	banoffee	True
+บะนอฟฟี	banoffi	True
+บะบูน	baboon	True
+บะราจ	barrage	True
+บะโลนี	baloney	True
+บัก	buck	True
+บัก	bug	True
+บักกิต	bucket	True
+บักกี	buggy	True
+บักช็อต	buckshot	True
+บักวีต	buckwheat	True
+บักเกอร์	bugger	True
+บักเกิล	buckle	True
+บักเบร์	bugbear	True
+บักแบร์	bugbear	True
+บังกะโล	bungalow	True
+บังก์	bunk	True
+บังเกอร์	bunker	True
+บังเกิล	bungle	True
+บัซ	buzz	True
+บัซเซอร์	buzzer	True
+บัซเซิร์ด	buzzard	True
+บัซเวิร์ด	buzzword	True
+บัด	bud	True
+บัดจิต	budget	True
+บัดจี	budgie	True
+บัดดี	buddy	True
+บัต	but	True
+บัต	butt	True
+บัตเตอร์	butter	True
+บัตเลอร์	butler	True
+บัตแทเลียน	battalion	True
+บัน	bun	True
+บันจี	bungee	True
+บันจีจัมป์	bungee jump	True
+บันช์	bunch	True
+บันต์	bunt	True
+บันนี	bunny	True
+บันเดิล	bundle	True
+บับเบิล	bubble	True
+บัฟ	buff	True
+บัฟฟาโล	buffalo	True
+บัฟเฟอร์	buffer	True
+บัม	bum	True
+บัมปี	bumpy	True
+บัมปี	bun	True
+บัมป์	bump	True
+บัมฟ์	bumf	True
+บัมเบิล	bumble	True
+บัมเบิลบี	bumblebee	True
+บัลกี	bulky	True
+บัลก์	bulk	True
+บัลจ์	bulge	True
+บัลบัส	bulbous	True
+บัลบ์	bulb	True
+บัลลิสติก	ballistic	True
+บัลลูน	balloon	True
+บัลเลต์	ballet	
+บัลเวิร์ก	bulwark	True
+บัส	bus	True
+บัสซูน	bassoon	True
+บัสตี	busty	True
+บัสต์	bust	True
+บัสบอย	busboy	True
+บัสบี	busby	True
+บัสเตอร์	buster	True
+บัสเติร์ด	bustard	True
+บัสไทต์	bastite	True
+บั๊ก	bug	
+บาซิลลัส	bacillus	True
+บาซิโลซอรัส	basilosaurus	True
+บาย	buy	True
+บาย	by	True
+บาย	bye	True
+บายพาส	bypass	True
+บารอมิเตอร์	barometer	True
+บาริสตา	barista	True
+บารีสตา	barista	True
+บาร์	bar	True
+บาร์ก	bark	True
+บาร์กิน	bargain	True
+บาร์คีวิไคต์	barkevikite	True
+บาร์จ	barge	True
+บาร์จี	bargee	True
+บาร์ด	bard	True
+บาร์น	barn	True
+บาร์นยาร์ด	barnyard	True
+บาร์บ	barb	True
+บาร์บิคิว	barbecue	True
+บาร์บีคิว	barbecue	
+บาร์ฟ	barf	True
+บาร์มบี	barmby	True
+บาร์เตอร์	barter	True
+บาร์เทนเดอร์	bartender	True
+บาร์เบล	barbell	True
+บาร์เบอร์	barber	True
+บาร์เบอร์ช็อป	barbershop	True
+บาร์เบเรียน	barbarian	True
+บาร์เรล	barrel	True
+บาร์เลย์	barley	True
+บาร์แบเรียน	barbarian	True
+บาร์โคด	bar code	True
+บาร์โค้ด	barcode	True
+บาลซัม	balsam	True
+บาลซา	balsa	True
+บาลซี	ballsy	True
+บาลด์	bald	True
+บาลด์วิน	baldwin	True
+บาล์ม	balm	True
+บาว	bough	True
+บาว	bow	True
+บาสกิต	basket	True
+บาสก์	bask	True
+บาสต์เนไซต์	bastnaesite	True
+บาสเกตบอล	basketball	True
+บาสเติร์ด	bastard	True
+บิก	big	True
+บิกซ์ไบต์	bixbite	True
+บิกิทาไอต์	bikitaite	True
+บิกิน	begin	True
+บิกินเนอร์	beginner	True
+บิคอส	because	True
+บิคัม	become	True
+บิคีนี	bikini	True
+บิง	bing	
+บิงโก	bingo	True
+บิซาร์	bizarre	True
+บิซี	busy	True
+บิต	bit	True
+บิตคอย	bitcoin	False
+บิตคอยน์	bitcoin	True
+บิตแม็ป	bitmap	True
+บิทคอยน์	bitcoin	False
+บิทวีน	between	True
+บิน	bin	True
+บินจ์	binge	True
+บินด์ไฮไมต์	bindheimite	True
+บินต์	bint	True
+บิฟอร์	before	True
+บิมโบ	bimbo	True
+บิล	bill	True
+บิล เกตส์	bill gates	
+บิลด์	build	True
+บิลด์อัป	build-up	True
+บิลต์	built	True
+บิลต์อิน	built-in	True
+บิลบอร์ด	billboard	True
+บิลล์	bill	True
+บิลอง	belong	True
+บิลีฟ	belief	True
+บิลีฟ	believe	True
+บิลเดอร์	builder	True
+บิลเลียด	billiards	True
+บิลเลียน	billion	True
+บิวคอลิก	bucolic	True
+บิวตี	beauty	True
+บิวตีบล็อกเกอร์	beauty blogger	True
+บิวท์อิน	built-in	
+บิวเกิล	bugle	True
+บิวเรตต์	burette	True
+บิสกิต	biscuit	True
+บิสก์	bisque	True
+บิสนิส	business	True
+บิสมัท	bismuth	True
+บิสมูทิไนต์	bismuthinite	True
+บิสมูไทต์	bismutite	True
+บิสเนส	business	True
+บิสโตร	bistro	True
+บิสไตรด์	bestride	True
+บิฮาล์ฟ	behalf	True
+บิฮีมอท	behemoth	True
+บิเทก	betake	True
+บิเทรย์	betray	True
+บิเมนไทต์	bementite	True
+บิเฮด	behead	True
+บิเฮฟ	behave	True
+บิแดซเซิล	bedazzle	True
+บิแวร์	beware	True
+บิแฮล์ฟ	behalf	True
+บิโลว์	below	True
+บิโฮลด์	behold	True
+บิไซด์	beside	True
+บิไนน์	benign	True
+บิไฮนด์	behind	True
+บี	bee	True
+บีก	beak	True
+บีกเกอร์	beaker	True
+บีคอน	beacon	True
+บีช	beach	True
+บีช	beech	True
+บีซีพีจี	bcpg	
+บีด	bead	True
+บีต	beat	True
+บีต	beet	True
+บีตรูต	beetroot	True
+บีตา	beta	True
+บีทาไฟต์	betafite	True
+บีทีเอส	bts	
+บีน	bean	True
+บีบอป	bebop	True
+บีบีซี	bbc	True
+บีบีซีเวิลด์	bbc world	
+บีบ็อป	bebop	True
+บีป	beep	True
+บีฟ	beef	True
+บีม	beam	True
+บียอนด์	beyond	True
+บีสก์	bisque	True
+บีสต์	beast	True
+บีสโตร	bistro	True
+บีเกิล	beagle	True
+บีเทิล	beetle	True
+บีเวอร์	beaver	True
+บีไฮฟ์	beehive	True
+บุก	book	True
+บุกกิง	booking	True
+บุช	bush	True
+บุตต์เจนแบไคต์	buttgenbachite	True
+บุตเชอร์	butcher	True
+บุฟเฟต์	buffet	True
+บุฟเฟ่ต์	buffet	
+บุล	bull	True
+บุลดอก	bulldog	True
+บุลด็อก	bulldog	True
+บุลรัช	bulrush	True
+บุลลิช	bullish	True
+บุลลิต	bullet	True
+บุลลี	bully	True
+บุลิเมีย	bulimia	True
+บุลเลียน	bullion	True
+บุลเวิร์ก	bulwark	True
+บุลโดซเซอร์	bulldozer	True
+บุ๊ก	book	True
+บุ๊กมาร์ก	bookmark	True
+บุ๊กส์	book	True
+บูกี	boogie	True
+บูกีแมน	boogeyman	True
+บูต	boot	True
+บูตส์	boots	True
+บูตเลก	bootleg	True
+บูท	booth	True
+บูทีก	boutique	True
+บูน	boon	True
+บูมเมอร์	boomer	True
+บูลีเมีย	bulimia	True
+บูสต์	boost	True
+บูสเตอร์	booster	True
+บูเค	bouquet	True
+บูเคต์	bouquet	True
+บูเมอแรง	boomerang	True
+บูแลนเจอไรต์	boulangerite	True
+บ็อกซิง	boxing	True
+บ็อกซ์	box	True
+บ็อกไซต์	bauxite	True
+บ็อตทอม	bottom	True
+บ็อนบ็อน	bonbon	True
+บ๊อกเซอร์	boxer	
+ปรอท	mercury	True
+ปริซึม	prism	True
+ปรินเตอร์	printer	
+ปลั๊ก	plug	True
+ปลาสเตอร์	plaster	True
+ปอนด์	pound	True
+ปารีส	paris	
+ปาร์ตี้ลิสต์	party-list	
+ปาล์ม	palm	
+ปิกนิก	picnic	True
+ปิงปอง	pingpong	True
+ปิโตรเลียม	petroleum	True
+ป๊อป	pop	
+ป๊อปคอร์น	popcorn	
+พริตตี	pretty	True
+พรินต์	print	True
+พริเซนต์	present	True
+พริเซนเตอร์	presenter	True
+พรีห์ไนต์	prehnite	True
+พรีเซนต์	present	True
+พรีเซนท์	present	False
+พรีเซนเตอร์	presenter	True
+พรีเซนเทชัน	persentation	True
+พรีเซ้นท์	present	True
+พรีเมียม	premium	True
+พรีเมียร์	premier	True
+พรีเมียร์	premiere	True
+พรีเมียร์	première	True
+พรีเวดดิ้ง	pre-wedding	
+พรูน	prune	True
+พรูสไทต์	proustite	True
+พร็อป	prop	True
+พลวง	antimony	True
+พลัม	plum	True
+พลัมบาโก	plumbago	True
+พลาสติก	plastic	True
+พลาสมา	plasma	True
+พลีโอนาสต์	pleonaste	True
+พลูออต	pluot	True
+พลูโต	pluto	True
+พลูโตเนียม	plutonium	
+พลูโทเนียม	plutonium	True
+พอดคาสต์	podcast	True
+พอดแคสต์	podcast	True
+พอร์ต	port	True
+พอร์ตแลนไดต์	portlandite	True
+พอร์ตโฟลิโอ	portfolio	True
+พอลลูไซต์	pollucite	True
+พอลล่า	paula	
+พอลิลิทิโอไนต์	polylithionite	True
+พอลิเบไซต์	polybasite	True
+พอลิเมอร์	polymer	True
+พอลิเฮไลต์	polyhalite	True
+พอเลียไนต์	polianite	True
+พอโลเนียม	polonium	True
+พัฟ	puff	True
+พัมเพลล์ไยต์	pumpellyite	True
+พานาโซนิค	panasonic	
+พาพรีกา	paprika	True
+พาพาโกไอต์	papagoite	True
+พาราซิมพลิไซต์	parasymplesite	True
+พาราดาไมต์	paradamite	True
+พาราฟิน	paraffin wax	True
+พาราว็อกไซต์	paravauxite	True
+พาราโกไนต์	paragonite	True
+พาราโบลา	parabola	True
+พาร์กาไซต์	pargasite	True
+พาร์ตเนอร์	partner	True
+พาร์ตไทม์	part-time	True
+พาร์ทไทม์	part time	
+พาร์เซก	parsec	True
+พาวเวอร์	power	True
+พาสตา	pasta	True
+พาสต้า	pasta	
+พาสปอร์ต	passport	True
+พาสเวิร์ด	password	
+พาเมล่า	pamela	
+พาโกไดต์	pagodite	True
+พิก	pick	True
+พิกซาร์	pixar	True
+พิกอัป	pickup	True
+พิกเชอร์	picture	True
+พิกเซล	pixel	
+พิกโนมิเตอร์	pycnometer	True
+พิจิโอไนต์	pigeonite	True
+พิซซา	pizza	True
+พิดมอนไทต์	piedmontite	True
+พิตชิงเวดจ์	pitching wedge	True
+พิตช์เบลนด์	pitchblende	True
+พิตบุล	pit bull	True
+พิตบูล	pit bull	
+พิตบูลล์	pit bull	
+พิตบูลเทอร์เรีย	pit bull terrier	
+พิทบูล	pit bull	
+พินโนไอต์	pinnoite	True
+พิร์โรไทต์	pyrrhotite	True
+พิโครเมอไรต์	picromerite	True
+พิโคไทต์	picotite	True
+พีก	peak	True
+พีช	peach	True
+พีระมิด	pyramid	True
+พูเซอไรต์	pucherite	True
+พ็อกเกตบุ๊ก	pocket book	True
+พ็อดคาสต์	podcast	
+พ็อดแคสต์	podcast	
+พ็อป	pop	True
+พ็อปคอร์น	popcorn	True
+พ็อปพิวลาร์	popular	True
+พ็อปอัป	pop up	True
+ฟรักโทส	fructose	True
+ฟรี	free	True
+ฟรีเดไลต์	friedelite	True
+ฟรุตสลัด	fruit salad	True
+ฟรุตเค้ก	fruit cake	True
+ฟลอปปีดิสก์	floppy disk	
+ฟลอร์	floor	True
+ฟลอร์เอ็กเซอร์ไซส์	floor exercise	True
+ฟลามิงโก	flamingo	
+ฟลินต์	flint	True
+ฟลูก	fluke	True
+ฟลูต	flute	True
+ฟลูออรีน	fluorine	True
+ฟลูออร์สปาร์	fluorspar	True
+ฟลูออร์อะพาไทต์	fluorapatite	True
+ฟลูออโรริชเทอไรต์	fluororichterite	True
+ฟลูออไรต์	fluorite	True
+ฟลูโอซีไรต์	fluocerite	True
+ฟลูโอบอไรต์	fluoborite	True
+ฟอนต์	font	
+ฟอร์กลิฟต์	forklift	True
+ฟอร์จูน พาร์ท อินดัสตรี้	fortune parts industry	
+ฟอร์มาลดีไฮด์	formaldehyde	True
+ฟอร์มาลิน	formalin	True
+ฟอร์สเตอไรต์	forsterite	True
+ฟอลคอน	falcon	True
+ฟอลโลว์	follow	True
+ฟอสจีไนต์	phosgenite	True
+ฟอสฟอรัส	phosphorus	True
+ฟอสฟอไรต์	phosphorite	True
+ฟอสฟูฟิลไลต์	phosphophyllite	True
+ฟอสฟูแรนิไลต์	phosphuranylite	True
+ฟอสเฟต	phosphate	True
+ฟังก์ชัน	function	True
+ฟังก์ชั่น	function	False
+ฟาทอม	fathom	True
+ฟายาไลต์	fayalite	True
+ฟาร์ม	farm	True
+ฟาร์มาซูทิคัล	pharmaceutical	True
+ฟาร์มาโคซิเดอไรต์	phamacosiderite	True
+ฟาร์มาโคไลต์	pharmacolite	True
+ฟาลคอน	falcon	True
+ฟาวล์	fowl	True
+ฟาสซิสต์	fascist	True
+ฟาสต์ฟูด	fast food	True
+ฟาสต์เลน	fast lane	True
+ฟิกซ์	fix	True
+ฟิตติง	fitting	True
+ฟิลลิปไซต์	phillipsite	True
+ฟิลเตอร์	filter	True
+ฟิล์ม	film	True
+ฟิวส์	fuse	True
+ฟิสิกส์	physics	True
+ฟีดแบ็ก	feedback	True
+ฟีลด์	field	True
+ฟีเชอร์	feature	True
+ฟีเดลอไรต์	fiedlerite	True
+ฟุกไซต์	fuchsite	True
+ฟุต	foot	True
+ฟุตบอล	football	True
+ฟุตพาท	footpath	True
+ฟุลกาไรต์	fulgarite	True
+ฟุลสแก๊ป	foolscap	True
+ฟูด	food	True
+ฟูมิโอะ คิชิดะ	岸田文雄	True
+มรกต	emerald	True
+มอกเทซูไมต์	moctezumite	True
+มอคค่า	mocha	False
+มองโกลอยด์	mongoloid	True
+มองโกเลีย	mongolia	True
+มอตทราไมต์	mottramite	True
+มอนต์มอริลโลไนต์	montmorillonite	True
+มอนทิบราไซต์	montebrasite	True
+มอนทิเซลไลต์	monticellite	True
+มอนิเตอร์	monitor	
+มอยส์ซอไนต์	moissanite	True
+มอยส์เชอไรเซอร์	moisturizer	True
+มอร์นิง	morning	True
+มอร์ฟีน	morphine	True
+มอร์เดไนต์	mordenite	True
+มอร์แกไนต์	morganite	True
+มอลดาไวต์	moldavite	True
+มอลต์	malt	
+มอลโทส	maltose	True
+มอเซลแลนดส์เบอร์ไกต์	moschellandsbergite	True
+มอเตอร์	motor	True
+มอเตอร์ไซค์	motorcycle	True
+มอเรียน	morion	True
+มะกะโรนี	macaroni	True
+มัก	mug	True
+มักกะโรนี	macaroni	True
+มัคคิอาโต	macchiato	False
+มัทฉะ	matcha	False
+มันนี	money	True
+มัฟฟินเรซินเค้ก	muffin raisin cake	True
+มัมมี่	mummy	True
+มัลแวร์	malware	
+มัสตาร์ด	mustard	True
+มัสลิน	muslin	True
+มัสโคไวต์	muscovite	True
+มากาเร็ท	margaret	
+มาดริด	madrid	
+มายด์เซต	mindset	
+มายองเนส	mayonnaise	
+มายเซ็ต	mindset	
+มายเซ็ท	mindset	
+มาริโอ	mario	
+มาริโอ้	mario	
+มาริโอ้ เมาเร่อ	mario maurer	
+มาร์กาไรต์	margarite	True
+มาร์ค	mark	
+มาร์คาไซต์	marcasite	True
+มาร์จิน	margin	True
+มาร์ช แฮร์	marsh hair	
+มาร์ติน ลูเธอร์ คิง	martin luther king	
+มาร์มาไทต์	marmatite	True
+มาร์เกต	market	True
+มาร์เก็ต	market	True
+มาร์เวล	marvel	True
+มาร์ไทต์	martite	True
+มาลาไคต์	malachite	True
+มาสก์	mask	True
+มาเลย์ไอต์	malayaite	True
+มิกซ์	mix	True
+มิกไซต์	mixite	True
+มินา	mina	
+มินาสเจไรไซต์	minasgeraisite	True
+มิราบิไลต์	mirabilite	True
+มิลก์	milk	True
+มิลค์	milk	False
+มิลลิบาร์	millibar	True
+มิลลิไซต์	millisite	True
+มิลาไรต์	milarite	True
+มิลเลอร์ไรต์	millerrite	True
+มิวสิก	music	True
+มิสเตอร์	mr.	
+มิสเตอร์บีน	mr. bean	
+มิเกล เด เซร์บันเตส	miguel de cervantes	
+มิเตอร์	meter	True
+มิเนียม	minium	True
+มิเมทีน	mimetene	True
+มิเมทีไซต์	mimetesite	True
+มิเมไทต์	mimetite	True
+มิ้ลค์	milk	False
+มีต	meet	True
+มีตแอนด์กรีต	meet and greet	True
+มีม	meme	True
+มีเทน	methane	True
+มุลไลต์	mullite	True
+ม็อบ	mob	
+ยอช์ต	yacht	True
+ยอร์ช	yacht	
+ยาฮู	yahoo	
+ยิปซัม	gypsum	True
+ยิปซี	gypsy	True
+ยิมนาสติก	gymnastic	True
+ยีน	jean	True
+ยีนส์	jeans	
+ยีลด์	yield	True
+ยีสต์	yeast	True
+ยุกสพอไรต์	yuksporite	True
+ยุโรป	europe	True
+ยูคริปไทต์	eucryptite	True
+ยูซีไนต์	euxenite	True
+ยูดิดิไมต์	eudidymite	True
+ยูทาห์ไลต์	utahlite	True
+ยูทูบ	youtube	
+ยูทูบเบอร์	youtuber	True
+ยูนาไคต์	unakite	True
+ยูนิค เอ็นจิเนียริ่ง แอนด์ คอนสตรัคชั่น	unique engineering and construction	
+ยูนิคอร์น	unicorn	
+ยูนิต	unit	
+ยูฟ่า	uefa	True
+ยูรานอเซอร์ไคต์	uranocircite	True
+ยูราโนแทนทาไลต์	uranotantalite	True
+ยูเคลส	euclase	True
+ยูเดียไลต์	eudialite	True
+ยูเนี่ยน เพาเวอร์	union power	True
+ยูเนี่ยนเพาเวอร์	union power	True
+ยูเรนัส	uranus	True
+ยูเรนิไนต์	uraninite	True
+ยูเรเชีย	eurasia	True
+ยูเรเนียม	uranium	True
+ยูเลกไซต์	ulexite	True
+ยูเวนตุส	juventus	
+ยูเอสบี	usb	True
+ยูแรโนเฟน	uranophane	True
+ยูโทเปีย	utopia	
+ยูโรปอยด์	europid	
+ยูโรเพียม	europium	True
+ยูไวต์	uvite	True
+รอยเตอร์	reuters	
+รักบี้	rugby	
+รัทเทอร์ฟอร์เดียม	rutherfordium	True
+รัมมี่	rummy	True
+ราสป์เบอร์รี	raspberry	True
+ริคาร์โด	ricardo	
+ริคาร์โด คาร์เรเร	ricardo carrere	
+ริชาร์ด	richard	True
+ริชเทอไรต์	richterite	True
+ริบบิ้น	ribbon	True
+ริสต์	wrist	True
+ริเชิร์ด	richard	True
+ริโมตคอนโทรล	remote control	True
+รีดักชัน	reduction	True
+รีทวีต	retweet	
+รีนิไอต์	rheniite	True
+รีพลาย	reply	True
+รีม	ream	True
+รีวิว	review	True
+รีสตาร์ต	restart	True
+รีสอร์ต	resort	
+รีสอร์ท	resort	
+รีอัลการ์	realgar	True
+รีเควสต์	request	True
+รีเนียม	rhenium	True
+รีเบกไคต์	riebeckite	True
+รีเฟรช	refresh	True
+รีแลกซ์	relax	True
+รีโมท	remote	
+รีไซเคิล	recycle	
+รีไวนด์	rewind	True
+รูทีเนียม	ruthenium	True
+รูบิเดียม	rubidium	True
+รูบี้	ruby	
+รูมเมท	roommate	
+รูอิน	ruin	True
+รูเบลไลต์	rubellite	True
+รูเล็ตต์	roulette	True
+รูไทล์	rutile	True
+ร็อก	rock	True
+ร็อกบริดไจต์	rockbridgeite	True
+ร็อตเตอร์ดัม	rotterdam	
+ลอการิทึม	logarithm	True
+ลองจิจูด	longitude	True
+ลอตเตอรี่	lottery	True
+ลอนดอน	london	True
+ลอนเชอร์	launcher	True
+ลอริมา	lorimar	True
+ลอริโอไนต์	laurionite	True
+ลอว์ซอไนต์	lawsonite	True
+ลอว์เรนเซียม	lawrencium	True
+ลอสเองเจิลลิส	los angeles	
+ลอเรนเซไนต์	lorenzenite	True
+ละติจูด	latitude	True
+ลัดเลไมต์	ludlamite	True
+ลางไบไนต์	langbeinite	True
+ลาซูไรต์	lazurite	True
+ลาซูไลต์	lazulite	True
+ลาร์เดอเรลไลต์	larderellite	True
+ลาวา	lava	True
+ลาเต้	latte	False
+ลาเท็กซ์	latex	
+ลาเวนเดอร์	lavender	
+ลิกไนต์	lignite	True
+ลิงก์	link	True
+ลิดดิโคไทต์	liddicoatite	True
+ลิตมัส	lithium	True
+ลิทิโอฟอไรต์	lithiophorite	True
+ลิทิโอฟิไลต์	lithiophilite	True
+ลินาไรต์	linarite	True
+ลินิน	linen	True
+ลินุกซ์	linux	
+ลิปซิงก์	lip sinc.	True
+ลิปบาล์ม	lip balm	True
+ลิปสติก	lipstick	True
+ลิฟ	live	True
+ลิฟต์	lift	True
+ลิมิติดอิดิชัน	limited edition	True
+ลิสติ้ง	listing	
+ลิเทียม	lithium	True
+ลิเบเทไนต์	libethenite	True
+ลิโรคอไนต์	liroconite	True
+ลีแกรนไดต์	legrandite	True
+ลีไฟต์	leifite	True
+ลุก	look	True
+ลุดวิไกต์	ludwigite	True
+ลูซอไนต์	luzonite	True
+ลูทีเชียม	lutetium	True
+ลูน่า	luna	
+ลูสพารตส์	loose-parts	True
+ลูโคซีน	leucoxene	True
+ลูโคเฟน	leucophane	True
+ลูโคเฟไนต์	leucophanite	True
+ลูไซต์	leucite	True
+ล็อก	lock	True
+ล็อกดาวน์	lockdown	True
+ล็อกเกต	locket	True
+ล็อกเกอร์	locker	True
+ล็อตเตอรี	lottery	True
+ล็อบบี้	lobby	True
+ล็อบบี้ยิสต์	lobbyist	
+ล็็อก	lock	True
+วอตส์แอปป์	whatsapp	True
+วอนเซไนต์	vonsenite	True
+วอบเบลอร์	wobbler	True
+วอฟเฟิล	waffle	True
+วอร์ม	worm	
+วอร์รูม	war room	True
+วอร์ไดต์	wardite	True
+วอลต์ ดิสนีย์	walt disney	
+วอลบอร์ไทต์	volborthite	True
+วอลล์เปเปอร์	wallpaper	
+วอลล์เพเปอร์	wallpaper	True
+วอลูม	volume	True
+วอลเตอร์ อีเลียส ดิสนีย์	walter elias disney	
+วอลเพอร์ไจต์	walpurgite	True
+วอลเลย์บอล	volley ball	True
+วอลเล่ย์บอล	volley ball	False
+วอล์ก	walk	True
+วอล์กอิน	walk-in	True
+วอล์กเอาต์	walk out	True
+วัคซีน	vaccine	True
+วัตต์	watt	True
+วันเดย์	one day	
+วาคอม	wacom	
+วาติกัน	vatican	
+วานาดิไนต์	vanadinite	True
+วายฟาย	wi-fi	True
+วาริสไซต์	variscite	True
+วาร์ลามอฟไฟต์	varlamoffite	True
+วาล์ว	valve	True
+วาเนเดียม	vanadium	True
+วาเลนไทน์	valentine	
+วิกตอเรีย	victoria	
+วิกิ	wiki	
+วิกิพีเดีย	wikipedia	True
+วิกิลีกส์	wikileaks	
+วิดิโอ	video	False
+วิดีโอ	vdo	
+วิดีโอ	video	True
+วิดีโอคลิป	video clip	True
+วิดีโอคอล	video call	True
+วิดเจ็ต	widget	True
+วิตล็อกไทต์	whitlockite	True
+วิตามิน	vitamin	True
+วิตามินบี 1	vitamin b 1	True
+วินเทจ	vintage	
+วินเนอร์กรุ๊ป เอ็นเตอร์ไพรซ์	winner group enterprise	True
+วินโดวส์	windows	
+วินโดวส์วิสตา	windows vista	
+วินโดวส์เอ็กซ์พี	windows xp	
+วิปปิงครีม	whipping cream	True
+วิลอซิแร็ปเตอร์	velociraptor	True
+วิลเลจดรัม	village drum	True
+วิลเลียม	william	
+วิลเลไมต์	willemite	True
+วิว	view	
+วิสกี้	whisky	True
+วิสตา	vista	
+วิสเทค	vistec	True
+วิเทอไรต์	witherite	True
+วิเวียไนต์	vivianite	True
+วีก	week	True
+วีซูเวียไนต์	vesuvianite	True
+วีดีโอ	video	
+วีต์ไชต์	veatchite	True
+วีแชต	wechat	True
+วุดเฮาไซต์	woodhouseite	True
+วุลฟีไนต์	wulfenite	True
+วุลแฟรม	wolfram	True
+วุลแฟรไมต์	wolframite	True
+วุลไฟต์	wolfeite	True
+วูสไทต์	wuestite	True
+วูสไทต์	wustite	True
+ว็อกไซต์	vauxite	True
+สกริปต์	script	True
+สกลอดอว์สไกต์	sklodowskite	True
+สกวิด	squid	True
+สกอร์ซาไลต์	scorzaalite	True
+สกอลิไซต์	scolecite	True
+สกอโรไดต์	scorodite	True
+สกี	ski	True
+สกุตเทอรูไดต์	skutterudite	True
+สกูป	scoop	True
+สคริปต์	script	
+สคัดเดอร์	scudder	
+สตรอนเชียม	strontium	True
+สตรอนเชียไนต์	strontianite	True
+สตรอว์เบร์รี	strawberry	True
+สตรอว์เบอร์รี	strawberry	True
+สตรอว์เบอร์รี่	strawberry	False
+สตรอเบอร์รี่	strawberry	
+สตรันไซต์	strunzint	True
+สตริกนิน	strychnine	True
+สตรีตฟูด	street food	True
+สตรีมมิ่ง	streaming	
+สตรูเวอร์ไรต์	struverite	True
+สตอร์	store	True
+สตอร์มเซิร์จ	storm surge	True
+สตอเบอร์รี่	strawberry	
+สตอโรไลต์	staurolite	True
+สตัน	stun	True
+สตันต์แมน	stuntman	True
+สตัฟ	stuff	True
+สตัฟฟ์	stuff	True
+สตัสส์เฟอร์ไทต์	stassfurtite	True
+สตาฟ	staff	True
+สตาร์	star	True
+สตาร์ต	start	True
+สตาร์ตอัป	start-up	True
+สตาร์ตอัป	startup	True
+สตาร์ทอัพ	startup	False
+สติกเกอร์	sticker	True
+สติชไทต์	stichtite	True
+สติบาร์เซน	stibarsen	True
+สติบิโคไนต์	stibiconite	True
+สติบิโอแทนทาไลต์	stibiotantalite	True
+สติบไนต์	stibnite	True
+สติลไบต์	stilbite	True
+สติแรโคซอรัส	styracosaurus	True
+สติโชไวต์	stishovite	True
+สตีฟ จ็อบส์	steve jobs	
+สตีฟ บัลเมอร์	steve ballmer	
+สตีไทต์	steatite	True
+สตู	stew	True
+สตูดิโอ	studio	
+สต็อก	stock	True
+สต๊อก	stock	
+สปริง	spring	True
+สปอดูมีน	spodumene	True
+สปอต	spot	True
+สปอติฟาย	spotify	True
+สปอตไลต์	spotlight	True
+สปอนเซอร์	sponsor	True
+สปอยล์	spoil	True
+สปอร์	spore	True
+สปอร์ต	sport	True
+สปอร์ตไรเดอร์	sport rider	
+สปา	spa	True
+สปายแวร์	spyware	
+สปาเกตตี	spaghetti	True
+สปาเกตตี	spaghetti 	
+สปินเอาต์	spin out	True
+สปิเนล	spinel	True
+สปีดโบต	speedboat	True
+สปุตนิก ไลท์	sputnik light	
+สป็อต	spot	True
+สป็อตไลต์	spotlight	True
+สฟาเลอไรต์	sphalerite	True
+สฟีน	sphene	True
+สฟีโรโคบอลไทต์	sphaerocobaltite	True
+สมอลไทต์	smaltite	True
+สมาร์ต	smart	True
+สมาร์ตการ์ด	smart card	True
+สมาร์ตวอตช์	smart watch	
+สมาร์ตโฟน	smart phone	True
+สมาร์ตโฟน	smartphone	True
+สมาร์ทโฟน	smart phone	False
+สมาร์ทโฟน	smartphone	
+สมิท	smith	
+สมิทซอไนต์	smithsonite	True
+สมูทตี้	smoothie	False
+สมูทที	smoothie	True
+สยามสปอร์ต ซินดิเคต	siam sport syndicate	
+สวิตช์	switch	True
+สวิตซ์	switch	
+สวิสเซอร์แลนด์	switzerland	
+สวีต	suite	True
+สวีต	sweet	True
+สะวันนา	savanna	True
+สังกะสี	zinc	True
+สารหนู	arsenic	True
+สเกต	skate	True
+สเกตช์	sketch	True
+สเตจ	stage	True
+สเตซี่	stacy	
+สเตซี่ย์	stacy	
+สเตนเลส	stainless	True
+สเตนเลสสตีล	stainless steel	True
+สเตป	step	True
+สเตฟาไนต์	stephanite	True
+สเตย์	stay	True
+สเตรนไจต์	strengite	True
+สเตร็ปโทค็อกคัส	streptococcus	True
+สเตลเลอไรต์	stellerite	True
+สเตอรอล	sterol	True
+สเตอร์มาไนต์	sturmanite	True
+สเตโกซอรัส	stegosaurus	True
+สเต็ป	step	True
+สเต๊ก	steak	True
+สเปก	spec	
+สเปกตรัม	spectrum	True
+สเปกโทรสโกป	spectroscope	True
+สเปค	spec	True
+สเปรย์	spray	True
+สเปสซาร์ทีน	spessartine	True
+สเปสซาร์ไทต์	spessertite	True
+สเปอร์ริไลต์	sperrylite	True
+สเปอร์ไรต์	spurrite	True
+สเป็ก	spec	True
+สเป็ค	spec	
+สเมกไทต์	smectite	True
+สเลต	slate	True
+สเวต	sweat	True
+สเวตเตอร์	sweater	
+สแกน	scan	True
+สแกนเดียม	scandium	True
+สแกนเนอร์	scanner	
+สแกโพไลต์	scapolite	True
+สแคร์โคร์ว	scarecrow	
+สแควร์รูต	square root	True
+สแตนดาร์ด	standard	True
+สแตนดี	standy	True
+สแตนด์	stand	True
+สแตนเดิร์ด	standard	True
+สแตนไนต์	stannite	True
+สแตฟ	staff	True
+สแตมป์	stamp	False
+สแนป	snap	
+สแปนโกไลต์	spangolite	True
+สแปม	spam	
+สแล็ก	slag	True
+สแวนเบอร์ไจต์	svanbergite	True
+สโตรโบสโคป	stroboscope	True
+สโนว์บอร์ด	snowboard	True
+สไกป์	skype	True
+สไตลิสต์	stylist	
+สไตล์	style	
+สไปก์	spike	True
+สไปซี	spicy	True
+สไปโนซอรัส	spinosaurus	True
+สไลซ์	slice	True
+สไลด์	slide	True
+หยก	jade	True
+หลุยส์	louis	
+อนาคอนดา	anaconda	
+อลิซ	alice	
+อลิซาเบธ	elizabeth	
+อลิส	alice	
+อลิสซาเบธ	elizabeth	
+อลิสัน	alison	
+อวทาร์	avatar	True
+ออกซิเจน	oxygen	True
+ออกซิเดชัน	oxidation	True
+ออกไซด์	oxide	True
+ออตเทรไลต์	ottrelite	True
+ออตโต	otto	
+ออทิสติก	autism	
+ออทูไนต์	autunite	True
+ออนซ์	ounce	True
+ออนไลน์	online	
+ออปติซอร์บ	optisorb	True
+ออฟฟิซ	office	False
+ออฟฟิศ	office	True
+ออฟเฟรไทต์	offretite	True
+ออฟไลน์	offline	
+ออมฟาไซต์	omphacite	True
+ออราเคิล	oracle	
+ออริคาลไซต์	aurichalcite	True
+ออร์กาไนเซอร์	organizer	True
+ออร์บิต	orbit	True
+ออร์พิเมนต์	orpiment	True
+ออร์เซไลต์	orcelite	True
+ออร์เดอร์	order	True
+ออร์แกนิก	organic	True
+ออร์แกนิค	organic	
+ออร์โทเคลส	ortoclase	True
+ออร์ไทต์	orthite	True
+ออล	all	True
+ออลดริน	aldrin	True
+ออสทิไนต์	austinite	True
+ออสบอร์ไนต์	osbornite	True
+ออสเมียม	osmium	True
+ออเจไลต์	augelite	True
+ออโต	auto	True
+ออไจต์	augite	True
+อะกัลมาโทไลต์	agalmatolite	True
+อะคริลิก	acrylic	True
+อะความารีน	aquamarine	True
+อะซูร์มาลาไคต์	azurmalachite	True
+อะซูไรต์	azurite	True
+อะดรีนัล	adrenal	True
+อะดรีนาลิน	adrenalin	True
+อะดอนิส	adonis	True
+อะดูลาเรีย	adularia	True
+อะตอม	atom	True
+อะทาคาไมต์	atacamite	True
+อะนอร์โทเคลส	anorthoclase	True
+อะนอร์ไทต์	anorthite	True
+อะนาลไซต์	analcite	True
+อะนาลไซม์	analcime	True
+อะนาเทส	anatase	True
+อะนิว	anew	True
+อะนีเมีย	anaemia	True
+อะนู	anew	True
+อะพาร์ตเมนต์	apartment	True
+อะพาไทต์	apatite	True
+อะมีบา	amoeba	True
+อะม็อกซิซิลลิน	amoxicillin	True
+อะราบิกา	arabica	True
+อะราโกไนต์	aragonite	True
+อะลอง	along	True
+อะลัม	alum	True
+อะลาบาสเตอร์	alabaster	True
+อะลาแบนไดต์	alabandite	True
+อะลูมิเนียม	aluminium	True
+อะลูไนต์	alunite	True
+อะเกต	agate	True
+อะเซทิลีน	acetylene	True
+อะเดล	adele	
+อะเมซิง	amazing	True
+อะเมริเซียม	americium	True
+อะเลกซานไดรต์	alexandrite	True
+อะเวนจูรีน	aventurine	True
+อะแควเรียม	aquarium	True
+อะแควเรียส	aquarius	True
+อะแด็ปเตอร์	adapter	True
+อะแพชี	apache	True
+อะแพโทซอรัส	apatosaurus	True
+อะแมลกัม	amalgam	True
+อะโกโกเบล	agogo bell	True
+อะโครไอต์	achroite	True
+อะโซโพรไอต์	azoproite	True
+อะโดนิส	adonis	True
+อะโดบี	adobe	True
+อะโพฟิลไลต์	apophyllite	True
+อะโรมา	aroma	True
+อะโลน	alone	True
+อะไรส์	arise	True
+อังสตรอม	angstrom	True
+อัปเกรด	upgrade	True
+อัปเดต	update	True
+อัปโหลด	upload	True
+อัพเกรด	upgrade	
+อัพเดต	update	False
+อัพเดท	update	False
+อัพโหลด	upload	False
+อัลคาไลน์	alkaline	
+อัลตราซาวนด์	ultrasound	True
+อัลตราไวโอเลต	ultraviolet	True
+อัลตร้าไวด์	ultra-wide	
+อัลติเมต	ultimate	True
+อัลบั้ม	album	True
+อัลปากา	alpaca	True
+อัลฟ่า	alpha	
+อัลลอย	alloy	True
+อัลล์มันไนต์	ullmannite	True
+อัลเบิร์ดไอน์สไตน์	albert einstein	
+อาการ์	agar	True
+อาควา	aqua	True
+อาซาร์	azar	
+อาบิเกล	abigail	
+อาฟเตอร์	after	True
+อามอนด์	almond	True
+อารบิก	arabic	
+อาร์ก	arc	True
+อาร์กติก	arctic	
+อาร์กอน	argon	True
+อาร์คีอ็อปส์เทริกซ์	archaeopteryx	True
+อาร์จิโรไดต์	argyrodite	True
+อาร์ต	art	True
+อาร์ทิไนต์	artinite	True
+อาร์ฟเวดโซไนต์	arfvedsonite	True
+อาร์ม	arm	True
+อาร์มิเจอร์	armiger	True
+อาร์มแชร์	armchair	True
+อาร์เคน	arcane	True
+อาร์เจนโทไพไรต์	argentopyrite	True
+อาร์เจนไทต์	argentite	True
+อาร์เซนต์ซูเมไบต์	arsentsumebite	True
+อาร์เซนัล	arsenal	True
+อาร์เซนิก	arsenic	True
+อาร์เซโนไพไรต์	arsenopyrite	True
+อาร์เซโนไลต์	arsenolite	True
+อาร์เทอไรต์	arthurite	True
+อาร์เมอร์	armor	True
+อาร์เมอร์	armour	True
+อาร์แคไนต์	arcanite	True
+อาร์โก	argot	True
+อาร์โกต์	argot	True
+อาลดริน	aldrin	True
+อาลมอนด์	almond	True
+อาลาการ์ต	a la carte	True
+อาเซติคแอนไฮไดรด์	acetic anhydride	
+อาเซติลคลอไรด์	acetyl chloride	
+อาเซียน	asean	True
+อาเมน	amen	True
+อาเรีย	aria	True
+อาแคนไทต์	acanthite	True
+อาแรบิกา	arabica	True
+อาโวคาโด	avocado	True
+อิกซิโอไลต์	ixiolite	True
+อิกวานา	iguana	True
+อิกวาโนดอน	iguanodon	True
+อิดดิงไซต์	iddingsite	True
+อิดิชัน	edition	True
+อิตเทรียม	yttrium	True
+อิตเทอร์เบียม	ytterbium	True
+อิตโทรแทนทาไลต์	yttrotantalite	True
+อินจอย	enjoy	True
+อินซูลิน	insulin	True
+อินดัสตรี	industry	True
+อินดิเคเตอร์	indicator	True
+อินดิโกไลต์	indigolite	True
+อินดิโคไลต์	indicolite	True
+อินทราเน็ต	intranet	
+อินบอกซ์	inbox	True
+อินบ็อกซ์	inbox	True
+อินฟราเรด	infrared	True
+อินสตาแกรม	instagram	
+อินเดอร์บอไรต์	inderborite	True
+อินเดอไรต์	inderite	True
+อินเดียม	indium	True
+อินเตอร์คอม	intercom	True
+อินเตอร์เน็ต	internet	False
+อินเตอร์เฟส	interface	
+อินเทล	intel	
+อินเทอร์พรีเตอร์	interpreter	
+อินเทอร์เน็ต	internet	True
+อินเนอร์	inner	True
+อินโฟกราฟิก	infographic	True
+อินโยไอต์	inyoite	True
+อิมพัลส์	impulse	
+อิมมิวโนโกลบิวลิน	immunoglobulin	True
+อิมัลชัน	emulsion	True
+อิมเมจ	image	
+อิริเดียม	iridium	True
+อิลวาไอต์	ilvaite	True
+อิลเมไนต์	ilmenite	True
+อิลไลต์	illite	True
+อิหม่าม	imam	True
+อิเนไซต์	inesite	True
+อิเล็กตรอน	electron	True
+อิเล็กทรอนิกส์	electronics	True
+อิเล็กโทน	electone	True
+อิเล็คทรอนิกส์	electronics	
+อิเวนต์	event	True
+อิแลสโมซอรัส	elasmosaurus	True
+อีคอมเมิร์ซ	e-commerce	True
+อีจิรีน	aegirite	True
+อีจิส	aegis	True
+อีจิไรต์	aegirite	True
+อีนาร์ไกต์	enargite	True
+อีบุ๊ก	e-book	
+อีบุ๊ก	ebook	
+อีริค ชมิดต์	eric schmidt	
+อีริโทรไมซิน	erythromycin	True
+อีริโอไนต์	erionite	True
+อีริไทรต์	erythrite	True
+อีสเตอร์	easter	
+อีออน	aeon	True
+อีเดไนต์	edenite	True
+อีเทอร์	ether	True
+อีเธอเรียม	ethereum	
+อีเบย์	ebay	
+อีเมล	e-mail	True
+อีเมล	email	True
+อีเมลล์	e-mail	False
+อีเมล์	e-mail	False
+อีเลกทรัม	electrum	True
+อีเลิร์นนิง	e-learning	
+อีแมกะซีน	e-magazine	
+อีโอสฟอไรต์	eosphorite	True
+อูบุนตู	ubuntu	
+อูราลบอไรต์	uralborite	True
+อูราไลต์	uralite	True
+อูวาโรไวต์	uvarovite	True
+อเดลล์	adele	
+อเมซอน	amazon	
+อเมริกันฟุตบอล	american football	
+อโดบี	adobe	
+อ็อปชัน	option	True
+ฮอกกี้	hockey	True
+ฮอดจ์คินซอไนต์	hodgkinsonite	True
+ฮอป	hop	
+ฮอยน์	hauyne	True
+ฮอยไนต์	hauynite	True
+ฮอร์นเบลนด์	hornblende	True
+ฮอร์โมน	hormone	True
+ฮอลลีวูด	hollywood	
+ฮอลันดา	hollanda	True
+ฮอลแลนด์	holland	True
+ฮอลแลนไดต์	hollandite	True
+ฮอโลแกรม	hologram	True
+ฮันนีมูน	honeymoon	
+ฮันไทต์	huntite	True
+ฮับ	hub	
+ฮัสเซียม	hassium	True
+ฮั่น	hun	True
+ฮาร์ดดิสก์	hard disk	True
+ฮาร์ดดิสก์	harddisk	
+ฮาร์ดิสโทไนต์	hardystonite	True
+ฮาร์ดแวร์	hardware	True
+ฮาร์ดไดรฟ์	hard drive	
+ฮาร์ต	heart	True
+ฮาร์โมโทม	harmotome	True
+ฮาลลอยไซต์	halloysite	True
+ฮาลโลวีน	halloween	True
+ฮาวาย	hawaii	
+ฮาวไลต์	howlite	True
+ฮาห์เนียม	hahnium	True
+ฮาเร็ม	harem	True
+ฮาโรลด์	harold	
+ฮาโลวีน	halloween	
+ฮิดเดไนต์	hiddenite	True
+ฮินส์ดาไลต์	hinsdalite	True
+ฮิปฮอป	hip hop	True
+ฮิปโปโปเตมัส	hippopo-tamus	True
+ฮิพฮอพ	hip hop	False
+ฮิวแลนไดต์	heulandite	True
+ฮิวโรไลต์	hureaulite	True
+ฮิวไมต์	humite	True
+ฮิสทรี	history	True
+ฮิสทีเรีย	hysteria	True
+ฮีมาทีน	hematine	True
+ฮีมาไทต์	hematite	True
+ฮีลิโอโทรป	heliotrope	True
+ฮีเซลวูไดต์	heazlewoodite	True
+ฮีเลียม	helium	True
+ฮีเวลไลต์	whewellite	True
+ฮีโร	hero	True
+ุโพสต์	post	
+เกตเวย์	gateway	True
+เกม	game	True
+เกม	games	
+เกมส์	game	False
+เกมโชว์	game show	True
+เกย์ลุสไซต์	gaylussite	True
+เกราไทต์	groutite	True
+เกรแฮม	graham	
+เกลาเบอไรต์	glauberite	True
+เกอร์สดอร์ฟไฟต์	gersdorffite	True
+เกอไทต์	goethite	True
+เกาต์	gout	True
+เกาลิน	kaolin	True
+เกียร์	gear	True
+เคจ	cage	True
+เคซีน	casein	True
+เคน	cane	True
+เคป	cape	True
+เคป๊อป	k-pop	
+เคพอน	capon	True
+เคฟ	cave	True
+เครดิต	credit	True
+เครนเนอไรต์	krennerite	True
+เคราเวย์	caraway	True
+เคร์ริจ	carriage	True
+เคร์รี	carry	True
+เคร์เรียน	carrion	True
+เคร์เรียร์	carrier	True
+เคลนส์	cleanse	True
+เคลนเซอร์	cleanser	True
+เคลฟ	clef	True
+เคลม	claim	True
+เคลย์	clay	True
+เคลย์มอร์	claymore	True
+เคลริก	cleric	True
+เคลอร์จี	clergy	True
+เคลิร์ก	clerk	True
+เคลี	ceilidh	True
+เคลียร์	clear	True
+เคส	case	True
+เคอร์ซูไทต์	kaersutite	True
+เคอร์ฟิว	curfew	
+เคอร์มิไซต์	kermesite	True
+เคอร์เซอร์	cursor	True
+เคอร์เนล	kernel	
+เคอร์ไนต์	kernite	True
+เคออติก	chaotic	True
+เคออส	chaos	True
+เคอเรียร์	career	True
+เคานต์ดาวน์	countdown	True
+เคาน์เตอร์	counter	True
+เคเดอร์	cadre	True
+เคเตอริง	catering	True
+เคเตอร์	cater	True
+เคเบอร์	caber	True
+เคเบิล	cable	True
+เคโอลิไนต์	kaolinite	True
+เคไนน์	canine	True
+เค้ก	cake	True
+เงิน	silver	True
+เจด	jade	True
+เจดา	jada	True
+เจนนิเฟอร์	jennifer	
+เจนีวา	geneva	
+เจมซอไนต์	jamesonite	True
+เจอร์เบรา	gerbera	True
+เจอร์เมเนียม	germanium	True
+เจเนอเรชัน	generation	True
+เจไดต์	jadeite	True
+เชงเดไอต์	chengdeite	True
+เชน	chain	True
+เชนจ์	change	True
+เชนซอว์	chainsaw	True
+เชฟ	chef	True
+เชฟรอน	chevron	True
+เชฟโรเลต	chevrolet	True
+เชมเบอร์	chamber	True
+เชรับ	cherub	True
+เชรับ	cherubim	True
+เชริช	cherish	True
+เชริตี	charity	True
+เชริล	cheryl	True
+เชร์รี	cherry	True
+เชลซี	chelsea	True
+เชลฟ์	shelf	True
+เชลแล็ก	shellac	True
+เชลโล	cello	True
+เชส	chase	True
+เชส	chess	True
+เชสซิไลต์	chessylite	True
+เชสต์	chaste	True
+เชสต์	chest	True
+เชสต์นัต	chestnut	True
+เชสนัต	chestnut	True
+เชสเตอร์	chester	True
+เชอนีล	chenille	True
+เชอรี่	cherry	
+เชอร์ชิลล์	churchill	True
+เชอร์มาไคต์	tschermakite	True
+เชอร์รี่	cherry	
+เชอร์เบต	sherbet	True
+เชอร์ไชต์	churchite	True
+เชิร์ช	church	True
+เชิร์ต	chert	True
+เชิร์น	churn	True
+เชิร์ป	chirp	True
+เชิ้ต	shirt	True
+เชียร์	cheer	True
+เชียร์ลีดเดอร์	cheerleader	True
+เชเรียต	chariot	True
+เช็ก	check	True
+เช็กลิสต์	checklist	True
+เช็กเมต	checkmate	True
+เช็ค	cheque	True
+เซต	set	True
+เซนติกรัม	centigramme	True
+เซนติพีด	centipede	True
+เซนติลิตร	centilitre	True
+เซนติเกรด	centigrade	True
+เซนติเมตร	centimetre	True
+เซนต์	cent	True
+เซนทรัม	centrum	True
+เซนทรัล	central	True
+เซนทริโน	centrino	
+เซนทอร์	centaur	True
+เซนาร์มอนไทต์	senarmontite	True
+เซนเชอรี	century	True
+เซนเซอร์	censer	True
+เซนเซอร์	censor	True
+เซนเซอร์	sensor	
+เซนเตอร์	center	True
+เซนเตอร์	centre	True
+เซนเฟลไดต์	sainfeldite	True
+เซฟ	save	
+เซรัฟ	seraph	True
+เซรัฟ	seraphim	True
+เซรัสไซต์	cerussite	True
+เซรามิก	ceramic	
+เซราร์จีไรต์	cerargyrite	True
+เซราโทซอรัส	ceratosaurus	True
+เซริโมนี	ceremony	True
+เซริไซต์	sericite	True
+เซล	sale	True
+เซลฟี	selfie	True
+เซลฟี่	selfie	
+เซลลูลอยด์	celluloid	True
+เซลลูโลส	cellulose	True
+เซลล์	cell	True
+เซลาโดไนต์	celadonite	True
+เซลเซียส	celsius	True
+เซลเลไอต์	sellaite	True
+เซอรูเลียน	cerulean	True
+เซอร์ แฮรี่	sir harry	
+เซอร์คลิต	circlet	True
+เซอร์คอน	zircon	True
+เซอร์คัส	circus	True
+เซอร์ซี	circe	True
+เซอร์ทิฟิเคต	certificate	True
+เซอร์ทิฟิเคิต	certificate	True
+เซอร์เคล็ต	circlet	True
+เซอร์เคิล	circle	True
+เซอร์เคเดียน	circadian	True
+เซอร์เบอรัส	cerberus	True
+เซอร์เพนทีน	serpentine	True
+เซอร์โคเนีย	zirconnia	True
+เซอร์โคเนียม	zirconium	True
+เซอร์ไพรส์	surprise	True
+เซอแรนไดต์	serandite	True
+เซานา	sauna	True
+เซิร์ก	cirque	True
+เซิร์ช	search	True
+เซิร์ชชิง	searching	True
+เซิร์ฟเวอร์	server	
+เซิร์ลไซต์	searlessite	True
+เซียนนา	sienna	True
+เซียเรียล	cereal	True
+เซเลบ	celeb	True
+เซเลสไทต์	celestite	True
+เซเลอรี	celery	True
+เซเลไนต์	selenite	True
+เซเว่น ยูทิลิตี้ส์ แอนด์ พาวเวอร์	seven utilities and power	
+เซเว่นอีเลฟเว่น	7-eleven	
+เซ็กซี่	sexy	
+เซ็กซ์	sex	False
+เซ็กส์	sex	
+เซ็นเซอร์	censor	
+เซ็นเซอร์	sensor	
+เดกซ์โทรส	dextrose	True
+เดซิลิตร	decilitre	True
+เดซิเมตร	decimetre	True
+เดดไลน์	deadline	
+เดต	date	True
+เดนมาร์ก	denmark	True
+เดบิวต์	debut	
+เดย์	day	True
+เดลล์	dell	
+เดลิเวอรี	deliveree	
+เดวิด ทิม	david timm	
+เดสก์ท็อป	desktop	
+เดสเซิร์ต	dessert	True
+เดส์	days	True
+เดอะซีรี่ส์	the series	
+เดอะเดลีเมลล์	the daily mail	
+เดเบียน	debian	
+เดโม	demo	True
+เต็นท์	tent	True
+เทก	take	True
+เทกนิค	technic	False
+เทกแคร์	take care	True
+เทกโอเวอร์	take over	True
+เทคนิก	technic	False
+เทคนิค	technic	True
+เทคนิค	technique	True
+เทคนิเกิลน็อกเอาต์	technical knock out	True
+เทคนีเชียม	technetium	True
+เทคโนโลยี	technology	True
+เททราฮีไดรต์	tetrahedrite	True
+เทนนิส	tennis	True
+เทนอไรต์	tenorite	True
+เทนาร์ไดต์	thenardite	True
+เทนิโอไลต์	tainiolite	True
+เทนเซ็นต์	tencent	True
+เทนแนนไทต์	tennantite	True
+เทป	tape	
+เทมเพลต	template	True
+เทมเพล็ต	template	True
+เทรด	trade	
+เทรน	train	
+เทรนด์	trend	
+เทรลเลอร์	trailer	
+เทรุกไกต์	teruggite	True
+เทรโมไลต์	tremolite	True
+เทลลูเรียม	tellurium	True
+เทอม	term	True
+เทอร์คอยส์	turquoise	True
+เทอร์เบียม	terbium	True
+เทอร์โมมิเตอร์	thermometer	True
+เทอร์โมเนไทรต์	thermonatrite	True
+เทอร์โมไดนามิกส์	thermodynamics	True
+เทามาไซต์	thaumasite	True
+เทเลโฟโต้	telephoto	
+เทแรโนดอน	pteranodon	True
+เนกเคดไบค์	naked bike	
+เนกไท	necktie	True
+เนคเทค	nectec	True
+เนตบอล	netball	True
+เนทรอน	natron	True
+เนบิวลา	nebula	True
+เนปจูน	neptune	True
+เนปทูเนียม	neptunium	True
+เนปทูไนต์	neptunite	True
+เนฟิลีน	nephiline	True
+เนสควิโฮไนต์	nesquehonite	True
+เนิร์สเซอรี	nursery	True
+เนียไลต์	nealite	True
+เนเชอร์	nature	True
+เนเชอร์สมูท	nature smooth	True
+เนเธอร์แลนด์	nederland	
+เนโทรไลต์	natrolite	True
+เนไครต์	nacrite	True
+เนไฟรต์	nephrite	True
+เน็กไท	necktie	True
+เน็ตบุ๊ก	netbook	True
+เน็ตเวิร์ก	network	True
+เบก	bake	True
+เบก	beg	True
+เบกเกอร์	beggar	True
+เบคอน	bacon	True
+เบจ	beige	True
+เบซัล	basal	True
+เบซิน	basin	True
+เบซิล	basil	True
+เบซิส	basis	True
+เบด	bed	True
+เบดรุม	bedroom	True
+เบดรูม	bedroom	True
+เบดร็อก	bedrock	True
+เบต	bait	True
+เบตา	beta	True
+เบตาดีน	betadine	
+เบต้า	beta	
+เบน	bane	True
+เบนช์	bench	True
+เบนช์มาร์ก	benchmark	True
+เบนซีน	benzene	True
+เบนด์	bend	True
+เบนสตอไนต์	benstonite	True
+เบนิดิกต์	benedict	True
+เบนิฟิต	benefit	True
+เบนิโทไอต์	benitoite	True
+เบบี	baby	True
+เบย์	bay	True
+เบย์ลโดไนต์	bayldonite	True
+เบรก	brake	True
+เบรก	break	True
+เบรกดานซ์	break dance	True
+เบรกดาวน์	breakdown	True
+เบรกแดนซ์	break dance	True
+เบรซ	brace	True
+เบรด	bread	True
+เบรดไลน์	breadline	True
+เบรน	brain	True
+เบรนสตอร์ม	brainstorm	True
+เบรฟ	brave	True
+เบรสต์	breast	True
+เบระคูดา	barracuda	True
+เบราว์เซอร์	browser	
+เบราไนต์	braunite	True
+เบริง	bearing	True
+เบริล	beryl	True
+เบริลเลียม	beryllium	True
+เบริลโลไนต์	beryllonite	True
+เบรี	bury	True
+เบร์	bare	True
+เบร์	bear	True
+เบร์ฟุต	barefoot	True
+เบร์รี	barry	True
+เบร์รี	berry	True
+เบร์รีมอร์	barrymore	True
+เบร์ฮัก	bearhug	True
+เบร์แบ็ก	bareback	True
+เบร์โรว์	barrow	True
+เบล	bail	True
+เบล	bell	True
+เบลช์	belch	True
+เบลซ	blaze	True
+เบลด	blade	True
+เบลต์	belt	True
+เบลนช์	blench	True
+เบลนด์	blend	True
+เบลนด์	blende	True
+เบลนเดอร์	blender	True
+เบลบอย	bellboy	True
+เบลม	blame	True
+เบลลี	belly	True
+เบลส	bless	True
+เบลสซิง	blessing	True
+เบลอร์	blur	True
+เบลาส์	blouse	True
+เบลูกา	beluga	True
+เบลเซอร์	blazer	True
+เบลเยียม	belgium	
+เบลเยี่ยม	belgium	
+เบลโลว์	bellow	True
+เบส	base	True
+เบส	bass	True
+เบสต์	best	True
+เบสต์เซลเลอร์	bestseller	True
+เบสบอล	baseball	True
+เบสิก	basic	True
+เบสเมนต์	basement	True
+เบสไลน์	baseline	True
+เบอร์คีเลียม	berkelium	True
+เบอร์ซาร์	bursar	True
+เบอร์ดี	birdie	True
+เบอร์ตี้	bertie	
+เบอร์ทิไรต์	berthierite	True
+เบอร์นิช	burnish	True
+เบอร์มิวดา	bermuda	True
+เบอร์ลิไนต์	berlinite	True
+เบอร์เกอร์	burger	True
+เบอร์เกอไรต์	buergerite	True
+เบอร์เซิร์ก	berserk	True
+เบอร์เดนไทต์	beudantite	True
+เบอร์เนสไซต์	birnessite	True
+เบอร์แทรนไดต์	bertrandite	True
+เบอร์แบนไคต์	burbankite	True
+เบอร์ไคต์	burkeite	True
+เบอลูกา	beluga	True
+เบอห์ไมต์	boehmite	True
+เบอเราไนต์	beraunite	True
+เบาต์	bout	True
+เบานซ์	bounce	True
+เบิร์ช	birch	True
+เบิร์ด	bird	True
+เบิร์ดซอง	birdsong	True
+เบิร์ทเดย์	birthday	True
+เบิร์น	burn	True
+เบิร์นเนอร์	burner	True
+เบิร์นเอาต์	burn-out	True
+เบิร์นเอาต์	burnout	True
+เบิร์ป	burp	True
+เบิสต์	burst	True
+เบียร์	beer	True
+เบียร์ด	beard	True
+เบเกอรี	bakery	True
+เบเกิล	bagel	True
+เบเคอไรต์	bakerite	True
+เบเนดิกต์	benedict	True
+เบเนฟิต	benefit	True
+เบโอแบบ	baobab	True
+เบ็ก	beck	True
+เบ็กคัม	beckham	True
+เบ็กเคอเรล	becquerel	True
+เบ็ต	bet	True
+เบ็ตเตอร์	better	True
+เปอร์เซ็นต์	percent	True
+เป็ปซี่	pepsi	
+เป๊ก	peg	True
+เป๊ปซี่	pepsi	
+เพกทิน	pectin	True
+เพกโทไลต์	pectolite	True
+เพทาไลต์	petalite	True
+เพนต์เฮาส์	penthouse	True
+เพนต์แลนไดต์	pentlandite	True
+เพนนิไนต์	peninte	True
+เพนิซิลลิน	penicillin	True
+เพนเทียม	pentium	
+เพรซีโอดิเมียม	praseodymium	True
+เพรส	prase	True
+เพริดอต	peridot	True
+เพริเคลส	pariclase	True
+เพรเมียร์	premier	True
+เพรเมียร์	premiere	True
+เพรเมียร์	première	True
+เพลซ	place	True
+เพลย์	play	True
+เพอรอฟสไกต์	perrovskite	True
+เพอร์พูไรต์	purpurite	True
+เพอร์เฟกชันนิสต์	perfectionist	True
+เพอร์เฟกต์	perfect	True
+เพอร์เฟ็กชันนิสต์	perfectionist	True
+เพอร์เฟ็กต์	perfect	True
+เพอร์ไทต์	perthite	True
+เพาเวลไลต์	powellite	True
+เพียร์ทูเพียร์	peer to peer	
+เพเลคานิไมมัส	pelecanimimus	True
+เฟซบุค	facebook	False
+เฟซบุ๊ก	facebook	True
+เฟซบุ๊ก	facebook   	
+เฟนไกต์	phengite	True
+เฟรนช์ฟรายส์	french fries	
+เฟรนด์	friend	True
+เฟรมเวิร์ค	framework	
+เฟร์โรนาไทรต์	ferronatrite	True
+เฟร์โรอีเดไนต์	ferro-edenite	True
+เฟร์โรเกลาโคเฟน	ferroglaucophane	True
+เฟลด์สปาทอยด์	feldspathoid	True
+เฟลด์สปาร์	feldspar	True
+เฟสบุค	facebook	False
+เฟสบุ๊ก	facebook	False
+เฟสบุ๊ค	facebook	False
+เฟอร์กูซอไนต์	fergusonite	True
+เฟอร์นิเจอร์	furniture	True
+เฟอร์นิเชอร์	furniture	True
+เฟอร์รารี่	ferrari	
+เฟอร์เบอไรต์	ferberite	True
+เฟอร์เมียม	fermium	True
+เฟอร์ไรต์	ferrite	True
+เฟาจาไซต์	faujasite	True
+เฟิน	fern	True
+เฟิร์น	fern	True
+เฟเนไคต์	phenakite	True
+เมกอัป	makeup	True
+เมกะเฮิรตซ์	megahertz	True
+เมกเกอร์	maker	นักประดิษฐ์
+เมตริก	metric	True
+เมตริกตัน	metric ton	True
+เมตา	meta	True
+เมตาเวิร์ส	metaverse	True
+เมทาซูเนอไรต์	meta-zeunerite	True
+เมทาทอร์เบอร์ไนต์	meta-torbernite	True
+เมทานอล	methanol	True
+เมทาวาริสไซต์	meta-variscite	True
+เมทาออทูไนต์	meta-antunite	True
+เมทาเเองโคลีไอต์	meta-ankoleite	True
+เมทิลแอลกอฮอล์	methyl alcohol	True
+เมนทอล	menthol	True
+เมนบอร์ด	mainboard	
+เมนู	menu	True
+เมนเดลีเวียม	mendelevium	True
+เมนเฟรน	mainframe	
+เมนโดไซต์	mendozite	True
+เมย์เดย์	mayday	
+เมล	mail	True
+เมลาโนโฟลไกต์	melanophlogite	True
+เมลาไนต์	melanite	True
+เมลิซ่า	melissa	
+เมลิฟาไนต์	meliphanite	True
+เมลิสซ่า	melissa	
+เมลิเฟน	meliphane	True
+เมลิโนเฟน	melinophane	True
+เมลิไลต์	melilite	True
+เมสเซจ	message	True
+เมอร์คิวรี	mercury	True
+เมอร์มาไนต์	murmanite	True
+เมาท์	mouth	True
+เมาส์	mouse	True
+เมาเชอร์ไรต์	maucherite	True
+เมิร์จ	merge	True
+เมเนกิไนต์	meneghinite	True
+เมแลนเทอไรต์	melanterite	True
+เมโซไลต์	mesolite	True
+เยซู	jesus	True
+เยลลี	jelly	
+เยลลี่	jelly	
+เยอรมนี	germany	
+เรซ	race	True
+เรซซิง	racing	True
+เรดอน	radon	True
+เรดาร์	radar	True
+เรดแฮท	red hat	
+เรตติ้ง	rating	
+เรอัล มาดริด	real madrid	
+เรินต์เกเนียม	roentgenium	True
+เรเดียม	radium	True
+เรเนียไรต์	renierite	True
+เรไอต์	raite	True
+เลคอนไทต์	lecontite	True
+เลดฮิลไลต์	leadhillite	True
+เลนส์	lens	True
+เลวูโลส	laevulose	True
+เลอชาเทเลียไรต์	lechatelierite	True
+เลอโนโว	lenovo	
+เลาทาไรต์	lautarite	True
+เลานจ์	lounge	True
+เลามอนไทต์	laumontite	True
+เลาไอต์	laueite	True
+เลิลลิงไกต์	loellingite	True
+เลเซอร์	laser	True
+เลโอไนต์	leonite	True
+เลโอไนต์เลโอไนต์	leonite	True
+เล็กเชอร์	lecture	True
+เวกเตอร์	vector	
+เวต	weight	True
+เวตเทรนนิง	weight training	True
+เวนต์	vent	True
+เวบไซต์	website	False
+เวย์น รูนี่ย์	wayne rooney	
+เวลที	wealthy	True
+เวอร์ชวล	virtual	True
+เวอร์ชัน	version	True
+เวอร์ชั่น	version	True
+เวอร์ดีไลต์	verdelite	True
+เวอร์มิคิวไลต์	vermiculite	True
+เวอร์เนอไรต์	wernerite	True
+เวอร์แนไดต์	vernadite	True
+เวอร์ไดต์	verdite	True
+เวาเชอร์	voucher	True
+เวิร์ก	work	
+เวิร์กชอป	workshop	
+เวิร์กช็อป	workshop	True
+เวิร์ดโพรเซสเซอร์	word processor	
+เวิร์ตไซต์	wurtzite	True
+เวิลด์	world	True
+เวียดนาม	vietnam	
+เวเลนซี	valency	True
+เวเวลไลต์	wavellite	True
+เวโลกาไนต์	weloganite	True
+เว็บ	web	True
+เว็บบอร์ด	webboard	
+เว็บเซอร์วิส	web service	
+เว็บเบราว์เซอร์	web browser	
+เว็บเพจ	web page	True
+เว็บไซต์	website	True
+เว็บไซท์	website	False
+เสิร์ช	search	
+เสิร์ชเอ็นจิน	search engine	
+เสิร์ชเอ็นจิ้น	search engine	
+เสิร์ฟ	serve	True
+เสียวหมี่	xiaomi	
+เหล็ก	iron	True
+เอกซเรย์	x-ray	
+เอกซเรย์	x-rays	True
+เอกซ์คลูซิฟ	exclusive	True
+เอกซ์ปอตส์	exports	True
+เอกซ์เทนซิฟ	extensive	True
+เอกซ์เอ็มแอล	xml	
+เอกมาไนต์	ekmanite	True
+เอการ์	agar	True
+เอชดีเอ็มไอ	hdmi	
+เอชทีซี	htc	
+เอชไอวี	hiv	
+เอดมอนโทซอรัส	edmontosaurus	True
+เอดิงโทไนต์	edingtonite	True
+เอดิเตอร์	editor	True
+เอต์ทรินไกต์	ettringite	True
+เอทิลีนออกไซด์	ethylene oxide	True
+เอทิลแอลกอฮอล์	ethyl alcohol	True
+เอทีเอ็ม	atm	True
+เอนด์	end	True
+เอนทิตี	entity	
+เอนสตาไทต์	enstatite	True
+เอนเจล	angel	True
+เอนเจิล	angel	True
+เอนเทอร์เทนเมนต์	entertainment	True
+เอนไซม์	enzyme	True
+เอนไซม์แอมีเลส	amylase enzyme	True
+เอนไซม์แอมีโลไลติก	amylolytic enzyme	True
+เอบ	abe	True
+เอบราฮัม	abraham	True
+เอบราแฮม	abraham	True
+เอปซอไมต์	epsomite	True
+เอพิดิดิไมต์	epididymite	True
+เอพิสติลไบต์	epistilbite	True
+เอพิสโตไลต์	epistolite	True
+เอพิโดต	epidote	True
+เอฟบีไอ	fbi	True
+เอฟีไซต์	ephesite	True
+เอฟเฟกต์	effect	False
+เอฟเฟ็กต์	effect	
+เอมมอนไซต์	emmonsite	True
+เอมเพลกไทต์	emplectite	True
+เอมโบไลต์	embolite	True
+เอริด	arid	True
+เอรีส	aries	True
+เอลพิไดต์	elpidite	True
+เอลเบไอต์	elbaite	True
+เอสซีบี	scb	True
+เอสเพรสโซ่	espresso	False
+เอสเอ็มเอส	sms	
+เอสโตรเจน	estrogen	True
+เออร์เบียม	erbium	True
+เอาต์คัม	outcome	True
+เอเคอร์	acre	True
+เอเจ แอดวานซ์ เทคโนโลยี	aj advance technology	True
+เอเจนซี	agency	True
+เอเจนต์	agent	True
+เอเดรียน	adrian	True
+เอเนอร์จี	energy	True
+เอเมน	amen	True
+เอเมอรัลด์	emerald	True
+เอเมอรี	emery	True
+เอเลียน	alien	True
+เอเอสเอ็น โบรกเกอร์	asn broker	
+เอเอ็มดี	amd	
+เอแจ็กซ์	ajax	
+เอโมไซต์	amosite	True
+เอโรบิก	aerobic	True
+เอไอ เอนเนอร์จี	ai energy	True
+เอไอจี	aig	
+เอไอเอ	aia	
+เอไอเอส	ais	
+เอ็กซ์ตรีม	extreme	True
+เอ็กซ์บ็อกซ์	xbox	
+เอ็กเซอร์ไซส์	exercise	True
+เอ็นซีแอล อินเตอร์เนชั่นแนล โลจิสติกส์	ncl international logistics	True
+เอ็นอาร์ อินสแตนท์ โปรดิวซ์	nr instant produce	True
+เอ็นเตอร์เทนเมนต์	entertainment	True
+เอ็นเอฟซี	nfc	True
+เอ็นเอฟที	nft	
+เอ็นเฮชเอส	nhs	True
+เอ็มคอตเอชดี	mcot hd	
+เอ็มบริโอ	embryo	True
+เอ็มพีจี คอร์ปอเรชั่น	mpg corporation	True
+เอ็มพีสาม	mp3	
+เอ็มวี	mv	True
+เอ็มเค	mk	
+เอ็มเอ็มเอส	mms	
+เอ๊กซ์	x	
+เฮกตาร์	hectare	True
+เฮกเทอไรต์	hectorite	True
+เฮดสแตนด์	headstand	True
+เฮดิเฟน	hedyphane	True
+เฮดโฟน	headphone	True
+เฮฟวีเวต	heavyweight	True
+เฮมิมอร์ไฟต์	hemimorphite	True
+เฮลที	healthy	True
+เฮลท์	health	True
+เฮลท์แคร์	healthcare	True
+เฮลิคอปเตอร์	helicopter	True
+เฮลิโอดอร์	heliodor	True
+เฮลไวต์	helvite	True
+เฮสทิงไซต์	hastingsite	True
+เฮสโซไนต์	hessonite	True
+เฮสไซต์	hessite	True
+เฮอริเคน	hurricane	True
+เฮอร์ซิไนต์	hercynite	True
+เฮอร์เดอไรต์	herderite	True
+เฮาส์มันไนต์	hausmannite	True
+เฮิบเนอไรต์	huebnerite	True
+เฮิรตซ์	hertz	True
+เฮเดนเบอร์ไกต์	hedenbergite	True
+เฮเลน	helen	
+เฮเลน่า	helena	
+เฮโมโกลบิน	haemoglobin	True
+เฮโรอีน	heroin	True
+เฮไลต์	halite	True
+เฮ้	hey	True
+เฮ้าส์	house	
+แกดจิต	gadget	True
+แกมมา	gamma	True
+แกรนิต	granite	True
+แกรโทไนต์	grotonite	True
+แกรไฟต์	graphite	True
+แกลลอน	gallon	True
+แกลลิไมมัส	gallimimus	True
+แกลเลอรี	gallery	True
+แกลเลียม	gallium	True
+แกสเพไอต์	gaspeite	True
+แกโดลิเนียม	gadolinium	True
+แก๊ง	gang	True
+แก๊ป	cap	True
+แก๊ส	gas	
+แคกตัส	cactus	True
+แคคตัส	cactus	True
+แคช	cache	True
+แคช	cash	True
+แคชลิส	cashless	True
+แคชวล	casual	True
+แคชูว์	cashew	True
+แคชูว์นัต	cashew nut	True
+แคชเลส	cashless	True
+แคชแบ็ก	cashback	True
+แคดดี	caddie	True
+แคดเมียม	cadmium	True
+แคน	can	True
+แคนคริไนต์	cancrinite	True
+แคนดิด	candid	True
+แคนดิเดต	candidate	True
+แคนดี	candy	True
+แคนตัส	cactus	False
+แคนต์	can't	True
+แคนต์	cant	True
+แคนทีน	canteen	True
+แคนนอน	cannon	True
+แคนนี	canny	True
+แคนอน	canon	True
+แคนิสเตอร์	canister	True
+แคนเซอร์	cancer	True
+แคนเซิล	cancel	True
+แคนเดิล	candle	True
+แคนเตอร์	canter	True
+แคนเทอร์	canter	True
+แคนไดต์	kandite	True
+แคบ	cab	True
+แคบาไซต์	chabasite	True
+แคบิน	cabin	True
+แคปซูล	capsule	True
+แคปริคอร์น	capricorn	True
+แคปริคอร์นัส	capricornus	True
+แคปิทัล	capital	True
+แคพิบารา	capybara	True
+แคฟแทน	caftan	True
+แคมคอร์เดอร์	camcorder	True
+แคมชาฟต์	camshaft	True
+แคมบริก	cambric	True
+แคมปัส	campus	True
+แคมปิง	camping	True
+แคมป์	camp	True
+แคมีโอ	cameo	True
+แคมเบอร์	camber	True
+แคมเปญ	campaign	
+แคมเปอร์	camper	True
+แคมเพน	campaign	True
+แคมแชฟต์	camshaft	True
+แครนดาลไลต์	crandallite	True
+แครอล	carol	True
+แครักเตอร์	character	True
+แครักเตอไรเซชัน	characterization	True
+แคราเมล	caramel	True
+แคราเวย์	caraway	True
+แคราแคล	caracal	True
+แคริบู	caribou	True
+แคริบเบียน	caribbean	True
+แครีส	caries	True
+แคร์	care	True
+แคร์นกอร์ม	cairngorm	True
+แคร์ฟรี	carefree	True
+แคร์ฟุล	careful	True
+แคร์รอต	carrot	True
+แคร์ริจ	carriage	True
+แคร์รี	carry	True
+แคร์เรียน	carrion	True
+แคร์เรียร์	carrier	True
+แคลคูลัส	calculus	True
+แคลง	clang	True
+แคลงก์	clank	True
+แคลช	clash	True
+แคลซิเฟอรอล	calciferol	True
+แคลด	clad	True
+แคลน	clan	True
+แคลนนิช	clannish	True
+แคลม	clam	True
+แคลมป์	clamp	True
+แคลมมี	clammy	True
+แคลมเบก	clambake	True
+แคลมเบอร์	clamber	True
+แคลริฟาย	clarify	True
+แคลริเน็ต	clarinet	True
+แคลลัส	callus	True
+แคลส	class	True
+แคลสซี	classy	True
+แคลสรูม	classroom	True
+แคลสเมต	classmate	True
+แคลอรี	calorie	True
+แคลาเวอไรต์	calaverite	True
+แคลิบอไรต์	kaliborite	True
+แคลิฟอร์เนีย	california	
+แคลิฟอร์เนียม	californium	True
+แคลิฟอร์ไนต์	californite	True
+แคลิเบรต	calibrate	True
+แคลิเบอร์	caliber	True
+แคลิเบอร์	calibre	True
+แคลิเปอส์	calipers	True
+แคลิเปอส์	callipers	True
+แคลิโค	calico	True
+แคลิโดไนต์	caledonite	True
+แคลเซียม	calcium	True
+แคลเซียมคาร์ไบด์	calcium carbide	True
+แคลเซียมไซคลาเมต	calcium cyclamate	True
+แคลไซต์	calcite	True
+แคล็ก	claque	True
+แคล็ป	clap	True
+แคล็ปบอร์ด	clapboard	True
+แคล็ปเปอร์บอร์ด	clapperboard	True
+แคล์ฟ	calf	True
+แคสก์	cask	True
+แคสซิเทอไรต์	cassiterite	True
+แคสติง	casting	True
+แคสต์	cast	True
+แคสเคด	cascade	True
+แคสเตอร์	castor	True
+แคสเปียน	caspian	True
+แคเช	cachet	True
+แคเชต์	cachet	True
+แคเชียร์	cashier	True
+แคเทกอรี	category	True
+แคเทอกอรี	category	True
+แคเฟ	cafe	True
+แคเฟ	café	True
+แคเมล	camel	True
+แคเมอรา	camera	True
+แคแวนไซต์	cavansite	True
+แคโคซีไนต์	cacoxenite	True
+แคโทด	cathode	True
+แคโมมีล	camomile	True
+แคโมมีล	chamomile	True
+แคโมไมล์	camomile	True
+แคโมไมล์	chamomile	True
+แคโรทีน	carotene	True
+แค็กเกิล	cackle	True
+แค็ต	cat	True
+แค็ตตาล็อก	catalogue	True
+แค็ตนิป	catnip	True
+แค็ตวอล์ก	catwalk	True
+แค็ปชัน	caption	True
+แค็ปซิคัม	capsicum	True
+แค็ปเชอร์	capture	True
+แค็ปเตอร์	captor	True
+แจซ	jazz	True
+แจสเพอร์	jasper	True
+แจ็ก	jack	True
+แจ็ก-โอ-แลนเทิร์น	jack-o'-lantern	True
+แจ็กเกต	jacket	True
+แจ็กเก็ต	jacket	True
+แจ็คเก็ต	jackets	
+แชต	chat	True
+แชท	chat	False
+แชทบอท	chatbot	
+แชนดิเลียร์	chandelier	True
+แชนต์	chant	True
+แชนเดอเลียร์	chandelier	True
+แชนเนล	channel	True
+แชนเนิล	channel	True
+แชมป์	champ	True
+แชมเปียน	champion	True
+แชมเปียนชิป	championship	True
+แชริตี	charity	True
+แชร์	chair	True
+แชร์	cher	True
+แชร์	share	True
+แชลเลนเจอร์	challenger	True
+แชสซี	chassis	True
+แชเรียต	chariot	True
+แชเล	chalet	True
+แชเลต์	chalet	True
+แช็ต	chat	True
+แช็ป	chap	True
+แช็ปเตอร์	chapter	True
+แซตทักไกต์	shatuckite	True
+แซนด์วิช	sandwich	True
+แซนบอร์ไนต์	sanbornite	True
+แซนิไทเซอร์	sanitizer	True
+แซปไฟรีน	sapphirine	True
+แซปไฟร์	sapphire	True
+แซฟฟลอไรต์	safflorite	True
+แซมบาวิสเซิล	samba whistle	True
+แซมอน	salmon	True
+แซลมอน	salmon	True
+แซสโซไลต์	sassolite	True
+แซ็ก	sac	True
+แซ็กคาริน	saccharin	True
+แซ็กคารินโซเดียม	saccharin sodium	True
+แซ็กโซโฟน	saxophone	True
+แดดดี	daddy	True
+แดนซ์	dance	True
+แดนบูไรต์	danburite	True
+แดนเซอร์	dancer	True
+แดแรปสไกต์	darapskite	True
+แทกไฮไดรต์	tachhydrite	True
+แทนซาไนต์	tanzanite	True
+แทนทาลัม	tantalum	True
+แทนทาไลต์	tantalite	True
+แทนเจนต์	tangent	True
+แทพิโอไลต์	tapiolite	True
+แทมารินด์	tamarind	True
+แทรกเตอร์	tractor	True
+แทรฟฟิก	traffic	True
+แทร็ก	track	True
+แทลเลียม	thallium	True
+แทเมอรูไกต์	tamarugite	True
+แท็ก	tag	True
+แท็กซี	taxi	False
+แท็กซี่	taxi	True
+แท็บ	tab	
+แท็บเล็ต	tablet	True
+แบคทีเรีย	bacteria	True
+แบง	bang	True
+แบงก์	bank	True
+แบงควิต	banquet	True
+แบงค์	bank	False
+แบงเกิล	bangle	True
+แบงเคว็ต	banquet	True
+แบงเค็ต	banquette	True
+แบช	bash	True
+แบซอลต์	basalt	True
+แบซาลต์	basalt	True
+แบซิล	basil	True
+แบซิลิสก์	basilisk	True
+แบด	bad	True
+แบดจ์	badge	True
+แบดมินตัน	badminton	True
+แบดเจอร์	badger	True
+แบดเดเลย์ไอต์	baddeleyite	True
+แบตเตอรี	battery	False
+แบตเตอรี่	battery	True
+แบท	bath	True
+แบทีก	batik	True
+แบน	ban	True
+แบนฃี	banshee	True
+แบนชี	banshee	True
+แบนดิต	bandit	True
+แบนด์	band	True
+แบนด์วิดท์	bandwidth	
+แบนทัม	bantam	True
+แบนทัมเวต	bantamweight	True
+แบนน็อก	bannock	True
+แบนิช	banish	True
+แบนเนอร์	banner	True
+แบนแดนนา	bandanna	True
+แบนแดนา	bandana	True
+แบนแยน	banyan	True
+แบนโจ	banjo	True
+แบบิงทอไนต์	babingtonite	True
+แบบูน	baboon	True
+แบปทิซึม	baptism	True
+แบมบู	bamboo	True
+แบมบูเซิล	bamboozle	True
+แบรน	bran	True
+แบรนช์	branch	True
+แบรนดิช	brandish	True
+แบรนด์	brand	True
+แบรนเนอไรต์	brannerite	True
+แบรส	brass	True
+แบระคูดา	barracuda	True
+แบราจ	barrage	True
+แบราโทไวต์	baratovite	True
+แบริง	bearing	True
+แบรีออนิกซ์	baryonyx	True
+แบรเคียซอรัส	brachiosaurus	True
+แบร็ต	brat	True
+แบร์	bare	True
+แบร์	bear	True
+แบร์ฟุต	barefoot	True
+แบร์รี	barry	True
+แบร์รีมอร์	barrymore	True
+แบร์ฮัก	bearhug	True
+แบร์แบ็ก	bareback	True
+แบร์โรว์	barrow	True
+แบลค์เมล์	blackmail	
+แบลงกิต	blanket	True
+แบลงก์	blank	True
+แบลนช์	blanch	True
+แบลนดิฃ	blandish	True
+แบลนดิช	blandish	True
+แบลนด์	bland	True
+แบลลัด	ballad	True
+แบลลัสต์	ballast	True
+แบลสต์	blast	True
+แบลโคนี	balcony	True
+แบล็ก	black	True
+แบล็กฟอเรสต์	black forest	True
+แบล็กเบร์รี	blackberry	True
+แบล็กเบอร์รี	blackberry	True
+แบส	bass	True
+แบสก์	bask	True
+แบสซอไนต์	bassanite	True
+แบสเก็ต	basket	True
+แบสเติร์ด	bastard	True
+แบเรียม	barium	True
+แบไรต์	barite	True
+แบ็ก	bag	True
+แบ็กกราวนด์	background	True
+แบ็กดร็อป	backdrop	True
+แบ็กยาร์ด	backyard	True
+แบ็กสเปซ	backspace	True
+แบ็กสแลช	backslash	True
+แบ็กอัป	back up	True
+แบ็กอัป	backup	True
+แบ็กเวิร์ด	backward	True
+แบ็กแกมมอน	backgammon	True
+แบ็กแพ็ก	backpack	True
+แบ็กแฮนด์	backhand	True
+แบ็กโฮ	backhoe	True
+แบ็กไฟเออร์	backfire	True
+แบ็กไลต์	backlight	True
+แบ็ต	bat	True
+แบ็ตเทิล	battle	True
+แบ็ปทอร์นิส	baptornis	True
+แบ็ปทิซึม	baptism	True
+แปซิฟิก	pacific	True
+แปซิฟิกไพพ์	pacific pipe	True
+แพกโนไลต์	pachnolite	True
+แพคิเซฟาโลซอรัส	pachycephalosaurus	True
+แพคเกจ	package	False
+แพชชั่น	passion	
+แพดพาแรดชา	padparradscha	True
+แพตเทิร์น	pattern	
+แพนเค้ก	pancake	
+แพนเดอร์ไมต์	pandermite	True
+แพรซิโอดิเมียม	praeseodymium	True
+แพรรีด็อก	prairie dog	
+แพรรี่ด็อก	prairie dog	
+แพราซอรอโลฟัส	parasaurolophus	True
+แพริไซต์	parisite	True
+แพลจิโอเคลส	plagioclase	True
+แพลตต์เนอไรต์	plattnerite	True
+แพลตฟอร์ม	platform	True
+แพลทินัม	platinum	True
+แพลน	plan	
+แพลนชีไอต์	plancheite	True
+แพลนต์	plant	True
+แพลิกอร์สไกต์	palygorskite	True
+แพลเนต	planet	True
+แพลเลเดียม	palladium	True
+แพล็ตฟอร์ม	platform	True
+แพสชัน	passion	
+แพ็ก	pack	True
+แพ็กเกจ	package	True
+แพ็กเกจจิง	packaging	True
+แฟกซ์	fax	True
+แฟชั่น	fashion	True
+แฟนคลับ	fan club	
+แฟนด้อม	fandom	
+แฟนมีต	fanmeet	True
+แฟนเพจ	fanpage	True
+แฟมิลี	family	True
+แฟรงคลิไนต์	franklinite	True
+แฟรงคีไอต์	franckeite	True
+แฟรนเซียม	francium	True
+แฟรนโคไลต์	francolite	True
+แฟรนไชส์	franchise	True
+แฟลกซ์	flax	True
+แฟลต	flat	True
+แฟลร์	flare	True
+แมกซีซี	maxixe	True
+แมกนีเซียม	magnesium	True
+แมกนีไซต์	magnesite	True
+แมกนีไทต์	magnetite	True
+แมกฮีไมต์	maghemite	True
+แมกาซีน	magazine	True
+แมกเฟอร์ซอไนต์	macphersonite	True
+แมค	mac	
+แมคเวจ	mcwage	
+แมงกานิน	manganin	True
+แมงกานีส	manganese	True
+แมงกาโนโซต์	maganosite	True
+แมงกาไนต์	manganite	True
+แมงแกนแบบิงทอไนต์	manganbabingtinite	True
+แมชชีนเลิร์นนิง	machine learning	
+แมชีน เลิร์นนิ่ง	machine learning	
+แมตช์	match	True
+แมทชีน เลินนิ่ง	machine learning	
+แมนซิตี้	man city	
+แมนยู	man u	
+แมมมอท	mammoth	True
+แมยิสเตร็ด	magistrate	True
+แมลาคอน	malacon	True
+แมลโดไนต์	maldonite	True
+แมสก์	mask	True
+แมสซิคอต	massicot	True
+แมโคร	macro	
+แม็กเคอเรล	mackerel	True
+แม็ตช์	match	True
+แยม	jam	True
+แย็บ	jab	True
+แรนซัมแวร์	ransomware	
+แรบโดเฟน	rhabdophane	True
+แรป	rap	True
+แรม	ram	True
+แรมส์เดลไลต์	ramsdellite	True
+แรมเมลส์เบอร์ไกต์	rammelsbergite	True
+แรลลี่	rally	
+แรสป์เบร์รี	raspberry	True
+แร็กคูน	raccoon	True
+แร็กเกต	racket	True
+แร็ป	rap	True
+แร็ปเปอร์	rapper	
+แร็พเปอร์	rapper	
+แลคโตส	lactose	True
+แลนด์	land	
+แลนด์มาร์ก	landmark	True
+แลนทานัม	lanthanum	True
+แลนทาไนต์	lanthanite	True
+แลบราโดไรต์	labradorite	True
+แลมโพรโบไลต์	lamprobolite	True
+แล็ก	lag	True
+แล็กติก	lactic	True
+แล็กเกอร์	lacquer	True
+แล็กเตต	lactate	True
+แล็กเทต	lactate	True
+แล็กโทส	lactose	True
+แล็บ	lab	True
+แล็บท็อป	laptop	
+แล็ป	lab	
+แล็ปท็อป	laptop	
+แวนต์ฮอฟไฟต์	vanthoffite	True
+แวมไพร์ ทไวไลท์	vampire twilight	
+แวเลนทิไนต์	valentinite	True
+แสตมป์	stamp	True
+แอกซิไนต์	axinite	True
+แอกทิเนียม	actinium	True
+แอกทิโนไลต์	actinolite	True
+แอกนิส	agnes	True
+แอกเซส	access	True
+แอกเนส	agnes	True
+แอกไมต์	acmite	True
+แอควา	aqua	True
+แองกรี	angry	True
+แองกลีไซต์	anglesite	True
+แองเกลอร์	angler	True
+แองเกอร์	anger	True
+แองเกิล	angle	True
+แองเคอร์	anchor	True
+แองเคอโลซอรัส	ankylosaurus	True
+แองเคอไรต์	ankerite	True
+แอซีทัลดีไฮด์	acetaldehyde	True
+แอดดัมส์	addams	True
+แอดดิกต์	addict	True
+แอดมิต	admit	True
+แอดมิน	admin	True
+แอดัม	adam	True
+แอดาไมต์	adamite	True
+แอดิโพส	adipose	True
+แอดเวนต์	advent	True
+แอดเวนเชอร์	adventure	True
+แอดเวิร์บ	adverb	True
+แอตทาพุลไกต์	attapulgite	True
+แอนดรอยด์	android	True
+แอนดราไดต์	andradite	True
+แอนดาลูไซต์	andalusite	True
+แอนดีซีน	andesine	True
+แอนติบอดี	antibody	True
+แอนติออกซิแดนต์	antioxidant	True
+แอนติเจน	antigen	True
+แอนทิเพอร์ไทต์	antiperthite	True
+แอนทิโกไรต์	antigorite	True
+แอนทิโมนี	antimony	True
+แอนนาเบอร์ไกต์	annabergite	True
+แอนฟีลด์	anfield	True
+แอนอกไซต์	anauxite	True
+แอนะล็อก	analog	True
+แอนะล็อก	analogue	True
+แอนาพาไอต์	anapaite	True
+แอนิเมชัน	animation	True
+แอนิเมเตอร์	animator	True
+แอนเจไลต์	angelite	True
+แอนเดอร์ซอไนต์	andersonite	True
+แอนเทิลไรต์	antlerite	True
+แอนโชวี	anchovy	True
+แอนโทนีโอ้	antonio	
+แอนโทนี่	anthony	
+แอนโทฟิลไลต์	anthophyllite	True
+แอนโยไลต์	anyolite	True
+แอนไฮไดรต์	anhydrite	True
+แอบสแตร็กต์	abstract	True
+แอบาโลนี	abalone	True
+แอบิเกล	abigail	True
+แอบโซลูต	absolute	True
+แอป	app	True
+แอปพลิเคชัน	application	True
+แอปฯ	app	False
+แอปเปิล	apple	True
+แอปเปิ้ล	apple	
+แอพ	app	False
+แอพพลิเคชั่น	application	False
+แอฟทิทาไลต์	aphthitalite	True
+แอฟเตอร์	after	True
+แอฟเฟล็ก	affleck	True
+แอมนีชา	amnesia	True
+แอมนีเซีย	amnesia	True
+แอมบลิโกไนต์	amblygonite	True
+แอมบิชัน	ambition	True
+แอมบุช	ambush	True
+แอมฟิเบียน	amphibian	True
+แอมฟิโบล	amphibole	True
+แอมมิเตอร์	ammeter	True
+แอมะซอน	amazon	True
+แอมะซอนสโตน	amazon stone	True
+แอมะซอไนต์	amazonite	True
+แอมเบอร์	amber	True
+แอมแปร์	ampere	True
+แอมโม	ammo	True
+แอมโมเนีย	ammonia	True
+แอรอน	aaron	True
+แอริด	arid	True
+แอรีส	aries	True
+แอร์บัส	airbus	
+แอร์รี่	airy	
+แอร์เอเชีย	airasia	
+แอลกอฮอล์	alcohol	True
+แอลคานอแลมีนส์	alkanolamines	True
+แอลจี	lg	
+แอลมันดัน	almandine	True
+แอลมันดีน	almandine	True
+แอลมันไดต์	almandite	True
+แอลลอย	alloy	True
+แอลลาไนต์	allanite	True
+แอลลีย์	alley	True
+แอลิซ	alice	True
+แอลิไบ	alibi	True
+แอลแพกา	alpaca	True
+แอลโลเฟน	allophane	True
+แอลไบต์	albite	True
+แอลไพน์	alpine	True
+แอสทาทีน	astatine	True
+แอสฟัลต์	asphalt	True
+แอสเตอรอยด์	asteroid	True
+แอสเตอริสก์	asterisk	True
+แอสเบสทอส	asbestos	True
+แอสโทรฟิลไลต์	astrophyllite	True
+แอสไพริน	aspirin	True
+แอเจิล	agile	True
+แอเชอร์	azure	True
+แอเมทิสต์	amethyst	True
+แอโกนี	agony	True
+แอโครแบ็ต	acrobat	True
+แอโคไลต์	acolyte	True
+แอโดเลสเซนซ์	adolescence	True
+แอโดเลสเซนต์	adolescent	True
+แอโนด	anode	True
+แอโรบิก	aerobic	True
+แอโลวีรา	aloe vera	True
+แอโลเวรา	aloe vera	True
+แอโลเวียรา	aloe vera	True
+แอโวคาโด	avocado	True
+แอไจล์	agile	True
+แอ็กชัน	action	
+แอ็กซิเดนต์	accident	True
+แอ็กทิฟ	active	True
+แอ็กทิเวต	activate	True
+แอ็กเคานต์	account	True
+แอ็ป	app	True
+แฮกมาไนต์	hackmanite	True
+แฮกเกอร์	hacker	
+แฮงเอาต์	hangout	True
+แฮงไซต์	hanksite	True
+แฮชแทก	hashtag	True
+แฮชแท็ก	hashtag	
+แฮนด์	hand	
+แฮนด์บอล	handball	True
+แฮนด์เมด	hand made	
+แฮนด์เอ๊ก	hand x	
+แฮนด์แซนิไทเซอร์เจล	hand sanitizer gel	True
+แฮปปี	happy	True
+แฮปปีเบิร์ทเดย์	happy birthday	True
+แฮฟเนียม	hafnium	True
+แฮม	ham	True
+แฮมเตอร์	hamster	
+แฮมเบอร์ไกต์	harmotome	True
+แฮรี่	harry	
+แฮร์รี่	harry	
+แฮร์รี่ พอตเตอร์	harry potter	
+แฮร์รี่ เคน	harry kane	
+โกชีไนต์	goshenite	True
+โกลด์	gold	True
+โกลว์	glow	True
+โคด	code	True
+โคต	coat	True
+โคนิคาลไซต์	conichalcite	True
+โคบอลต์	cobalt	True
+โคบอลไทต์	cobaltite	True
+โคฟ	cove	True
+โคม่า	coma	True
+โครคอยต์	crocoite	True
+โครซิโดไลต์	crocidolite	True
+โครม	chrome	True
+โครมา	chroma	True
+โครมาทิน	chromatin	True
+โครมาโทกราฟี	chromatography	True
+โครเก้	croquet	
+โครเมียม	chromium	True
+โครแมติก	chromatic	True
+โครโมโซม	chromosome	True
+โครไมต์	chromite	True
+โคลก	cloak	True
+โคลมาไนต์	colemanite	True
+โคลวีไซต์	kolwezite	True
+โคลอี	chloe	True
+โคลัมไบต์	columbite	True
+โคลแมนไอต์	colemanite	True
+โควตา	quota	True
+โควิด	covid	True
+โควิด 19	covid-19	True
+โคออร์ดิเนต	coordinate	True
+โคอาลา	koala	True
+โคะกิริโกะ	kokiriko	True
+โคเคน	cocaine	True
+โคเซแคนต์	cosecant	True
+โคเวลไลต์	covellite	True
+โคโทไอต์	kotoite	True
+โคไซต์	coesite	True
+โคไซน์	cosine	True
+โค้ก	coke	
+โค้ช	coach	True
+โค้ด	code	True
+โจอะควิไนต์	joaquinite	True
+โจ๊ก	joke	True
+โชว์	show	True
+โซดา	soda	True
+โซดาไนเตอร์	sodaniter	True
+โซดาไลต์	sodalite	True
+โซนี่	sony	
+โซนี่อีริคสัน	sony ericsson	
+โซฟา	sofa	
+โซลาริส	solaris	
+โซลเจอร์	soldier	True
+โซเชียล	social	
+โซเชียลมีเดีย	social media	
+โซเชียลเน็ตเวิร์ก	social network	
+โซเชียลเน็ตเวิร์ค	social network	
+โซเดียม	sodium	True
+โซเดียมคาร์บอเนต	sodium carbonate	True
+โซเดียมซัลเฟต	sodium sulphate	True
+โซเดียมไซคลาเมต	sodium cyclamate	True
+โซเดียมไฮโดรเจนกลูทาเมต	sodium hydrogen glutamate	True
+โซเดียมไฮโดรเจนคาร์บอเนต	sodium hydrogen carbonate	True
+โซเดียมไฮโดรเจนซัลเฟต	sodium hydrogen sulphate	True
+โซโนตไลต์	xonotlite	True
+โซโล	solo	True
+โด	dough	True
+โดนัต	donut	True
+โดนัท	donut	
+โดนัล	donald	
+โดนัลด์	donald	
+โดส	dose	True
+โดเนต	donate	True
+โดเมน	domain	True
+โดเมย์ไคต์	domeykite	True
+โดโลไมต์	dolomite	True
+โทน	tone	True
+โทนี่	tony	
+โทมัส	thomas	
+โทมัส ทูเคิ่ล	thomas tuchel	
+โทรนา	trona	True
+โทะเซะกิ	toseki	True
+โทเคน	token	
+โทแพซ	topaz	True
+โทแพโซไลต์	topazolite	True
+โนซีไลต์	noselite	True
+โนวา	nova	True
+โนวาคิวไลต์	novaculite	True
+โนเซียน	nosean	True
+โนเบล	nobel	True
+โนเบเลียม	nobelium	True
+โนเวลล์	novell	
+โน้ต	note	True
+โน้ตบุ๊ก	notebook	True
+โน้ตบุ๊ค	notebook	False
+โน๊ตบุ๊ก	notebook	True
+โบ	beau	True
+โบ	bow	True
+โบกัส	bogus	True
+โบกีแมน	bogeyman	True
+โบต	boat	True
+โบน	bone	True
+โบนัส	bonus	True
+โบนีโต	bonito	True
+โบร	bro	True
+โบรกเกอร์	broker	
+โบรช	brooch	True
+โบรชัวร์	brochure	
+โบรมาร์จิไรต์	bromargyrite	True
+โบรมีน	bromine	True
+โบรอน	boron	True
+โบรเชนไทต์	brochantite	True
+โบล	bole	True
+โบลด์	bold	True
+โบลต	bloat	True
+โบลต์	bolt	True
+โบลต์วูไดต์	boltwoodite	True
+โบลว์	blow	True
+โบลีไอต์	boleite	True
+โบวีไนต์	bowenite	True
+โบว์	bow	True
+โบว์ลิง	bowling	True
+โบว์ลินไกต์	bowlingite	True
+โบสต์	boast	True
+โบห์เรียม	bohrium	True
+โบฮีเมียน	bohemian	True
+โบแนนซา	bonanza	True
+โบโซ	bozo	True
+โปรตอน	proton	True
+โปรตีน	protein	True
+โปรเจกต์	project	
+โปรเจค	project	True
+โปรเจคต์	project	False
+โปรเจ็ค	project	False
+โปรเตสแตนต์	protestant	True
+โปรแกรม	program	True
+โปรแกรมเมอร์	programmer	True
+โปรแทรกเตอร์	protractor	True
+โปรโตคอล	protocol	
+โปรโมท	promote	True
+โปรไฟล์	profile	False
+โปลิโอ	poliomyelitis	True
+โปสต์การ์ด	postcard	True
+โป๊กเกอร์	poker	True
+โป๊ป	pope	True
+โพซิตรอน	positron	True
+โพรดักชันส์	productions	True
+โพรมิเทียม	promethium	True
+โพรมีเทียม	promethium	True
+โพรเจกเตอร์	projector	True
+โพรเซส	process	
+โพรเซสเซอร์	processor	
+โพรเบอร์ไทต์	probertite	True
+โพรโตไทป์	prototype	True
+โพรโทเซราท็อปส์	protoceratops	True
+โพรโทแอกทิเนียม	protoactinium	True
+โพรโทไทป์	prototype	True
+โพรโมชัน	promotion	True
+โพรโมต	promote	True
+โพรไฟล์	profile	True
+โพลีเอสเตอร์	polyester	True
+โพส	pose	True
+โพสต์	post	True
+โพสต์ทูเดย์	post today	
+โพแทช	potash	True
+โพแทสเซียม	potassium	True
+โฟกัส	focus	True
+โฟตอน	photon	True
+โฟน	phone	True
+โฟลว์	flow	True
+โฟลเรนไซต์	florencite	True
+โฟลโกไพต์	phlogopite	True
+โฟโตอิเล็กทริก	photoelectric	True
+โฟโต้ชอป	photoshop	True
+โมนาไซต์	monazite	True
+โมบาย	mobile	True
+โมลิบดีนัม	molybdenum	True
+โมลิบดีไนต์	molybdenite	True
+โมฮาไวต์	mohavite	True
+โมเดล	model	True
+โมเดอร์นา	moderna	
+โมเดิร์น	modern	
+โมเด็ม	modem	True
+โมเมนต์	moment	True
+โมเลกุล	molecule	True
+โมเลกุลาร์	molecular	
+โมเสก	mosaic	True
+โมโตโรลา	motorola	
+โมโนแซ็กคาไรด์	monosaccharide	True
+โมไบล์	mobile	True
+โรดิไซต์	rhodizite	True
+โรบอต	robot	True
+โรบัสตา	robusta	True
+โรบินสัน	robinson	
+โรบ็อต	robot	True
+โรมัน	roman	True
+โรมันคาทอลิก	roman catholic	True
+โรมาเนไคต์	romanechite	True
+โรสแมรี่	rosemary	
+โรเซไลต์	roselite	True
+โรเดียม	rhodium	True
+โรเบิร์ต	robert	
+โรแซไซต์	rosasite	True
+โรโดโครไซต์	rhodochrosite	True
+โรโดไนต์	rhodonite	True
+โรโดไลต์	rhodolite	True
+โลคัล	local	True
+โลจิสติกส์	logistics	True
+โลชัน	lotion	
+โลตัส	lotus	
+โลพาไรต์	loparite	True
+โลวีไอต์	loeweite	True
+โวลลาสโทไนต์	wollastonite	True
+โหลด	load	True
+โหวต	vote	True
+โอซุมิไลต์	osumilite	True
+โอดอนโทไลต์	odontolite	True
+โอดีเอฟ	odf	True
+โอท๊อป	otop	True
+โอนิกซ์	onyx	True
+โอบามา	obama	
+โอปอ	opal	True
+โอพอล	opal	True
+โอพาไลต์	opalite	True
+โอลด์โรส	olg rose	True
+โอลิมปิก	olympic	True
+โอลิวีน	olivine	True
+โอลิเวไนต์	olivenite	True
+โอลิโกเคลส	oligoclase	True
+โอวิแร็ปเตอร์	oviraptor	True
+โอห์ม	ohm	True
+โอห์มมิเตอร์	ohmmeter	True
+โอเค	ok	True
+โอเคไนต์	okenite	True
+โอเชียน	ocean	True
+โอเทไวต์	otavite	True
+โอเปร่า	opera	
+โอเปอเรเตอร์	operator	
+โอเพนซอร์ส	open source	
+โอเพิ่นสตรีทแมป	openstreetmap	
+โอเพ่นซอร์ส	open source	
+โอเมกา 3	omega 3	True
+โอเอซิส	oasis	True
+โอเอส	os	True
+โอโซน	ozone	True
+โอ๊ก	oak	True
+โอ๊ต	oat	True
+โฮมสเตย์	homestay	True
+โฮมเพจ	home page	
+โฮลเมียม	holmium	True
+โฮสต์	host	
+โฮเต็ล	hotel	True
+โฮโนลูลู	honolulu	
+โฮไพต์	hopeite	True
+ไกด์	guide	True
+ไกลโคไซด์	glycoside	True
+ไคทิน	chitin	True
+ไคมีรา	chimaera	True
+ไคมีรา	chimera	True
+ไคม์	chyme	True
+ไคยาไนต์	kyanite	True
+ไครสต์เชิร์ช	christchurch	True
+ไครโอไลต์	cryolite	True
+ไคลนอปไทโลไลต์	clinoptilolite	True
+ไคลน์	cline	True
+ไคลฟ์	clive	True
+ไคลเอนต์	client	True
+ไคลแมกซ์	climax	True
+ไคลแม็กซ์	climax	True
+ไคลโนคลอร์	clinochlore	True
+ไคลโนซอยไซต์	clinozoisite	True
+ไคลโนฮิวไมต์	clinohumite	True
+ไคลโนฮีไดรต์	clinohrdrite	True
+ไคลโนเคลส	clinoclase	True
+ไคลโนเอนสตาไทต์	clinoenstatite	True
+ไคล์	chyle	True
+ไควเออร์	choir	True
+ไคสโทไลต์	chaistolite	True
+ไคแอสโทไลต์	chiastolite	True
+ไคโอไลต์	chiolite	True
+ไจโรไลต์	gyrolite	True
+ไชนาทาวน์	chinatown	True
+ไชนีส	chinese	True
+ไชน์	shine	True
+ไชน์เทอราพี	shine therapy	True
+ไชม์	chime	True
+ไชลด์	child	True
+ไชลด์ฮุด	childhood	True
+ไซซ์	size	True
+ไซต์	cite	True
+ไซต์	site	True
+ไซน์	sine	True
+ไซบอร์ก	cyborg	True
+ไซยาโนทริไคต์	cyanotrichite	True
+ไซยาไนต์	cyanite	True
+ไซลินไดรต์	cylindrite	True
+ไซเกิล	cycle	True
+ไซเดอร์	cider	True
+ไซเทชัน	citation	True
+ไซเบอร์	cyber	True
+ไซเฟอร์	cipher	True
+ไซเรน	siren	True
+ไซเอนซ์	science	True
+ไซโกมาตา	zygomata	True
+ไซโคลน	cyclone	True
+ไซโทไคนิน	cytokinin	True
+ไซโมเฟน	cymophane	True
+ไซโล	silo	True
+ไซโลมิเลน	psilomelane	True
+ไดกิ้น	daikin	
+ไดครอยต์	dichroite	True
+ไดนาโม	dynamo	True
+ไดมอนด์	diamond	True
+ไดรฟ์	drive	
+ไดออปเทส	dioptase	True
+ไดออปไซด์	diopside	True
+ไดอะสปอร์	diaspore	True
+ไดอะโบลีไอต์	diaboleite	True
+ไดอามอนด์	diamond	True
+ไดอิเล็กทริก	dielectric	True
+ไดเจไนต์	digenite	True
+ไดเรกตริกซ์	directrix	True
+ไดแซ็กคาไรด์	disaccharide	True
+ไดโนเสาร์	dinosaur	True
+ไทซอไนต์	tysonite	True
+ไททันออไจต์	titanaugite	True
+ไททาโนแมกนีไทต์	titanomagnetite	True
+ไททาไนต์	titanite	True
+ไทม์	time	True
+ไทร-เฟล็กซ์	tri-flex	True
+ไทรกลีเซอไรด์	triglyceride	True
+ไทรฟิไลต์	triphylite	True
+ไทรอยด์	thyroid	
+ไทรเซราท็อปส์	triceratops	True
+ไทรโคลแซน	triclosan	True
+ไทเทรต	titrate	True
+ไทเทเนียม	titanium	True
+ไทไคต์	tychite	True
+ไนต์คลับ	night club	
+ไนต์คลับ	nightclub	True
+ไนทราทีน	nitratine	True
+ไนน์ทีน	nineteen	
+ไนลอน	nylon	True
+ไนเตอร์	niter	True
+ไนเตอร์	nitre	True
+ไนโตรเจน	nitrogen	True
+ไนโอเบียม	niobium	True
+ไบต์	bite	True
+ไบต์	byte	True
+ไบนารี	binary	
+ไบรด์	bride	True
+ไบรต์	bright	True
+ไบรน์	brine	True
+ไบรบ์	bribe	True
+ไบรเทน	brighten	True
+ไบเดลไลต์	beidellite	True
+ไบโทว์ไนต์	bytownite	True
+ไบโนเมียล	binomial	True
+ไบโพลาร์	bipolar	True
+ไบโอดาตา	biodata	True
+ไบโอดีเซล	biodiesel	True
+ไบโอเดตา	biodata	True
+ไบโอไทต์	biotite	True
+ไปรเวต	private	False
+ไป่ตู้	baidu	
+ไพทอน	python	True
+ไพธอน	python	
+ไพรด์	pride	True
+ไพรม์ไทม์	prime time	True
+ไพรอกซีน	pyroxene	True
+ไพราร์จีไรต์	pyrargyrite	True
+ไพรเวต	private	True
+ไพรไซต์	priceite	True
+ไพโรคลอร์	pyrochlore	True
+ไพโรป	pyrope	True
+ไพโรฟิลไลต์	pyrophyllite	True
+ไพโรมอร์ไฟต์	pyromorphite	True
+ไพโรลูไซต์	pyrolusite	True
+ไพโรออไรต์	pyroaurite	True
+ไพไนต์	pinite	True
+ไพไรต์	pyrite	True
+ไฟต์	fight	True
+ไฟรเบอร์ไกต์	freibergite	True
+ไฟร์ฟอกซ์	firefox	True
+ไฟร์ฟ็อกซ์	firefox	
+ไฟร์วอลล์	firewall	
+ไฟลต์	flight	True
+ไฟล์	file	
+ไฟเซอร์	pfizer	
+ไฟเบอร์	fiber	True
+ไฟเออร์	fire	True
+ไฟแนนซ์	finance	
+ไฟโบรไลต์	fibrolite	True
+ไมกา	mica	True
+ไมครอน	micron	True
+ไมต์เนเรียม	meitnerium	True
+ไมล์	mile	True
+ไมอาซอรา	maiasaura	True
+ไมอาร์จิไรต์	miargyrite	True
+ไมโครคอมพิวเตอร์	microcomputer	True
+ไมโครซอฟต์	microsoft	
+ไมโครซอฟท์	microsoft	True
+ไมโครฟิล์ม	microfilm	True
+ไมโครมิเตอร์	micrometer	True
+ไมโครเพอร์ไทต์	microperthite	True
+ไมโครเวฟ	microwave	True
+ไมโครโฟน	microphone	True
+ไมโครไคลน์	microcline	True
+ไมโครไลต์	microlite	True
+ไรย์	rye	True
+ไรเดอร์	rider	
+ไลก์	like	True
+ไลค์	like	False
+ไลซาร์ไดต์	lizardite	True
+ไลน์	line	True
+ไลฟ์	live	True
+ไลฟ์โค้ช	life coach	
+ไลมอไนต์	limonite	True
+ไลโอพลัวโรดอน	liopleurodon	True
+ไวน์	wine	True
+ไวฟาย	wi-fi	True
+ไวรัส	virus	True
+ไวราไคต์	wairakite	True
+ไวแทลิตี	vitality	True
+ไวโอลาน	violan	True
+ไวโอลาไรต์	violarite	True
+ไวโอลาไอต์	violaite	True
+ไวโอลิน	violin	True
+ไวไทต์	whiteite	True
+ไอคอน	icon	
+ไอจี	ig	
+ไอซ์สเกต	ice skate	True
+ไอที	it	True
+ไอน์สไตเนียม	einsteinium	True
+ไอบีเอ็ม	ibm	
+ไอพอด	ipod	
+ไอพี	ip	True
+ไอพ็อด	ipod	
+ไอร์แลนด์	ireland	
+ไอศกรีม	ice cream	
+ไอออน	ion	True
+ไอเดีย	idea	True
+ไอเทม	item	True
+ไอแซกนิวตัน	isaac newton	
+ไอแซค นิวตัน	isaac newton	
+ไอแพด	ipad	
+ไอโซโทป	isotope	True
+ไอโดเครส	idocrase	True
+ไอโฟน	iphone	True
+ไอโอดีน	iodine	True
+ไอโอที	iot	True
+ไอโอเอส	ios	True
+ไอโอไซต์	iozite	True
+ไอโอไลต์	iolite	True
+ไฮดรอกซิลบาสต์เนไซต์	hydroxylbastnasite	True
+ไฮดรอกซิลอะพาไทต์	hydroxylapatite	True
+ไฮดรา	hydra	True
+ไฮดราร์จิลไลต์	hydrargillite	True
+ไฮบริด	hybrid	True
+ไฮยาซินท์	hyacinth	True
+ไฮยาโลเฟน	hyalophane	True
+ไฮยาไลต์	hyalite	True
+ไฮยาไลน์	hyaline	True
+ไฮยีนา	hyaena	True
+ไฮเพอร์สทีน	hypersthene	True
+ไฮโกรมิเตอร์	hygrometer	True
+ไฮโดรกรอสซูลาร์	hydrogrossular	True
+ไฮโดรคาร์บอน	hydrocarbon	True
+ไฮโดรซิงไคต์	hydrozincite	True
+ไฮโดรบอราไซต์	hydroboracite	True
+ไฮโดรพอนิกส์	hydroponics	True
+ไฮโดรมิเตอร์	hydrometer	True
+ไฮโดรเจน	hydrogen	True
+ไฮโดรเจนซัลไฟด์	hydrogen sulphide	True
+ไฮโดรเจนเพอร์ออกไซด์	hydrogen peroxide	True
+ไฮโดรเฟน	hydrophane	True
+ไฮโดรแมกนีไซต์	hydromagnesite	True
+ไฮโพคลอไรต์	hypochlorite	True
+ไฮโพทาลามัส	hypothalamus	True
+ไฮไฟ	hi–fi	True
+ไฮไลต์	highlight	True
+ไฮไลท์	highlight	

--- a/pythainlp/transliterate/lookup.py
+++ b/pythainlp/transliterate/lookup.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""
+Look up romanized Thai words in a predefined dictionary compiled by Wannaphong, 2022.
+
+Wannaphong Phatthiyaphaibun. (2022). 
+wannaphong/thai-english-transliteration-dictionary: v1.4 (v1.4). 
+Zenodo. https://doi.org/10.5281/zenodo.6716672
+"""
+
+from typing import Callable, Optional
+from pythainlp.corpus.th_en_translit import (
+    TRANSLITERATE_DICT,
+    TRANSLITERATE_EN,
+    TRANSLITERATE_FOLLOW_RTSG,
+)
+from pythainlp.tokenize import word_tokenize
+
+
+_TRANSLITERATE_IDX = 0
+
+
+def follow_rtgs(text: str) -> Optional[bool]:
+    """
+    Check if the `text` follows romanization defined by Royal Society of Thailand (RTGS).
+    :param str text: Text to look up. Must be a self-contained word.
+    :return: True if text follows the definition by RTGS, False otherwise.
+            `None` means unverified or unknown word.
+    :rtype: Optional[bool]
+    """
+    try:
+        follow = TRANSLITERATE_DICT[text][TRANSLITERATE_FOLLOW_RTSG][
+            _TRANSLITERATE_IDX
+        ]
+    except IndexError:
+        return None
+    else:
+        return follow
+
+
+def _romanize(text: str, fallback_func: Callable[[str], str]) -> str:
+    """
+    Romanize one word. Look up first, call `fallback_func` if not found.
+    """
+    try:
+        # try to get 0-th idx of look up result, simply ignore other possible variations.
+        # not found means no mapping.
+        lookup = TRANSLITERATE_DICT[text][TRANSLITERATE_EN][_TRANSLITERATE_IDX]
+    except IndexError:
+        return fallback_func(text)
+    except TypeError as e:
+        raise TypeError(f"`fallback_engine` is not callable. {e}")
+    else:
+        return lookup
+
+
+def romanize(text: str, fallback_func: Callable[[str], str]) -> str:
+    """
+    Render Thai words in Latin alphabet by looking up
+    Thai-English transliteration dictionary.
+
+    :param str text: Thai text to be romanized
+    :param Callable[[str], str] fallback_func: Callable
+    :return: A string of Thai words rendered in the Latin alphabet
+    :rtype: str
+    """
+    # split by whitespace. word_tokenizer may break text into subwords.
+    # e.g. กาแลกซี่ -> ["กา", "แลก", "ซี่"]
+    words = text.strip().split()
+    romanized_words = [_romanize(word, fallback_func) for word in words]
+
+    return " ".join(romanized_words)

--- a/pythainlp/transliterate/lookup.py
+++ b/pythainlp/transliterate/lookup.py
@@ -2,8 +2,8 @@
 """
 Look up romanized Thai words in a predefined dictionary compiled by Wannaphong, 2022.
 
-Wannaphong Phatthiyaphaibun. (2022). 
-wannaphong/thai-english-transliteration-dictionary: v1.4 (v1.4). 
+Wannaphong Phatthiyaphaibun. (2022).
+wannaphong/thai-english-transliteration-dictionary: v1.4 (v1.4).
 Zenodo. https://doi.org/10.5281/zenodo.6716672
 """
 

--- a/pythainlp/transliterate/lookup.py
+++ b/pythainlp/transliterate/lookup.py
@@ -13,7 +13,6 @@ from pythainlp.corpus.th_en_translit import (
     TRANSLITERATE_EN,
     TRANSLITERATE_FOLLOW_RTSG,
 )
-from pythainlp.tokenize import word_tokenize
 
 
 _TRANSLITERATE_IDX = 0

--- a/tests/test_transliterate.py
+++ b/tests/test_transliterate.py
@@ -87,6 +87,35 @@ class TestTransliteratePackage(unittest.TestCase):
         self.assertEqual(romanize("สกุนต์", engine="thai2rom"), "sakun")
         self.assertEqual(romanize("ชารินทร์", engine="thai2rom"), "charin")
 
+    def test_romanize_lookup(self):
+        # found in v1.4
+        self.assertEqual(romanize("บอล", engine="lookup"), "ball")
+        self.assertEqual(romanize("บอยแบนด์", engine="lookup"), "boyband")
+        self.assertEqual(romanize("กาแล็กซี", engine="lookup"), "galaxy")
+        self.assertEqual(romanize("กีย์เซอไรต์", engine="lookup"), "geyserite")
+        self.assertEqual(romanize("พลีโอนาสต์", engine="lookup"), "pleonaste")
+        self.assertEqual(
+            romanize("คาราเมล คาปูชิโน่", engine="lookup"),
+            "caramel cappuccino",
+        )
+        ## found individually, but needs tokenization
+        self.assertEqual(
+            romanize("คาราเมลคาปูชิโน่", engine="lookup"), "khanamenkhapuchino"
+        )
+        # not found in v1.4
+        ## default fallback
+        self.assertEqual(romanize("ภาพยนตร์", engine="lookup"), "phapn")
+        self.assertEqual(romanize("แมว", engine="lookup"), "maeo")
+        ## fallback = 'thai2rom'
+        self.assertEqual(
+            romanize("ความอิ่ม", engine="lookup", fallback_engine="thai2rom"),
+            "khwam-im",
+        )
+        self.assertEqual(
+            romanize("สามารถ", engine="lookup", fallback_engine="thai2rom"),
+            "samat",
+        )
+
     def test_thai2rom_prepare_sequence(self):
         transliterater = ThaiTransliterator()
 
@@ -149,51 +178,35 @@ class TestTransliteratePackage(unittest.TestCase):
 
     def test_transliterate_iso11940(self):
         self.assertEqual(
-            transliterate("เชียงใหม่", engine="iso_11940"),
-            "echīyngıh̄m̀"
+            transliterate("เชียงใหม่", engine="iso_11940"), "echīyngıh̄m̀"
         )
         self.assertEqual(
-            transliterate("ภาษาไทย", engine="iso_11940"),
-            "p̣hās̛̄āịthy"
+            transliterate("ภาษาไทย", engine="iso_11940"), "p̣hās̛̄āịthy"
         )
 
     def test_transliterate_wunsen(self):
         wt = WunsenTransliterate()
-        self.assertEqual(
-            wt.transliterate("ohayō", lang="jp"),
-            'โอฮาโย'
-        )
+        self.assertEqual(wt.transliterate("ohayō", lang="jp"), "โอฮาโย")
         self.assertEqual(
             wt.transliterate(
-                "ohayou",
-                lang="jp",
-                jp_input="Hepburn-no diacritic"
+                "ohayou", lang="jp", jp_input="Hepburn-no diacritic"
             ),
-            'โอฮาโย'
+            "โอฮาโย",
         )
         self.assertEqual(
-            wt.transliterate("ohayō", lang="jp", system="RI35"),
-            'โอะฮะโย'
+            wt.transliterate("ohayō", lang="jp", system="RI35"), "โอะฮะโย"
         )
         self.assertEqual(
-            wt.transliterate("annyeonghaseyo", lang="ko"),
-            'อันนย็องฮาเซโย'
+            wt.transliterate("annyeonghaseyo", lang="ko"), "อันนย็องฮาเซโย"
         )
-        self.assertEqual(
-            wt.transliterate("xin chào", lang="vi"),
-            'ซีน จ่าว'
-        )
-        self.assertEqual(
-            wt.transliterate("ni3 hao3", lang="zh"),
-            'หนี เห่า'
-        )
+        self.assertEqual(wt.transliterate("xin chào", lang="vi"), "ซีน จ่าว")
+        self.assertEqual(wt.transliterate("ni3 hao3", lang="zh"), "หนี เห่า")
         self.assertEqual(
             wt.transliterate("ni3 hao3", lang="zh", zh_sandhi=False),
-            'หนี่ เห่า'
+            "หนี่ เห่า",
         )
         self.assertEqual(
-            wt.transliterate("ni3 hao3", lang="zh", system="RI49"),
-            'หนี ห่าว'
+            wt.transliterate("ni3 hao3", lang="zh", system="RI49"), "หนี ห่าว"
         )
         with self.assertRaises(NotImplementedError):
             wt.transliterate("xin chào", lang="vii")
@@ -212,5 +225,5 @@ class TestTransliteratePackage(unittest.TestCase):
         self.assertEqual(puan("นาริน"), "นิน-รา")
         self.assertEqual(puan("นาริน", show_pronunciation=False), "นินรา")
         self.assertEqual(
-             puan("การทำความดี", show_pronunciation=False), "ดานทำความกี"
+            puan("การทำความดี", show_pronunciation=False), "ดานทำความกี"
         )


### PR DESCRIPTION
### What does this changes

Add [Thai-English transliteration dictionary v1.4](https://github.com/wannaphong/thai-english-transliteration-dictionary) to `pythainlp.transliterate.romanize`.

### What was wrong

Nothing's wrong. A new feature to improve new transliteration quality.

### How this fixes it

Instead of algorithmically generating transliteration (which can be wrong), find one from a predefined look up table.

Fixes #681 

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [/] Passed code styles and structures
- [/] Passed code linting checks and unit test
