### PR TITLE
[WIP] Fixed URLs.IMDB_SAMPLE in pythainlp.generate.thai2fit

### DIFF
--- a/pythainlp/generate/thai2fit.py
+++ b/pythainlp/generate/thai2fit.py
@@ -22,7 +22,7 @@ from fastai.text import *
 from pythainlp.ulmfit import *
 
 # get dummy data
-imdb = untar_data(URLs.IMDB_SAMPLE)
+imdb = untar_data("https://github.com/PyThaiNLP/pythainlp-corpus/releases/download/fastai-imdb_sample.tgz/imdb_sample.tgz")
 dummy_df = pd.read_csv(imdb/'texts.csv')
 
 # get vocab

--- a/tests/test_ulmfit.py
+++ b/tests/test_ulmfit.py
@@ -212,7 +212,7 @@ class TestUlmfitPackage(unittest.TestCase):
         self.assertEqual(actual, expect)
 
     def test_document_vector(self):
-        imdb = untar_data(URLs.IMDB_SAMPLE)
+        imdb = untar_data("https://github.com/PyThaiNLP/pythainlp-corpus/releases/download/fastai-imdb_sample.tgz/imdb_sample.tgz")
         dummy_df = pd.read_csv(imdb/'texts.csv')
         thwiki = THWIKI_LSTM
         thwiki_itos = pickle.load(open(thwiki['itos_fname'], 'rb'))


### PR DESCRIPTION
### What does this changes

Change url from http://files.fast.ai/data/examples/imdb_sample.tgz to https://github.com/PyThaiNLP/pythainlp-corpus/releases/download/fastai-imdb_sample.tgz/imdb_sample.tgz because the fastai website is down.
