### PR TITLE
Add style.css: extend docs page width

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 notebooks/iso_11940-dev.ipynb
+
+# vscode devcontainer
+.devcontainer/

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -1,0 +1,3 @@
+.wy-nav-content {
+    max-width: none;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,6 +144,9 @@ html_theme_options = {"display_version": True}
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
+# Custom css file
+html_css_files = ["style.css"]
+
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
 #


### PR DESCRIPTION
### What does this changes

Add docs/_static/style.css and modified docs/conf.py (refer to https://github.com/PyThaiNLP/pythainlp/issues/720)

### What was wrong

According to the issue, the document page's width is limited to 1100px.

### How this fixes it

1. add css file to modify class `.wy-nav-content` width.
```css
.wy-nav-content {
    max-width: none;
}
```
2. add custom configuration inside conf.py
```python
html_css_files = ["style.css"]
```

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test
