### PR TITLE
PyThaiNLP 3.1.1

### DIFF
--- a/pythainlp/__init__.py
+++ b/pythainlp/__init__.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2016-2022 PyThaiNLP Project
 # URL: <https://pythainlp.github.io/>
 # For license information, see LICENSE
-__version__ = "3.1.0"
+__version__ = "3.1.1"
 
 thai_consonants = "กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรลวศษสหฬอฮ"  # 44 chars
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.0
+current_version = 3.1.1
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ extras = {
 
 setup(
     name="pythainlp",
-    version="3.1.0",
+    version="3.1.1",
     description="Thai Natural Language Processing library",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
PyThaiNLP v3.1.1 is the releases updates of PyThaiNLP v3.1.0.

## What is new?
- `pythainlp.tools.misspell` changed to `pythainlp.tools.misspell.misspell`.
-  Add Reduce import time #719 to PyThaiNLP 3.1.1 #753
-  Doc: Lst20 deprecation warning for 3.1.1 (#749) #752

**Full Changelog**: https://github.com/PyThaiNLP/pythainlp/compare/v3.1.0...v3.1.1

You can install by `pip install pythainlp` or upgrade by `pip install -U pythainlp`.

Documentation: [https://pythainlp.github.io/docs/3.1](https://pythainlp.github.io/docs/3.1)

Report bug: [https://github.com/PyThaiNLP/pythainlp/issues](https://github.com/PyThaiNLP/pythainlp/issues)

See [PyThaiNLP 3.1 change log](https://github.com/PyThaiNLP/pythainlp/issues/643)

See [3.1 Milestone](https://github.com/PyThaiNLP/pythainlp/milestone/16).

## Contributors

<a href="https://github.com/PyThaiNLP/pythainlp/graphs/contributors">
  <img src="https://contributors-img.firebaseapp.com/image?repo=PyThaiNLP/pythainlp" />
</a>

Thanks all the [contributors](https://github.com/PyThaiNLP/pythainlp/graphs/contributors). (Image made with [contributors-img](https://contributors-img.firebaseapp.com/))