### PR TITLE
PyThaiNLP 4.0 beta 1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ extras = {
 
 setup(
     name="pythainlp",
-    version="4.0.0dev0",
+    version="4.0.0beta1",
     description="Thai Natural Language Processing library",
     long_description=readme,
     long_description_content_type="text/markdown",
@@ -165,7 +165,7 @@ setup(
         "Thai language",
     ],
     classifiers=[
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 4 - Beta",
         "Programming Language :: Python :: 3",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
This post will give you the change log for PyThaiNLP 4.0. PyThaiNLP published [the first version is 0.0.4 to PyPI at 6 years ago](https://pypi.org/project/pythainlp/0.0.4/), so PyThaiNLP 4.0 will have special codename. The codename for PyThaiNLP 4.0 is **PyThaiNLP 4.0 (Real)**.

This release is the first beta release of PyThaiNLP 4.0.

**Schedule**
- Beta release: 1 April 2023
- Production release: 14 April 2023

See [4.0 Milestone](https://github.com/PyThaiNLP/pythainlp/milestone/17).


## What is new?
### Deprecation and other API changes
- Delete all LST20 model #728 
- https://github.com/PyThaiNLP/pythainlp/commit/947c7be9ce4199af58ecf042629dda4d752dbcd6 Change pythainlp.tools.misspell to pythainlp.tools.misspell.misspell

### Improve
- Reduce import time #719 
-  Fix/broken numeric data format (#652) #723

### Tokenizer
-  Add blackboard cls #732
-  Add <Karan> rule to TCC and Change TCC rule for newmm #741 

### Tag
- Add blackboard pos_tag #733 
- Add ThaiNER 2.0 #781 

### Util
- Add pythainlp.util.count_thai_chars #748 
- Add thai_strptime and convert_years #767

### Transliterate
- Add Thai2Rom ONNX model #743 

## Khavee
-  add khavee to pythainlp #777
-  add aek/too checker function to khavee #779

### Parse
-  Add ud_goeswith #757

### Corpus
- Add new science word #763 