### PR TITLE
Fix mishandling Karun in Kavee Matra Checker

### DIFF
--- a/pythainlp/khavee/core.py
+++ b/pythainlp/khavee/core.py
@@ -214,7 +214,7 @@ class KhaveeVerifier:
         """
         if word[-1] == 'ร' and word[-2] in ['ต','ท'] :
             word = word[:-1]
-        word = self.handle_karun_sound_silenced(word)
+        word = self.handle_karun_sound_silence(word)
         if 'ำ' in word or ('ํ' in word and 'า' in word) or 'ไ' in word or 'ใ' in word:
             return 'กา'
         elif word[-1] in ['า','ะ','ิ','ี','ุ','ู','อ'] or ('ี' in word and 'ย' in word[-1]) or ('ื' in word and 'อ' in word[-1]):
@@ -448,7 +448,7 @@ class KhaveeVerifier:
         else:
             return False
 
-    def handle_karun_sound_silence(text: str) -> str:
+    def handle_karun_sound_silence(self, word: str) -> str:
         """
         Handle sound silence in Thai word using '์' character (Karun)
         by stripping all the characters before the 'Karun' character that should be silenced
@@ -459,7 +459,7 @@ class KhaveeVerifier:
         """
         sound_silenced = True if word.endswith('์') else False
         if not sound_silenced:
-            return text
+            return word
         thai_consonants = "กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรลวศษสหฬอฮ"
         locate_silenced = word.rfind('์') - 1
         can_silence_two = True if word[locate_silenced-2] in thai_consonants else False

--- a/pythainlp/khavee/core.py
+++ b/pythainlp/khavee/core.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from typing import List, Union
 from pythainlp.tokenize import subword_tokenize
-
+from pythainlp.util import sound_syllable
 
 class KhaveeVerifier:
     def __init__(self):
@@ -380,11 +380,11 @@ class KhaveeVerifier:
         else:
             return 'Something went wrong Make sure you enter it in correct form.'
 
-    def check_aek_too(self, text: Union[List[str], str]) -> Union[List[bool], List[str], bool, str]:
+    def check_aek_too(self, text: Union[List[str], str], dead_syllable_as_aek:bool = False) -> Union[List[bool], List[str], bool, str]:
         """
         Thai tonal word checker
 
-        :param str or list[str] text: Thai word or list of Thai words
+        :param str or list[str] text: Thai word or list of Thai words, bool dead_syllable_as_aek: if True, dead syllable will be considered as aek
         :return: the check if the word is aek or too or False(not both) or list of the check if input is list
         :rtype: Union[List[bool], List[str], bool, str]
 
@@ -402,7 +402,7 @@ class KhaveeVerifier:
             ## -> [False, 'aek', 'too']
         """
         if isinstance(text, list):
-            return [self.check_aek_too(t) for t in text]
+            return [self.check_aek_too(t, dead_syllable_as_aek) for t in text]
 
         if not isinstance(text, str):
             raise TypeError('text must be str or iterable list[str]')
@@ -412,5 +412,7 @@ class KhaveeVerifier:
             return 'aek'
         elif '้' in word_characters and not '่' in word_characters:
             return 'too'
+        if dead_syllable_as_aek and sound_syllable(text) == 'dead':
+            return 'aek'
         else:
             return False

--- a/pythainlp/khavee/core.py
+++ b/pythainlp/khavee/core.py
@@ -214,11 +214,7 @@ class KhaveeVerifier:
         """
         if word[-1] == 'ร' and word[-2] in ['ต','ท'] :
             word = word[:-1]
-        if '์' in word[-1]:
-            if 'ิ' in word[-2] or 'ุ' in word[-2]:
-                word = word[:-3]
-            else:
-                word = word[:-2]
+        word = self.handle_karun_sound_silenced(word)
         if 'ำ' in word or ('ํ' in word and 'า' in word) or 'ไ' in word or 'ใ' in word:
             return 'กา'
         elif word[-1] in ['า','ะ','ิ','ี','ุ','ู','อ'] or ('ี' in word and 'ย' in word[-1]) or ('ื' in word and 'อ' in word[-1]):
@@ -451,3 +447,22 @@ class KhaveeVerifier:
             return 'aek'
         else:
             return False
+
+    def handle_karun_sound_silence(text: str) -> str:
+        """
+        Handle sound silence in Thai word using '์' character (Karun)
+        by stripping all the characters before the 'Karun' character that should be silenced
+
+        :param str text: Thai word
+        :return: Thai word with silence word stripped
+        :rtype: str
+        """
+        sound_silenced = True if word.endswith('์') else False
+        if not sound_silenced:
+            return text
+        thai_consonants = "กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรลวศษสหฬอฮ"
+        locate_silenced = word.rfind('์') - 1
+        can_silence_two = True if word[locate_silenced-2] in thai_consonants else False
+        cut_off = 2 if can_silence_two else 1
+        word = word[:locate_silenced + 1 - cut_off]
+        return word

--- a/pythainlp/khavee/core.py
+++ b/pythainlp/khavee/core.py
@@ -412,8 +412,8 @@ class KhaveeVerifier:
     def check_aek_too(self, text: Union[List[str], str], dead_syllable_as_aek:bool = False) -> Union[List[bool], List[str], bool, str]:
         """
         Thai tonal word checker
-
-        :param str or list[str] text: Thai word or list of Thai words
+        :param Union[List[str], str] text: Thai word or list of Thai words
+        :param bool dead_syllable_as_aek: if True, dead syllable will be considered as aek
         :return: the check if the word is aek or too or False(not both) or list of the check if input is list
         :rtype: Union[List[bool], List[str], bool, str]
 

--- a/pythainlp/khavee/example.py
+++ b/pythainlp/khavee/example.py
@@ -59,3 +59,5 @@ print(kv.check_aek_too('เอง'), kv.check_aek_too('เอ่ง'), kv.check_
 # -> False, aek, too
 print(kv.check_aek_too(['เอง', 'เอ่ง', 'เอ้ง'])) # ใช้ List ได้เหมือนกัน
 # -> [False, 'aek', 'too']
+print(kv.check_aek_too(['ห๊ะ', 'เอ่ง', 'เอ้ง'], dead_syllable_as_aek=True)) # ใช้ List ได้เหมือนกัน และสามารถตั้งค่า ให้นับคำที่เสียงตายเป็นเอกได้ ตามการเช็คคฉันทลักษณ์กลอน
+# -> ['aek', 'aek', 'too']


### PR DESCRIPTION
### What does this changes
referring to this issue: #791 
This changes Karun(sound silence) handler algorithm with another function

### What was wrong
referring to this issue: #791 
the reason is khavee matra checker only check LAST character AKA. ตัวสะกด
for example 'มนตร์' will return กด because the karun handled text by old cleaner is มนต instead of มน

### How this fixes it

This new function check if there's Karun is it possible to silence the last two characters/vowel
if so we delete unnecessary sound form for example 
พักตร์ will be พัก since it is possible to silence ต to ร

Fixes #...

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [ ] Passed code styles and structures
- [ ] Passed code linting checks and unit test
