### PR TITLE
add `paragraph_threshold` into `paragraph_tokenize` function

### DIFF
--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -439,7 +439,7 @@ def sent_tokenize(
     return segments
 
 
-def paragraph_tokenize(text: str, engine: str = "wtp-mini") -> List[List[str]]:
+def paragraph_tokenize(text: str, engine: str = "wtp-mini", paragraph_threshold:float=0.5) -> List[List[str]]:
     """
     Paragraph tokenizer.
 
@@ -485,7 +485,8 @@ def paragraph_tokenize(text: str, engine: str = "wtp-mini") -> List[List[str]]:
         else:
             _size = engine.split("-")[-1]
         from pythainlp.tokenize.wtsplit import tokenize as segment
-        segments = segment(text,size=_size,tokenize="paragraph")
+        segments = segment(text,size=_size,tokenize="paragraph",paragraph_threshold=paragraph_threshold)
+        
     else:
         raise ValueError(
             f"""Tokenizer \"{engine}\" not found.

--- a/pythainlp/tokenize/wtsplit.py
+++ b/pythainlp/tokenize/wtsplit.py
@@ -28,7 +28,8 @@ def _tokenize(
         text:str,
         lang_code:str="th",
         model:str="wtp-bert-mini",
-        tokenize:str="sentence"
+        tokenize:str="sentence",
+        paragraph_threshold:float=0.5,
     )-> List[str]:
     global _MODEL_NAME,_MODEL
     if _MODEL_NAME != model:
@@ -40,11 +41,12 @@ def _tokenize(
         return _MODEL.split(
             text,
             lang_code=lang_code,
-            do_paragraph_segmentation=True
+            do_paragraph_segmentation=True,
+            paragraph_threshold=paragraph_threshold
         )
 
 
-def tokenize(text:str, size:str="mini", tokenize:str="sentence")-> List[str]:
+def tokenize(text:str, size:str="mini", tokenize:str="sentence", paragraph_threshold:float=0.5)-> List[str]:
     _model_load=""
     if size=="tiny":
         _model_load="wtp-bert-tiny"
@@ -54,4 +56,4 @@ def tokenize(text:str, size:str="mini", tokenize:str="sentence")-> List[str]:
         _model_load="wtp-canine-s-12l"
     else:  # mini
         _model_load="wtp-bert-mini"
-    return _tokenize(text, model=_model_load,tokenize=tokenize)
+    return _tokenize(text, model=_model_load,tokenize=tokenize,paragraph_threshold=paragraph_threshold)


### PR DESCRIPTION
Adding `paragraph_threshold` argument, According to the original paper **'Where's the Point? Self-Supervised Multilingual Punctuation-Agnostic Sentence Segmentation,'** we have the option to adjust the paragraph threshold using the `paragraph_threshold` argument. This threshold corresponds to the `alpha` value mentioned in the paper's method section. By default, the paragraph threshold is set to 0.5

>  α can be set to a small constant value such as 0.01, where a higher α gives rise to more conservative segmentation


Here is a usage:

when `paragraph_threshold=0.5` 
```
from pythainlp.tokenize import paragraph_tokenize

sent = (
    "(1) บทความนี้ผู้เขียนสังเคราะห์ขึ้นมาจากผลงานวิจัยที่เคยทำมาในอดีต"
    +"  มิได้ทำการศึกษาค้นคว้าใหม่อย่างกว้างขวางแต่อย่างใด"
    +" จึงใคร่ขออภัยในความบกพร่องทั้งปวงมา ณ ที่นี้"
)

# same as paragraph_tokenize(sent, paragraph_threshold=0.5)
paragraph_tokenize(sent)

# output
# [['(1) '],
# ['บทความนี้ผู้เขียนสังเคราะห์ขึ้นมาจากผลงานวิจัยที่เคยทำมาในอดีต  ',
#  'มิได้ทำการศึกษาค้นคว้าใหม่อย่างกว้างขวางแต่อย่างใด ',
#  'จึงใคร่ขออภัยในความบกพร่องทั้งปวงมา ',
#  'ณ ที่นี้']]
```

when the `paragraph_threshold = 0.8` -> more conservative segmentation

```
paragraph_tokenize(sent, paragraph_threshold=0.8)

# output
# [['(1) ',
#  'บทความนี้ผู้เขียนสังเคราะห์ขึ้นมาจากผลงานวิจัยที่เคยทำมาในอดีต  ',
#  'มิได้ทำการศึกษาค้นคว้าใหม่อย่างกว้างขวางแต่อย่างใด ',
#  'จึงใคร่ขออภัยในความบกพร่องทั้งปวงมา ',
#  'ณ ที่นี้']]
```


when the `paragraph_threshold = 0.05` -> less conservative segmentation

```
paragraph_tokenize(sent, paragraph_threshold=0.05)

# output
# [['(1) '],
# ['บทความนี้ผู้เขียนสังเคราะห์ขึ้นมาจากผลงานวิจัยที่เคยทำมาในอดีต  '],
# ['มิได้ทำการศึกษาค้นคว้าใหม่อย่างกว้างขวางแต่อย่างใด ',
#  'จึงใคร่ขออภัยในความบกพร่องทั้งปวงมา '],
# ['ณ ที่นี้']]
```