### PR TITLE
Fix incorrect passing of flags to re.split

### DIFF
--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -413,7 +413,7 @@ def sent_tokenize(
 
         segments = segment(text)
     elif engine == "whitespace":
-        segments = re.split(r" +", text, re.U)
+        segments = re.split(r" +", text, flags=re.U)
     elif engine == "whitespace+newline":
         segments = text.split()
     elif engine == "tltk":


### PR DESCRIPTION
This is a common mistake, see https://github.com/python/cpython/issues/99918#issuecomment-1333382582