### PR TITLE
Add tzdata as a dependency on Windows

### DIFF
--- a/pythainlp/util/date.py
+++ b/pythainlp/util/date.py
@@ -97,7 +97,7 @@ thai_full_month_lists = [
     ["ธันวาคม", "ธันวา", "ธ.ค.", "12"]
 ]
 thai_full_month_lists_regex = "(" + '|'.join(
-    [str('|'.join([j for j in i])) for i in thai_full_month_lists]
+    ['|'.join(i) for i in thai_full_month_lists]
 ) + ")"
 year_all_regex = r"(\d\d\d\d|\d\d)"
 dates_list = "(" + '|'.join(

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ See https://github.com/PyThaiNLP/pythainlp for installation options.
 
 requirements = [
     "requests>=2.22.0",
-    "backports.zoneinfo; python_version<'3.9'"
+    "backports.zoneinfo; python_version<'3.9'",
+    "tzdata; sys_platform == 'win32'"
 ]
 
 extras = {


### PR DESCRIPTION
### What does this changes

Add `tzdata` as a dependency on Windows, and also some code cleanups in `pythainlp.util.data`.

### What was wrong

`pythainlp.util.data` use the standard library `zoneinfo`, which would uses the system’s time zone data if available, otherwise it would use `tzdata`.

Time zone data is included on macOS and Linux, but not on Windows, so `tzdata` is required to be installed on Windows, otherwise on `import pythainlp` it would show this error:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "D:\Python\lib\site-packages\pythainlp\__init__.py", line 57, in <module>
    from pythainlp.soundex import soundex
  File "D:\Python\lib\site-packages\pythainlp\soundex\__init__.py", line 29, in <module>
    from pythainlp.soundex.lk82 import lk82
  File "D:\Python\lib\site-packages\pythainlp\soundex\lk82.py", line 23, in <module>
    from pythainlp.util import remove_tonemark
  File "D:\Python\lib\site-packages\pythainlp\util\__init__.py", line 71, in <module>
    from pythainlp.util.date import (
  File "D:\Python\lib\site-packages\pythainlp\util\date.py", line 213, in <module>
    tzinfo=ZoneInfo("Asia/Bangkok")
  File "D:\Python\lib\zoneinfo\_common.py", line 24, in load_tzdata
    raise ZoneInfoNotFoundError(f"No time zone found with key {key}")
zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key Asia/Bangkok'
```

### How this fixes it

Add `tzdata` as a dependency on Windows.

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test
