### PR TITLE
Add extra segmentation style for `paragraph_tokenize` function

### DIFF
--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -446,7 +446,12 @@ def sent_tokenize(
     return segments
 
 
-def paragraph_tokenize(text: str, engine: str = "wtp-mini", paragraph_threshold:float=0.5) -> List[List[str]]:
+def paragraph_tokenize(
+      text: str, 
+      engine: str = "wtp-mini", 
+      paragraph_threshold:float=0.5,
+      style:str='newline',
+    ) -> List[List[str]]:
     """
     Paragraph tokenizer.
 
@@ -492,7 +497,13 @@ def paragraph_tokenize(text: str, engine: str = "wtp-mini", paragraph_threshold:
         else:
             _size = engine.split("-")[-1]
         from pythainlp.tokenize.wtsplit import tokenize as segment
-        segments = segment(text,size=_size,tokenize="paragraph",paragraph_threshold=paragraph_threshold)
+        segments = segment(
+                      text,
+                      size=_size,
+                      tokenize="paragraph",
+                      paragraph_threshold=paragraph_threshold,
+                      style=style,
+                    )
         
     else:
         raise ValueError(

--- a/pythainlp/tokenize/wtsplit.py
+++ b/pythainlp/tokenize/wtsplit.py
@@ -50,8 +50,9 @@ def _tokenize(
           return _MODEL.split(
               text,
               lang_code=lang_code,
-              style=style,
+              do_paragraph_segmentation=True,
               threshold=paragraph_threshold,
+              style=style,
           )
         else:
           raise ValueError(

--- a/pythainlp/tokenize/wtsplit.py
+++ b/pythainlp/tokenize/wtsplit.py
@@ -30,6 +30,7 @@ def _tokenize(
         model:str="wtp-bert-mini",
         tokenize:str="sentence",
         paragraph_threshold:float=0.5,
+        style:str='newline',
     )-> List[str]:
     global _MODEL_NAME,_MODEL
     if _MODEL_NAME != model:
@@ -38,15 +39,33 @@ def _tokenize(
     if tokenize=="sentence":
         return _MODEL.split(text,lang_code=lang_code)
     else: # Paragraph
-        return _MODEL.split(
-            text,
-            lang_code=lang_code,
-            do_paragraph_segmentation=True,
-            paragraph_threshold=paragraph_threshold
+        if style=='newline':
+          return _MODEL.split(
+              text,
+              lang_code=lang_code,
+              do_paragraph_segmentation=True,
+              paragraph_threshold=paragraph_threshold
+          )
+        elif style=='opus100':
+          return _MODEL.split(
+              text,
+              lang_code=lang_code,
+              style=style,
+              threshold=paragraph_threshold,
+          )
+        else:
+          raise ValueError(
+            f"""Segmentation style \"{style}\" not found.
+            It might be a typo; if not, please consult our document."""
         )
 
-
-def tokenize(text:str, size:str="mini", tokenize:str="sentence", paragraph_threshold:float=0.5)-> List[str]:
+def tokenize(
+        text:str, 
+        size:str="mini", 
+        tokenize:str="sentence", 
+        paragraph_threshold:float=0.5,
+        style:str='newline',
+    )-> List[str]:
     _model_load=""
     if size=="tiny":
         _model_load="wtp-bert-tiny"
@@ -56,4 +75,10 @@ def tokenize(text:str, size:str="mini", tokenize:str="sentence", paragraph_thres
         _model_load="wtp-canine-s-12l"
     else:  # mini
         _model_load="wtp-bert-mini"
-    return _tokenize(text, model=_model_load,tokenize=tokenize,paragraph_threshold=paragraph_threshold)
+    return _tokenize(
+              text, 
+              model=_model_load,
+              tokenize=tokenize,
+              paragraph_threshold=paragraph_threshold,
+              style=style,
+            )


### PR DESCRIPTION
According to issue #843, about `wtpsplit` engine used in `paragraph_tokenize` function. wtpsplit itself can adapt to the Universal Dependencies, OPUS100, or Ersatz corpus segmentation style in many languages as well. As for 2023, it supported Thai language in `OPUS100` corpus style. 

Since we both agreed on adding a segmentation style as an option, I've added `style` as a new argument of `paragraph_tokenize` function. 

Here is a usage:
```python
from pythainlp.tokenize import paragraph_tokenize

sent = (
    "(1) บทความนี้ผู้เขียนสังเคราะห์ขึ้นมาจากผลงานวิจัยที่เคยทำมาในอดีต"
    +"  มิได้ทำการศึกษาค้นคว้าใหม่อย่างกว้างขวางแต่อย่างใด"
    +" จึงใคร่ขออภัยในความบกพร่องทั้งปวงมา ณ ที่นี้"
)

```


1. `paragraph_tokenize` with default `paragraph_threshold=0.5` (the current version in PyThaiNLP):
```python
# same as paragraph_tokenize(sent, paragraph_threshold=0.5)
paragraph_tokenize(sent)

# output
# [['(1) '],
# ['บทความนี้ผู้เขียนสังเคราะห์ขึ้นมาจากผลงานวิจัยที่เคยทำมาในอดีต  ',
#  'มิได้ทำการศึกษาค้นคว้าใหม่อย่างกว้างขวางแต่อย่างใด ',
#  'จึงใคร่ขออภัยในความบกพร่องทั้งปวงมา ',
#  'ณ ที่นี้']]
```

## Here is `paragraph_tokenize` function after added `style` argument
- 2 segmentation styles available to choose that is `newline` and `opus100` style (as supported in wtpsplit)
- note that the default value of `paragraph_threshold` will be set to 0.5 in order to show how different in each segmentation style

2. `paragraph_tokenize` with `style='newline'` that is the default style in the current version of PyThaiNLP. In other word, this is the same as 1.) case:
```python
# this is the same as paragraph_tokenize(sent)
paragraph_tokenize(text, paragraph_threshold=0.5, style='newline')

# output
# [['(1) '],
# ['บทความนี้ผู้เขียนสังเคราะห์ขึ้นมาจากผลงานวิจัยที่เคยทำมาในอดีต  ',
#  'มิได้ทำการศึกษาค้นคว้าใหม่อย่างกว้างขวางแต่อย่างใด ',
#  'จึงใคร่ขออภัยในความบกพร่องทั้งปวงมา ',
#  'ณ ที่นี้']]
```

3. `paragraph_tokenize` with `style="opus100"` that is newly added style as mentioned in wtpsplit paper that this style is supported in Thai language. This will let the tokenizer adapt to `OPUS100` style for segmentation.
```python 
# this will change the segmentation style by adapt it to OPUS100 corpus style
paragraph_tokenize(text, paragraph_threshold=0.5, style='opus100')

# output
# [['(1) '],
# ['บทความนี้ผู้เขียนสังเคราะห์ขึ้นมาจากผลงานวิจัยที่เคยทำมาในอดีต  ',
# 'มิได้ทำการศึกษาค้นคว้าใหม่อย่างกว้างขวางแต่อย่างใด จึงใคร่ขออภัยในความบกพร่องทั้งปวงมา ณ ที่นี้']]
```
 
Apart from the usage of `style` argument. I also write a condition to handle the case when the given segmentation style input is not our available style. The **ValueError** will be raised.
```python 
# this is the case that specified style input is not our available style
paragraph_tokenize(text, paragraph_threshold=0.5, style='newjeans')
```

This is an error that will be raised if that case occurs
```
ValueError: Segmentation style "newjeans" not found. It might be a typo; if not, please consult our document.
```