### PR TITLE
Fix duplicate key in IPA to RTGS phoneme mapping

### DIFF
--- a/pythainlp/util/phoneme.py
+++ b/pythainlp/util/phoneme.py
@@ -125,7 +125,13 @@ dict_ipa_rtgs = {
     "d":"d",
     "f":"f",
     "h":"h",
-    "j":"y",
+    # The conversion of j depends on its position in the syllable.
+    # But, unfortunately, the current implementation cannot handle both cases.
+    # To remove confusions without changing the behavior and breaking existing codes,
+    # it is suggested that the first key-value mapping of j be simply commented out,
+    # as it would be overridden by the second one and thus never take effect from the beginning.
+    # See #846 for a more detailed discussion: https://github.com/PyThaiNLP/pythainlp/issues/846
+    # "j":"y",
     "k":"k",
     "kʰ":"kh",
     "l":"l",
@@ -198,7 +204,7 @@ def ipa_to_rtgs(ipa: str) -> str:
     Docs: https://en.wikipedia.org/wiki/Help:IPA/Thai
 
     :param str ipa: IPA phoneme
-    :return: The RTGS that is converted
+    :return: The RTGS that is converted, according to rules listed in the Wikipedia page
     :rtype: str
 
     :Example:


### PR DESCRIPTION
### What does this changes

Following #851, this PR removes the duplicate key in IPA to RTGS phoneme mapping, according to discussions in #846.

### What was wrong

Duplicate keys in Python dictionaries are meaningless and only create confusions.

### How this fixes it

The first key-value mapping of the duplicate key is commented out.

Fixes #846 along with #851.

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test
