### PR TITLE
Improve: [newmm tokenizer] Change regular expression of "non-thai-characters"

### DIFF
--- a/pythainlp/tokenize/newmm.py
+++ b/pythainlp/tokenize/newmm.py
@@ -37,7 +37,7 @@ from pythainlp.tokenize.tcc_p import tcc_pos
 
 # match non-Thai tokens
 # English, number, (space,whitespace) and non-Thai tokens
-_PAT_NONTHAI = re.compile(r"[-a-zA-Z]+|\d+([,\.]\d+)*|[ \t]+|\r?\n|[^\u0E00-\u0E7F]+|")
+_PAT_NONTHAI = re.compile(r"[-a-zA-Z]+|\d+([,\.]\d+)*|[ \t]+|\r?\n|[^\u0E00-\u0E7F]+")
 
 # match 2-consonant Thai tokens
 _PAT_THAI_TWOCHARS = re.compile("[ก-ฮ]{,2}$")

--- a/pythainlp/tokenize/newmm.py
+++ b/pythainlp/tokenize/newmm.py
@@ -37,6 +37,8 @@ from pythainlp.tokenize.tcc_p import tcc_pos
 
 # match non-Thai tokens
 # English, number, (space,whitespace) and non-Thai tokens
+# `|` is used as like "early return",
+# which divide "abc123" to "abc", "123" for example.
 _PAT_NONTHAI = re.compile(r"[-a-zA-Z]+|\d+([,\.]\d+)*|[ \t]+|\r?\n|[^\u0E00-\u0E7F]+")
 
 # match 2-consonant Thai tokens

--- a/pythainlp/tokenize/newmm.py
+++ b/pythainlp/tokenize/newmm.py
@@ -36,8 +36,8 @@ from pythainlp.util import Trie
 from pythainlp.tokenize.tcc_p import tcc_pos
 
 # match non-Thai tokens
-# number, (space,whitespace) and non-Thai tokens
-_PAT_NONTHAI = re.compile(r"\d+([,\.]\d+)*|[ \t]+|\r?\n|[^\u0E00-\u0E7F]+")
+# English, number, (space,whitespace) and non-Thai tokens
+_PAT_NONTHAI = re.compile(r"[-a-zA-Z]+|\d+([,\.]\d+)*|[ \t]+|\r?\n|[^\u0E00-\u0E7F]+|")
 
 # match 2-consonant Thai tokens
 _PAT_THAI_TWOCHARS = re.compile("[ก-ฮ]{,2}$")

--- a/pythainlp/tokenize/newmm.py
+++ b/pythainlp/tokenize/newmm.py
@@ -36,7 +36,8 @@ from pythainlp.util import Trie
 from pythainlp.tokenize.tcc_p import tcc_pos
 
 # match non-Thai tokens
-_PAT_NONTHAI = re.compile(r"[^\u0E00-\u0E7F]+")
+# number, (space,whitespace) and non-Thai tokens
+_PAT_NONTHAI = re.compile(r"\d+([,\.]\d+)*|[ \t]+|\r?\n|[^\u0E00-\u0E7F]+")
 
 # match 2-consonant Thai tokens
 _PAT_THAI_TWOCHARS = re.compile("[ก-ฮ]{,2}$")

--- a/pythainlp/tokenize/newmm.py
+++ b/pythainlp/tokenize/newmm.py
@@ -44,7 +44,7 @@ r"""(?x)
 \d+([,\.]\d+)*|    # numbers
 [ \t]+|            # spaces
 \r?\n|             # newlines
-[^\u0E00-\u0E7F]+  # other non-Thai characters
+[^\u0E00-\u0E7F \t]+  # other non-Thai characters
 """
 )
 

--- a/pythainlp/tokenize/newmm.py
+++ b/pythainlp/tokenize/newmm.py
@@ -43,8 +43,8 @@ r"""(?x)
 [-a-zA-Z]+|        # Latin characters
 \d+([,\.]\d+)*|    # numbers
 [ \t]+|            # spaces
-\r?\n              # newlines
-|[^\u0E00-\u0E7F]+ # other non-Thai characters
+\r?\n|             # newlines
+[^\u0E00-\u0E7F]+  # other non-Thai characters
 """
 )
 

--- a/pythainlp/tokenize/newmm.py
+++ b/pythainlp/tokenize/newmm.py
@@ -44,7 +44,7 @@ r"""(?x)
 \d+([,\.]\d+)*|    # numbers
 [ \t]+|            # spaces
 \r?\n|             # newlines
-[^\u0E00-\u0E7F \t]+  # other non-Thai characters
+[^\u0E00-\u0E7F \t\r\n]+  # other non-Thai characters
 """
 )
 

--- a/pythainlp/tokenize/newmm.py
+++ b/pythainlp/tokenize/newmm.py
@@ -37,16 +37,17 @@ from pythainlp.tokenize.tcc_p import tcc_pos
 
 # match non-Thai tokens
 # `|` is used as like "early return",
-# which divide "abc123" to "abc", "123" for example.
+# which divides "abc123" to "abc", "123" for example.
 _PAT_NONTHAI = re.compile(
-   r"""(?x)
+r"""(?x)
 [-a-zA-Z]+|        # Latin characters
 \d+([,\.]\d+)*|    # numbers
 [ \t]+|            # spaces
 \r?\n              # newlines
 |[^\u0E00-\u0E7F]+ # other non-Thai characters
-""")
-    
+"""
+)
+
 # match 2-consonant Thai tokens
 _PAT_THAI_TWOCHARS = re.compile("[ก-ฮ]{,2}$")
 

--- a/pythainlp/tokenize/newmm.py
+++ b/pythainlp/tokenize/newmm.py
@@ -36,14 +36,7 @@ from pythainlp.util import Trie
 from pythainlp.tokenize.tcc_p import tcc_pos
 
 # match non-Thai tokens
-_PAT_NONTHAI = re.compile(
-    r"""(?x)
-[-a-zA-Z]+|        # Latin characters
-\d+([,\.]\d+)*|    # numbers
-[ \t]+|            # spaces
-\r?\n              # newlines
-"""
-)
+_PAT_NONTHAI = re.compile(r"[^\u0E00-\u0E7F]+")
 
 # match 2-consonant Thai tokens
 _PAT_THAI_TWOCHARS = re.compile("[ก-ฮ]{,2}$")

--- a/pythainlp/tokenize/newmm.py
+++ b/pythainlp/tokenize/newmm.py
@@ -36,11 +36,17 @@ from pythainlp.util import Trie
 from pythainlp.tokenize.tcc_p import tcc_pos
 
 # match non-Thai tokens
-# English, number, (space,whitespace) and non-Thai tokens
 # `|` is used as like "early return",
 # which divide "abc123" to "abc", "123" for example.
-_PAT_NONTHAI = re.compile(r"[-a-zA-Z]+|\d+([,\.]\d+)*|[ \t]+|\r?\n|[^\u0E00-\u0E7F]+")
-
+_PAT_NONTHAI = re.compile(
+   r"""(?x)
+[-a-zA-Z]+|        # Latin characters
+\d+([,\.]\d+)*|    # numbers
+[ \t]+|            # spaces
+\r?\n              # newlines
+|[^\u0E00-\u0E7F]+ # other non-Thai characters
+""")
+    
 # match 2-consonant Thai tokens
 _PAT_THAI_TWOCHARS = re.compile("[ก-ฮ]{,2}$")
 

--- a/pythainlp/tokenize/newmm.py
+++ b/pythainlp/tokenize/newmm.py
@@ -44,7 +44,7 @@ r"""(?x)
 \d+([,\.]\d+)*|    # numbers
 [ \t]+|            # spaces
 \r?\n|             # newlines
-[^\u0E00-\u0E7F \t\r\n]+  # other non-Thai characters
+[^\u0E00-\u0E7F \t\r\n]+  # other non-Thai characters, and stops matching until space/newline
 """
 )
 

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -653,6 +653,15 @@ class TestTokenizePackage(unittest.TestCase):
                 keep_whitespace=False,
             )
         )
+        self.assertEqual(
+            word_tokenize("(คนไม่เอา)", engine="newmm"), ['(', 'คน', 'ไม่', 'เอา', ')']
+        )
+        self.assertEqual(
+            word_tokenize("กม/ชม", engine="newmm"), ['กม', '/', 'ชม']
+        )
+        self.assertEqual(
+            word_tokenize("สีหน้า(รถ)", engine="newmm"), ['สีหน้า', '(', 'รถ', ')']
+        )
 
     def test_newmm_longtext(self):
         self.assertIsInstance(


### PR DESCRIPTION
# What does this changes

Make the newmm tokenization more accurate; recognize more characters as "non-thai"

### What was wrong

#855 
It sometimes didn't recognize non-thai symbols as non-thai
"(คนไม่เอา)" -> ['(คน', 'ไม่', 'เอา', ')']
"กม/ชม" -> ['กม', '/ชม']
"สีหน้า(รถ)" -> ['สีหน้า', '(รถ)']

### How this fixes it

Fixed the recognition method of "non-thai-character".
The examples above are all improved.

### Your checklist for this pull request
- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test
