### PR TITLE
Update `pos_tag_transformers` function

### DIFF
--- a/pythainlp/tag/pos_tag.py
+++ b/pythainlp/tag/pos_tag.py
@@ -180,7 +180,9 @@ def pos_tag_sents(
 
 
 def pos_tag_transformers(
-    words: str, engine: str = "bert-base-th-cased-blackboard"
+    words: str, 
+    engine: str = "bert",
+    corpus: str = "blackboard",
 ):
     """
     "wangchanberta-ud-thai-pud-upos",
@@ -199,21 +201,27 @@ def pos_tag_transformers(
     if not words:
         return []
 
-    if engine == "wangchanberta-ud-thai-pud-upos":
-        model = AutoModelForTokenClassification.from_pretrained(
-            "Pavarissy/wangchanberta-ud-thai-pud-upos")
-        tokenizer = AutoTokenizer.from_pretrained("Pavarissy/wangchanberta-ud-thai-pud-upos")
-    elif engine == "mdeberta-v3-ud-thai-pud-upos":
-        model = AutoModelForTokenClassification.from_pretrained(
-            "Pavarissy/mdeberta-v3-ud-thai-pud-upos")
-        tokenizer = AutoTokenizer.from_pretrained("Pavarissy/mdeberta-v3-ud-thai-pud-upos")
-    elif engine == "bert-base-th-cased-blackboard":
-        model = AutoModelForTokenClassification.from_pretrained("lunarlist/pos_thai")
-        tokenizer = AutoTokenizer.from_pretrained("lunarlist/pos_thai")
+    _blackboard_support_engine = {
+        "bert" : "lunarlist/pos_thai",
+    }
+
+    _pud_support_engine = {
+        "wangchanberta" : "Pavarissy/wangchanberta-ud-thai-pud-upos",
+        "mdeberta" : "Pavarissy/mdeberta-v3-ud-thai-pud-upos",
+    }
+
+    if corpus == 'blackboard' and engine in _blackboard_support_engine.keys():
+        base_model = _blackboard_support_engine.get(engine)
+        model = AutoModelForTokenClassification.from_pretrained(base_model)
+        tokenizer = AutoTokenizer.from_pretrained(base_model)
+    elif corpus == 'pud' and engine in _pud_support_engine.keys():
+        base_model = _pud_support_engine.get(engine)
+        model = AutoModelForTokenClassification.from_pretrained(base_model)
+        tokenizer = AutoTokenizer.from_pretrained(base_model)
     else:
         raise ValueError(
-            "pos_tag_transformers not support {0} engine.".format(
-                engine
+            "pos_tag_transformers not support {0} engine or {1} corpus.".format(
+                engine, corpus
             )
         )
 

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -367,10 +367,13 @@ class TestTagPackage(unittest.TestCase):
 
     def test_pos_tag_transformers(self):
         self.assertIsNotNone(pos_tag_transformers(
-            words="แมวทำอะไรตอนห้าโมงเช้า", engine="bert-base-th-cased-blackboard"))
+            words="แมวทำอะไรตอนห้าโมงเช้า", engine="bert", corpus="blackboard"))
         self.assertIsNotNone(pos_tag_transformers(
-            words="แมวทำอะไรตอนห้าโมงเช้า", engine="mdeberta-v3-ud-thai-pud-upos"))
+            words="แมวทำอะไรตอนห้าโมงเช้า", engine="mdeberta", corpus="pud"))
         self.assertIsNotNone(pos_tag_transformers(
-            words="แมวทำอะไรตอนห้าโมงเช้า", engine="wangchanberta-ud-thai-pud-upos"))
+            words="แมวทำอะไรตอนห้าโมงเช้า", engine="wangchanberta", corpus="pud"))
         with self.assertRaises(ValueError):
             pos_tag_transformers(words="แมวทำอะไรตอนห้าโมงเช้า", engine="non-existing-engine")
+        with self.assertRaises(ValueError):
+            pos_tag_transformers(words="แมวทำอะไรตอนห้าโมงเช้า", engine="bert", 
+                                 corpus="non-existing corpus")


### PR DESCRIPTION
### What does this changes

from #866, i've updated `pos_tag_transformers` function by clean up the code, add docstring, fix deprecation, and change the output format of the function to make it be the same format as other tagger in PyThaiNLP

### What was wrong

in #857 , `pos_tag_transformers` was added which consist of 3 models, however, to call and engine, the full name of it must be specified, also the output still not the same format as another tagger. For example
```python
pos_tag_transformers(words="แมวทำอะไรตอนห้าโมงเช้า", engine = "bert-base-th-cased-blackboard")
# outputs
# [{'entity_group': 'NN', 'score': 0.910759, 'word': 'แมวมา', 'start': 0, 'end': 5},
#  {'entity_group': 'VV', 'score': 0.9462489, 'word': '##ทำ', 'start': 5,  'end': 7},
# {'entity_group': 'NN', 'score': 0.8325567, 'word': '##อะไรตอนห้าโมงเช้า',  'start': 7, 'end': 24}]
```
which is very hard for the normal user to remember its entire name, and may result in more mess in the internal code if another transformers model trained on new corpus are added. we will end up with a lot of if-else condition in order to call a model in the future
### How this fixes it

i've cleaned up the code to let a user call a model with parameters named `engine` and `corpus` same as what we have from the former function that is `pos_tag` and `pos_tag_sents` and also fix output format. This will reduce how hard to remember the entire model name. Here is the newly added version:
```python
from pythainlp.tag import pos_tag_transformers
txt = pos_tag_transformers(sentence="แมวทำอะไรตอนห้าโมงเช้า", engine="mdeberta", corpus='pud')
# outputs
# [[('แมว', 'NOUN'), ('ทําอะไร', 'VERB'), ('ตอนห้าโมงเช้า', 'NOUN')]]
```

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [ ] Passed code styles and structures
- [ ] Passed code linting checks and unit test
