### PR TITLE
switch PyThaiNLP source code to SPDX license ID

### DIFF
--- a/pythainlp/__init__.py
+++ b/pythainlp/__init__.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 # SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
 # SPDX-License-Identifier: Apache-2.0
-#
-# URL: <https://pythainlp.github.io/>
-# For license information, see LICENSE
 __version__ = "5.0.0dev0"
 
 thai_consonants = "กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรลวศษสหฬอฮ"  # 44 chars

--- a/pythainlp/__init__.py
+++ b/pythainlp/__init__.py
@@ -1,19 +1,6 @@
 # -*- coding: utf-8 -*-
-# PyThaiNLP: Thai Natural Language Processing in Python
-#
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 #
 # URL: <https://pythainlp.github.io/>
 # For license information, see LICENSE

--- a/pythainlp/__init__.py
+++ b/pythainlp/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 #
 # URL: <https://pythainlp.github.io/>

--- a/pythainlp/__main__.py
+++ b/pythainlp/__main__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 import argparse
 import sys

--- a/pythainlp/__main__.py
+++ b/pythainlp/__main__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 import argparse
 import sys
 

--- a/pythainlp/ancient/__init__.py
+++ b/pythainlp/ancient/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Ancient versions of the Thai language

--- a/pythainlp/ancient/__init__.py
+++ b/pythainlp/ancient/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Ancient versions of the Thai language
 """

--- a/pythainlp/ancient/aksonhan.py
+++ b/pythainlp/ancient/aksonhan.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from pythainlp.util import Trie
 from pythainlp import thai_consonants,thai_tonemarks
 from pythainlp.tokenize import Tokenizer

--- a/pythainlp/ancient/aksonhan.py
+++ b/pythainlp/ancient/aksonhan.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from pythainlp.util import Trie
 from pythainlp import thai_consonants,thai_tonemarks

--- a/pythainlp/augment/__init__.py
+++ b/pythainlp/augment/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai text augment
 """

--- a/pythainlp/augment/__init__.py
+++ b/pythainlp/augment/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai text augment

--- a/pythainlp/augment/lm/__init__.py
+++ b/pythainlp/augment/lm/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 LM
 """

--- a/pythainlp/augment/lm/__init__.py
+++ b/pythainlp/augment/lm/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 LM

--- a/pythainlp/augment/lm/fasttext.py
+++ b/pythainlp/augment/lm/fasttext.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 import itertools
 from typing import List, Tuple

--- a/pythainlp/augment/lm/fasttext.py
+++ b/pythainlp/augment/lm/fasttext.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 import itertools
 from typing import List, Tuple
 from gensim.models.fasttext import FastText as FastText_gensim

--- a/pythainlp/augment/lm/wangchanberta.py
+++ b/pythainlp/augment/lm/wangchanberta.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List
 from transformers import (

--- a/pythainlp/augment/lm/wangchanberta.py
+++ b/pythainlp/augment/lm/wangchanberta.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List
 from transformers import (
     CamembertTokenizer,

--- a/pythainlp/augment/word2vec/__init__.py
+++ b/pythainlp/augment/word2vec/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Word2Vec
 """

--- a/pythainlp/augment/word2vec/__init__.py
+++ b/pythainlp/augment/word2vec/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Word2Vec

--- a/pythainlp/augment/word2vec/bpemb_wv.py
+++ b/pythainlp/augment/word2vec/bpemb_wv.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple
 from pythainlp.augment.word2vec.core import Word2VecAug

--- a/pythainlp/augment/word2vec/bpemb_wv.py
+++ b/pythainlp/augment/word2vec/bpemb_wv.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple
 from pythainlp.augment.word2vec.core import Word2VecAug
 

--- a/pythainlp/augment/word2vec/core.py
+++ b/pythainlp/augment/word2vec/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple
 import itertools

--- a/pythainlp/augment/word2vec/core.py
+++ b/pythainlp/augment/word2vec/core.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple
 import itertools
 

--- a/pythainlp/augment/word2vec/ltw2v.py
+++ b/pythainlp/augment/word2vec/ltw2v.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple
 from pythainlp.augment.word2vec.core import Word2VecAug
 from pythainlp.corpus import get_corpus_path

--- a/pythainlp/augment/word2vec/ltw2v.py
+++ b/pythainlp/augment/word2vec/ltw2v.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple
 from pythainlp.augment.word2vec.core import Word2VecAug

--- a/pythainlp/augment/word2vec/thai2fit.py
+++ b/pythainlp/augment/word2vec/thai2fit.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple
 from pythainlp.augment.word2vec.core import Word2VecAug
 from pythainlp.corpus import get_corpus_path

--- a/pythainlp/augment/word2vec/thai2fit.py
+++ b/pythainlp/augment/word2vec/thai2fit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple
 from pythainlp.augment.word2vec.core import Word2VecAug

--- a/pythainlp/augment/wordnet.py
+++ b/pythainlp/augment/wordnet.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thank https://dev.to/ton_ami/text-data-augmentation-synonym-replacement-4h8l
 """

--- a/pythainlp/augment/wordnet.py
+++ b/pythainlp/augment/wordnet.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thank https://dev.to/ton_ami/text-data-augmentation-synonym-replacement-4h8l

--- a/pythainlp/benchmarks/__init__.py
+++ b/pythainlp/benchmarks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Performance benchmarking.

--- a/pythainlp/benchmarks/__init__.py
+++ b/pythainlp/benchmarks/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Performance benchmarking.
 """

--- a/pythainlp/benchmarks/word_tokenization.py
+++ b/pythainlp/benchmarks/word_tokenization.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 
 import re

--- a/pythainlp/benchmarks/word_tokenization.py
+++ b/pythainlp/benchmarks/word_tokenization.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 
 import re
 import sys

--- a/pythainlp/chat/__init__.py
+++ b/pythainlp/chat/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 pythainlp.chat

--- a/pythainlp/chat/__init__.py
+++ b/pythainlp/chat/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 pythainlp.chat
 """

--- a/pythainlp/chat/core.py
+++ b/pythainlp/chat/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 import torch
 

--- a/pythainlp/chat/core.py
+++ b/pythainlp/chat/core.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 import torch
 
 

--- a/pythainlp/cli/__init__.py
+++ b/pythainlp/cli/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """Command line helpers."""
 import sys

--- a/pythainlp/cli/__init__.py
+++ b/pythainlp/cli/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """Command line helpers."""
 import sys
 from argparse import ArgumentParser

--- a/pythainlp/cli/benchmark.py
+++ b/pythainlp/cli/benchmark.py
@@ -1,18 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 
 import argparse
 import json

--- a/pythainlp/cli/benchmark.py
+++ b/pythainlp/cli/benchmark.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse

--- a/pythainlp/cli/data.py
+++ b/pythainlp/cli/data.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Command line for PyThaiNLP's dataset/corpus management.
 """

--- a/pythainlp/cli/data.py
+++ b/pythainlp/cli/data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Command line for PyThaiNLP's dataset/corpus management.

--- a/pythainlp/cli/soundex.py
+++ b/pythainlp/cli/soundex.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Command line for PyThaiNLP's soundex.

--- a/pythainlp/cli/soundex.py
+++ b/pythainlp/cli/soundex.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Command line for PyThaiNLP's soundex.
 

--- a/pythainlp/cli/tag.py
+++ b/pythainlp/cli/tag.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Command line for PyThaiNLP's taggers.

--- a/pythainlp/cli/tag.py
+++ b/pythainlp/cli/tag.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Command line for PyThaiNLP's taggers.
 """

--- a/pythainlp/cli/tokenize.py
+++ b/pythainlp/cli/tokenize.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Command line for PyThaiNLP's tokenizers.

--- a/pythainlp/cli/tokenize.py
+++ b/pythainlp/cli/tokenize.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Command line for PyThaiNLP's tokenizers.
 """

--- a/pythainlp/cls/__init__.py
+++ b/pythainlp/cls/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 pythainlp.cls
 """

--- a/pythainlp/cls/__init__.py
+++ b/pythainlp/cls/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 pythainlp.cls

--- a/pythainlp/cls/param_free.py
+++ b/pythainlp/cls/param_free.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 
 import gzip

--- a/pythainlp/cls/param_free.py
+++ b/pythainlp/cls/param_free.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 
 import gzip
 from typing import List, Tuple

--- a/pythainlp/coref/__init__.py
+++ b/pythainlp/coref/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 PyThaiNLP Coreference Resolution
 """

--- a/pythainlp/coref/__init__.py
+++ b/pythainlp/coref/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 PyThaiNLP Coreference Resolution

--- a/pythainlp/coref/_fastcoref.py
+++ b/pythainlp/coref/_fastcoref.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List
 import spacy

--- a/pythainlp/coref/_fastcoref.py
+++ b/pythainlp/coref/_fastcoref.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List
 import spacy
 

--- a/pythainlp/coref/core.py
+++ b/pythainlp/coref/core.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List
 model = None
 

--- a/pythainlp/coref/core.py
+++ b/pythainlp/coref/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List
 model = None

--- a/pythainlp/coref/han_coref.py
+++ b/pythainlp/coref/han_coref.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 import spacy
 from pythainlp.coref._fastcoref import FastCoref

--- a/pythainlp/coref/han_coref.py
+++ b/pythainlp/coref/han_coref.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 import spacy
 from pythainlp.coref._fastcoref import FastCoref
 

--- a/pythainlp/corpus/__init__.py
+++ b/pythainlp/corpus/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Corpus related functions.
 

--- a/pythainlp/corpus/__init__.py
+++ b/pythainlp/corpus/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Corpus related functions.

--- a/pythainlp/corpus/common.py
+++ b/pythainlp/corpus/common.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Common lists of words.
 """

--- a/pythainlp/corpus/common.py
+++ b/pythainlp/corpus/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Common lists of words.

--- a/pythainlp/corpus/conceptnet.py
+++ b/pythainlp/corpus/conceptnet.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Get data from ConceptNet API at http://conceptnet.io

--- a/pythainlp/corpus/conceptnet.py
+++ b/pythainlp/corpus/conceptnet.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Get data from ConceptNet API at http://conceptnet.io
 """

--- a/pythainlp/corpus/core.py
+++ b/pythainlp/corpus/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Corpus related functions.

--- a/pythainlp/corpus/core.py
+++ b/pythainlp/corpus/core.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Corpus related functions.
 """

--- a/pythainlp/corpus/oscar.py
+++ b/pythainlp/corpus/oscar.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai unigram word frequency from OSCAR Corpus (words tokenized using ICU)
 

--- a/pythainlp/corpus/oscar.py
+++ b/pythainlp/corpus/oscar.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai unigram word frequency from OSCAR Corpus (words tokenized using ICU)

--- a/pythainlp/corpus/th_en_translit.py
+++ b/pythainlp/corpus/th_en_translit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai-English Transliteration Dictionary v1.4

--- a/pythainlp/corpus/th_en_translit.py
+++ b/pythainlp/corpus/th_en_translit.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai-English Transliteration Dictionary v1.4
 

--- a/pythainlp/corpus/tnc.py
+++ b/pythainlp/corpus/tnc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project.
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai National Corpus word frequency

--- a/pythainlp/corpus/tnc.py
+++ b/pythainlp/corpus/tnc.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai National Corpus word frequency
 """

--- a/pythainlp/corpus/ttc.py
+++ b/pythainlp/corpus/ttc.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai Textbook Corpus (TTC) word frequency
 

--- a/pythainlp/corpus/ttc.py
+++ b/pythainlp/corpus/ttc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai Textbook Corpus (TTC) word frequency

--- a/pythainlp/corpus/util.py
+++ b/pythainlp/corpus/util.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Tool for creating word lists

--- a/pythainlp/corpus/util.py
+++ b/pythainlp/corpus/util.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Tool for creating word lists
 codes are from Korakot Chaovavanich.

--- a/pythainlp/corpus/volubilis.py
+++ b/pythainlp/corpus/volubilis.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Provides an optional word list from the Volubilis dictionary.
 """

--- a/pythainlp/corpus/volubilis.py
+++ b/pythainlp/corpus/volubilis.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Provides an optional word list from the Volubilis dictionary.

--- a/pythainlp/corpus/wikipedia_titles.py
+++ b/pythainlp/corpus/wikipedia_titles.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Provides an optional word list from Thai Wikipedia titles.
 """

--- a/pythainlp/corpus/wikipedia_titles.py
+++ b/pythainlp/corpus/wikipedia_titles.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Provides an optional word list from Thai Wikipedia titles.

--- a/pythainlp/corpus/wordnet.py
+++ b/pythainlp/corpus/wordnet.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 NLTK WordNet wrapper

--- a/pythainlp/corpus/wordnet.py
+++ b/pythainlp/corpus/wordnet.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 NLTK WordNet wrapper
 

--- a/pythainlp/el/__init__.py
+++ b/pythainlp/el/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 pythainlp.el

--- a/pythainlp/el/__init__.py
+++ b/pythainlp/el/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 pythainlp.el
 """

--- a/pythainlp/el/_multiel.py
+++ b/pythainlp/el/_multiel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/pythainlp/el/_multiel.py
+++ b/pythainlp/el/_multiel.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 
 
 class MultiEL:

--- a/pythainlp/el/core.py
+++ b/pythainlp/el/core.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List, Union
 
 

--- a/pythainlp/el/core.py
+++ b/pythainlp/el/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List, Union
 

--- a/pythainlp/generate/__init__.py
+++ b/pythainlp/generate/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai Text Generation

--- a/pythainlp/generate/__init__.py
+++ b/pythainlp/generate/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai Text Generation
 """

--- a/pythainlp/generate/core.py
+++ b/pythainlp/generate/core.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Text generator using n-gram language model
 

--- a/pythainlp/generate/core.py
+++ b/pythainlp/generate/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Text generator using n-gram language model

--- a/pythainlp/generate/thai2fit.py
+++ b/pythainlp/generate/thai2fit.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai2fit: Thai Wikipeida Language Model for Text Generation
 

--- a/pythainlp/generate/thai2fit.py
+++ b/pythainlp/generate/thai2fit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai2fit: Thai Wikipeida Language Model for Text Generation

--- a/pythainlp/generate/wangchanglm.py
+++ b/pythainlp/generate/wangchanglm.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 import re
 import torch

--- a/pythainlp/generate/wangchanglm.py
+++ b/pythainlp/generate/wangchanglm.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 import re
 import torch
 

--- a/pythainlp/khavee/__init__.py
+++ b/pythainlp/khavee/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 __all__ = ["KhaveeVerifier"]
 
 from pythainlp.khavee.core import KhaveeVerifier

--- a/pythainlp/khavee/__init__.py
+++ b/pythainlp/khavee/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 __all__ = ["KhaveeVerifier"]
 

--- a/pythainlp/khavee/core.py
+++ b/pythainlp/khavee/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List, Union
 from pythainlp.tokenize import subword_tokenize

--- a/pythainlp/khavee/core.py
+++ b/pythainlp/khavee/core.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List, Union
 from pythainlp.tokenize import subword_tokenize
 from pythainlp.util import sound_syllable

--- a/pythainlp/parse/__init__.py
+++ b/pythainlp/parse/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 PyThaiNLP Parse

--- a/pythainlp/parse/__init__.py
+++ b/pythainlp/parse/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 PyThaiNLP Parse
 """

--- a/pythainlp/parse/core.py
+++ b/pythainlp/parse/core.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List, Union
 
 

--- a/pythainlp/parse/core.py
+++ b/pythainlp/parse/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List, Union
 

--- a/pythainlp/soundex/__init__.py
+++ b/pythainlp/soundex/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai soundex

--- a/pythainlp/soundex/__init__.py
+++ b/pythainlp/soundex/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai soundex
 

--- a/pythainlp/soundex/core.py
+++ b/pythainlp/soundex/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai soundex

--- a/pythainlp/soundex/core.py
+++ b/pythainlp/soundex/core.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai soundex
 

--- a/pythainlp/soundex/lk82.py
+++ b/pythainlp/soundex/lk82.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai soundex - LK82 system

--- a/pythainlp/soundex/lk82.py
+++ b/pythainlp/soundex/lk82.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai soundex - LK82 system
 

--- a/pythainlp/soundex/metasound.py
+++ b/pythainlp/soundex/metasound.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai soundex - MetaSound system

--- a/pythainlp/soundex/metasound.py
+++ b/pythainlp/soundex/metasound.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai soundex - MetaSound system
 

--- a/pythainlp/soundex/prayut_and_somchaip.py
+++ b/pythainlp/soundex/prayut_and_somchaip.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai-English Cross-Language Transliterated Word Retrieval
 using Soundex Technique

--- a/pythainlp/soundex/prayut_and_somchaip.py
+++ b/pythainlp/soundex/prayut_and_somchaip.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai-English Cross-Language Transliterated Word Retrieval

--- a/pythainlp/soundex/sound.py
+++ b/pythainlp/soundex/sound.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List
 import panphon

--- a/pythainlp/soundex/sound.py
+++ b/pythainlp/soundex/sound.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List
 import panphon
 import panphon.distance

--- a/pythainlp/soundex/udom83.py
+++ b/pythainlp/soundex/udom83.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai soundex - Udom83 system

--- a/pythainlp/soundex/udom83.py
+++ b/pythainlp/soundex/udom83.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai soundex - Udom83 system
 

--- a/pythainlp/spell/__init__.py
+++ b/pythainlp/spell/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Spell checking and correction.

--- a/pythainlp/spell/__init__.py
+++ b/pythainlp/spell/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Spell checking and correction.
 """

--- a/pythainlp/spell/core.py
+++ b/pythainlp/spell/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Spell checking functions

--- a/pythainlp/spell/core.py
+++ b/pythainlp/spell/core.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Spell checking functions
 """

--- a/pythainlp/spell/phunspell.py
+++ b/pythainlp/spell/phunspell.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Phunspell
 

--- a/pythainlp/spell/phunspell.py
+++ b/pythainlp/spell/phunspell.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Phunspell

--- a/pythainlp/spell/symspellpy.py
+++ b/pythainlp/spell/symspellpy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 symspellpy

--- a/pythainlp/spell/symspellpy.py
+++ b/pythainlp/spell/symspellpy.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 symspellpy
 

--- a/pythainlp/spell/tltk.py
+++ b/pythainlp/spell/tltk.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 TLTK
 

--- a/pythainlp/spell/tltk.py
+++ b/pythainlp/spell/tltk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 TLTK

--- a/pythainlp/spell/wanchanberta_thai_grammarly.py
+++ b/pythainlp/spell/wanchanberta_thai_grammarly.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Two-stage Thai Misspelling Correction based on Pre-trained Language Models

--- a/pythainlp/spell/wanchanberta_thai_grammarly.py
+++ b/pythainlp/spell/wanchanberta_thai_grammarly.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Two-stage Thai Misspelling Correction based on Pre-trained Language Models
 

--- a/pythainlp/summarize/__init__.py
+++ b/pythainlp/summarize/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Text summarization

--- a/pythainlp/summarize/__init__.py
+++ b/pythainlp/summarize/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Text summarization
 """

--- a/pythainlp/summarize/core.py
+++ b/pythainlp/summarize/core.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Text summarization and keyword extraction
 """

--- a/pythainlp/summarize/core.py
+++ b/pythainlp/summarize/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Text summarization and keyword extraction

--- a/pythainlp/summarize/freq.py
+++ b/pythainlp/summarize/freq.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Summarization by frequency of words

--- a/pythainlp/summarize/freq.py
+++ b/pythainlp/summarize/freq.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Summarization by frequency of words
 """

--- a/pythainlp/summarize/keybert.py
+++ b/pythainlp/summarize/keybert.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Minimal re-implementation of KeyBERT.
 

--- a/pythainlp/summarize/keybert.py
+++ b/pythainlp/summarize/keybert.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Minimal re-implementation of KeyBERT.

--- a/pythainlp/summarize/mt5.py
+++ b/pythainlp/summarize/mt5.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Summarization by mT5 model

--- a/pythainlp/summarize/mt5.py
+++ b/pythainlp/summarize/mt5.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Summarization by mT5 model
 """

--- a/pythainlp/tag/__init__.py
+++ b/pythainlp/tag/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Linguistic and other taggers.

--- a/pythainlp/tag/__init__.py
+++ b/pythainlp/tag/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Linguistic and other taggers.
 

--- a/pythainlp/tag/_tag_perceptron.py
+++ b/pythainlp/tag/_tag_perceptron.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Perceptron Tagger.
 

--- a/pythainlp/tag/_tag_perceptron.py
+++ b/pythainlp/tag/_tag_perceptron.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Perceptron Tagger.

--- a/pythainlp/tag/blackboard.py
+++ b/pythainlp/tag/blackboard.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple
 

--- a/pythainlp/tag/blackboard.py
+++ b/pythainlp/tag/blackboard.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple
 
 # defined strings for special characters

--- a/pythainlp/tag/chunk.py
+++ b/pythainlp/tag/chunk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple
 

--- a/pythainlp/tag/chunk.py
+++ b/pythainlp/tag/chunk.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple
 
 

--- a/pythainlp/tag/crfchunk.py
+++ b/pythainlp/tag/crfchunk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import Dict, List, Tuple
 from pycrfsuite import Tagger as CRFTagger

--- a/pythainlp/tag/crfchunk.py
+++ b/pythainlp/tag/crfchunk.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import Dict, List, Tuple
 from pycrfsuite import Tagger as CRFTagger
 from pythainlp.corpus import path_pythainlp_corpus, thai_stopwords

--- a/pythainlp/tag/locations.py
+++ b/pythainlp/tag/locations.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Recognizes locations in text
 """

--- a/pythainlp/tag/locations.py
+++ b/pythainlp/tag/locations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Recognizes locations in text

--- a/pythainlp/tag/named_entity.py
+++ b/pythainlp/tag/named_entity.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Named-entity recognizer

--- a/pythainlp/tag/named_entity.py
+++ b/pythainlp/tag/named_entity.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Named-entity recognizer
 """

--- a/pythainlp/tag/orchid.py
+++ b/pythainlp/tag/orchid.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Data preprocessing for ORCHID corpus
 """

--- a/pythainlp/tag/orchid.py
+++ b/pythainlp/tag/orchid.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Data preprocessing for ORCHID corpus

--- a/pythainlp/tag/perceptron.py
+++ b/pythainlp/tag/perceptron.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Perceptron part-of-speech tagger

--- a/pythainlp/tag/perceptron.py
+++ b/pythainlp/tag/perceptron.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Perceptron part-of-speech tagger
 """

--- a/pythainlp/tag/pos_tag.py
+++ b/pythainlp/tag/pos_tag.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple
 

--- a/pythainlp/tag/pos_tag.py
+++ b/pythainlp/tag/pos_tag.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple
 
 

--- a/pythainlp/tag/thai_nner.py
+++ b/pythainlp/tag/thai_nner.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple
 from thai_nner import NNER

--- a/pythainlp/tag/thai_nner.py
+++ b/pythainlp/tag/thai_nner.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple
 from thai_nner import NNER
 from pythainlp.corpus import get_corpus_path

--- a/pythainlp/tag/thainer.py
+++ b/pythainlp/tag/thainer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Named-entity recognizer

--- a/pythainlp/tag/thainer.py
+++ b/pythainlp/tag/thainer.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Named-entity recognizer
 """

--- a/pythainlp/tag/tltk.py
+++ b/pythainlp/tag/tltk.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple, Union
 try:
     from tltk import nlp

--- a/pythainlp/tag/tltk.py
+++ b/pythainlp/tag/tltk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple, Union
 try:

--- a/pythainlp/tag/unigram.py
+++ b/pythainlp/tag/unigram.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Unigram Part-Of-Speech tagger
 """

--- a/pythainlp/tag/unigram.py
+++ b/pythainlp/tag/unigram.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Unigram Part-Of-Speech tagger

--- a/pythainlp/tag/wangchanberta_onnx.py
+++ b/pythainlp/tag/wangchanberta_onnx.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List
 import json

--- a/pythainlp/tag/wangchanberta_onnx.py
+++ b/pythainlp/tag/wangchanberta_onnx.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List
 import json
 

--- a/pythainlp/tokenize/__init__.py
+++ b/pythainlp/tokenize/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Tokenizers at different levels of linguistic analysis.

--- a/pythainlp/tokenize/__init__.py
+++ b/pythainlp/tokenize/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Tokenizers at different levels of linguistic analysis.
 """

--- a/pythainlp/tokenize/_utils.py
+++ b/pythainlp/tokenize/_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Utility functions for tokenize module.

--- a/pythainlp/tokenize/_utils.py
+++ b/pythainlp/tokenize/_utils.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Utility functions for tokenize module.
 """

--- a/pythainlp/tokenize/attacut.py
+++ b/pythainlp/tokenize/attacut.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Wrapper for AttaCut - Fast and Reasonably Accurate Word Tokenizer for Thai
 

--- a/pythainlp/tokenize/attacut.py
+++ b/pythainlp/tokenize/attacut.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Wrapper for AttaCut - Fast and Reasonably Accurate Word Tokenizer for Thai

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Generic functions of tokenizers

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Generic functions of tokenizers
 """

--- a/pythainlp/tokenize/crfcls.py
+++ b/pythainlp/tokenize/crfcls.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Clause segmenter

--- a/pythainlp/tokenize/crfcls.py
+++ b/pythainlp/tokenize/crfcls.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Clause segmenter
 """

--- a/pythainlp/tokenize/crfcut.py
+++ b/pythainlp/tokenize/crfcut.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 CRFCut - Thai sentence segmenter.
 

--- a/pythainlp/tokenize/crfcut.py
+++ b/pythainlp/tokenize/crfcut.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 CRFCut - Thai sentence segmenter.

--- a/pythainlp/tokenize/deepcut.py
+++ b/pythainlp/tokenize/deepcut.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Wrapper for deepcut Thai word segmentation. deepcut is a

--- a/pythainlp/tokenize/deepcut.py
+++ b/pythainlp/tokenize/deepcut.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Wrapper for deepcut Thai word segmentation. deepcut is a
 Thai word segmentation library using 1D Convolution Neural Network.

--- a/pythainlp/tokenize/etcc.py
+++ b/pythainlp/tokenize/etcc.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Segmenting text into Enhanced Thai Character Clusters (ETCCs)
 Python implementation by Wannaphong Phatthiyaphaibun

--- a/pythainlp/tokenize/etcc.py
+++ b/pythainlp/tokenize/etcc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Segmenting text into Enhanced Thai Character Clusters (ETCCs)

--- a/pythainlp/tokenize/han_solo.py
+++ b/pythainlp/tokenize/han_solo.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 🪿 Han-solo: Thai syllable segmenter
 

--- a/pythainlp/tokenize/han_solo.py
+++ b/pythainlp/tokenize/han_solo.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 🪿 Han-solo: Thai syllable segmenter

--- a/pythainlp/tokenize/multi_cut.py
+++ b/pythainlp/tokenize/multi_cut.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Multi cut -- Thai word segmentation with maximum matching.
 Original codes from Korakot Chaovavanich.

--- a/pythainlp/tokenize/multi_cut.py
+++ b/pythainlp/tokenize/multi_cut.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Multi cut -- Thai word segmentation with maximum matching.

--- a/pythainlp/tokenize/nercut.py
+++ b/pythainlp/tokenize/nercut.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 nercut 0.2

--- a/pythainlp/tokenize/nercut.py
+++ b/pythainlp/tokenize/nercut.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 nercut 0.2
 

--- a/pythainlp/tokenize/newmm.py
+++ b/pythainlp/tokenize/newmm.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Dictionary-based maximal matching word segmentation, constrained by

--- a/pythainlp/tokenize/newmm.py
+++ b/pythainlp/tokenize/newmm.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Dictionary-based maximal matching word segmentation, constrained by
 Thai Character Cluster (TCC) boundaries with improved rules.

--- a/pythainlp/tokenize/nlpo3.py
+++ b/pythainlp/tokenize/nlpo3.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+#SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from sys import stderr
 from typing import List

--- a/pythainlp/tokenize/nlpo3.py
+++ b/pythainlp/tokenize/nlpo3.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from sys import stderr
 from typing import List
 

--- a/pythainlp/tokenize/oskut.py
+++ b/pythainlp/tokenize/oskut.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Wrapper OSKut (Out-of-domain StacKed cut for Word Segmentation).
 Handling Cross- and Out-of-Domain Samples in Thai Word Segmentation

--- a/pythainlp/tokenize/oskut.py
+++ b/pythainlp/tokenize/oskut.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Wrapper OSKut (Out-of-domain StacKed cut for Word Segmentation).

--- a/pythainlp/tokenize/pyicu.py
+++ b/pythainlp/tokenize/pyicu.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Wrapper for PyICU word segmentation. This wrapper module uses

--- a/pythainlp/tokenize/pyicu.py
+++ b/pythainlp/tokenize/pyicu.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Wrapper for PyICU word segmentation. This wrapper module uses
 :class:`icu.BreakIterator` with Thai as :class:`icu.Local`

--- a/pythainlp/tokenize/sefr_cut.py
+++ b/pythainlp/tokenize/sefr_cut.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Wrapper for SEFR CUT Thai word segmentation. SEFR CUT is a

--- a/pythainlp/tokenize/sefr_cut.py
+++ b/pythainlp/tokenize/sefr_cut.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Wrapper for SEFR CUT Thai word segmentation. SEFR CUT is a
 Thai Word Segmentation Models using Stacked Ensemble.

--- a/pythainlp/tokenize/ssg.py
+++ b/pythainlp/tokenize/ssg.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List
 

--- a/pythainlp/tokenize/ssg.py
+++ b/pythainlp/tokenize/ssg.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List
 
 from ssg import syllable_tokenize

--- a/pythainlp/tokenize/tcc.py
+++ b/pythainlp/tokenize/tcc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 The implementation of tokenizer according to Thai Character Clusters (TCCs)

--- a/pythainlp/tokenize/tcc.py
+++ b/pythainlp/tokenize/tcc.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 The implementation of tokenizer according to Thai Character Clusters (TCCs)
 rules proposed by `Theeramunkong et al. 2000. \

--- a/pythainlp/tokenize/tcc_p.py
+++ b/pythainlp/tokenize/tcc_p.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 The implementation of tokenizer according to Thai Character Clusters (TCCs)

--- a/pythainlp/tokenize/tcc_p.py
+++ b/pythainlp/tokenize/tcc_p.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 The implementation of tokenizer according to Thai Character Clusters (TCCs)
 rules proposed by `Theeramunkong et al. 2000. \

--- a/pythainlp/tokenize/tltk.py
+++ b/pythainlp/tokenize/tltk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List
 try:

--- a/pythainlp/tokenize/tltk.py
+++ b/pythainlp/tokenize/tltk.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List
 try:
     from tltk.nlp import word_segment as tltk_segment

--- a/pythainlp/tokenize/wtsplit.py
+++ b/pythainlp/tokenize/wtsplit.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Where's the Point? Self-Supervised Multilingual Punctuation-Agnostic Sentence Segmentation
 

--- a/pythainlp/tokenize/wtsplit.py
+++ b/pythainlp/tokenize/wtsplit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Where's the Point? Self-Supervised Multilingual Punctuation-Agnostic Sentence Segmentation

--- a/pythainlp/tools/__init__.py
+++ b/pythainlp/tools/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 __all__ = [
     "PYTHAINLP_DEFAULT_DATA_DIR",

--- a/pythainlp/tools/__init__.py
+++ b/pythainlp/tools/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 __all__ = [
     "PYTHAINLP_DEFAULT_DATA_DIR",
     "get_full_data_path",

--- a/pythainlp/tools/misspell.py
+++ b/pythainlp/tools/misspell.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List
 import numpy as np

--- a/pythainlp/tools/misspell.py
+++ b/pythainlp/tools/misspell.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List
 import numpy as np
 

--- a/pythainlp/tools/path.py
+++ b/pythainlp/tools/path.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 PyThaiNLP data tools

--- a/pythainlp/tools/path.py
+++ b/pythainlp/tools/path.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 PyThaiNLP data tools
 

--- a/pythainlp/translate/__init__.py
+++ b/pythainlp/translate/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Language translation.

--- a/pythainlp/translate/__init__.py
+++ b/pythainlp/translate/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Language translation.
 """

--- a/pythainlp/translate/core.py
+++ b/pythainlp/translate/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/pythainlp/translate/core.py
+++ b/pythainlp/translate/core.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 
 
 class Translate:

--- a/pythainlp/translate/en_th.py
+++ b/pythainlp/translate/en_th.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 English-Thai Machine Translation

--- a/pythainlp/translate/en_th.py
+++ b/pythainlp/translate/en_th.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 English-Thai Machine Translation
 

--- a/pythainlp/translate/th_fr.py
+++ b/pythainlp/translate/th_fr.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai-French Machine Translation

--- a/pythainlp/translate/th_fr.py
+++ b/pythainlp/translate/th_fr.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai-French Machine Translation
 

--- a/pythainlp/translate/zh_th.py
+++ b/pythainlp/translate/zh_th.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Lalita Chinese-Thai Machine Translation
 

--- a/pythainlp/translate/zh_th.py
+++ b/pythainlp/translate/zh_th.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Lalita Chinese-Thai Machine Translation

--- a/pythainlp/transliterate/__init__.py
+++ b/pythainlp/transliterate/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Transliteration.
 """

--- a/pythainlp/transliterate/__init__.py
+++ b/pythainlp/transliterate/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Transliteration.

--- a/pythainlp/transliterate/core.py
+++ b/pythainlp/transliterate/core.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 
 DEFAULT_ROMANIZE_ENGINE = "royin"
 DEFAULT_TRANSLITERATE_ENGINE = "thaig2p"

--- a/pythainlp/transliterate/core.py
+++ b/pythainlp/transliterate/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 
 DEFAULT_ROMANIZE_ENGINE = "royin"

--- a/pythainlp/transliterate/ipa.py
+++ b/pythainlp/transliterate/ipa.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Transliterating text to International Phonetic Alphabet (IPA)

--- a/pythainlp/transliterate/ipa.py
+++ b/pythainlp/transliterate/ipa.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Transliterating text to International Phonetic Alphabet (IPA)
 Using epitran

--- a/pythainlp/transliterate/iso_11940.py
+++ b/pythainlp/transliterate/iso_11940.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Transliterating Thai text using ISO 11940

--- a/pythainlp/transliterate/iso_11940.py
+++ b/pythainlp/transliterate/iso_11940.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Transliterating Thai text using ISO 11940
 

--- a/pythainlp/transliterate/lookup.py
+++ b/pythainlp/transliterate/lookup.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Look up romanized Thai words in a predefined dictionary compiled by Wannaphong, 2022.
 

--- a/pythainlp/transliterate/lookup.py
+++ b/pythainlp/transliterate/lookup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Look up romanized Thai words in a predefined dictionary compiled by Wannaphong, 2022.

--- a/pythainlp/transliterate/pyicu.py
+++ b/pythainlp/transliterate/pyicu.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Transliterating text to International Phonetic Alphabet (IPA)
 Using International Components for Unicode (ICU)

--- a/pythainlp/transliterate/pyicu.py
+++ b/pythainlp/transliterate/pyicu.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Transliterating text to International Phonetic Alphabet (IPA)

--- a/pythainlp/transliterate/royin.py
+++ b/pythainlp/transliterate/royin.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 The Royal Thai General System of Transcription (RTGS)
 is the official system for rendering Thai words in the Latin alphabet.

--- a/pythainlp/transliterate/royin.py
+++ b/pythainlp/transliterate/royin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 The Royal Thai General System of Transcription (RTGS)

--- a/pythainlp/transliterate/spoonerism.py
+++ b/pythainlp/transliterate/spoonerism.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from pythainlp.transliterate import pronunciate
 from pythainlp import thai_consonants
 

--- a/pythainlp/transliterate/spoonerism.py
+++ b/pythainlp/transliterate/spoonerism.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from pythainlp.transliterate import pronunciate
 from pythainlp import thai_consonants

--- a/pythainlp/transliterate/thai2rom.py
+++ b/pythainlp/transliterate/thai2rom.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Romanization of Thai words based on machine-learnt engine ("thai2rom")
 """

--- a/pythainlp/transliterate/thai2rom.py
+++ b/pythainlp/transliterate/thai2rom.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Romanization of Thai words based on machine-learnt engine ("thai2rom")

--- a/pythainlp/transliterate/thai2rom_onnx.py
+++ b/pythainlp/transliterate/thai2rom_onnx.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Romanization of Thai words based on machine-learnt engine in ONNX runtime ("thai2rom")

--- a/pythainlp/transliterate/thai2rom_onnx.py
+++ b/pythainlp/transliterate/thai2rom_onnx.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Romanization of Thai words based on machine-learnt engine in ONNX runtime ("thai2rom")
 """

--- a/pythainlp/transliterate/thaig2p.py
+++ b/pythainlp/transliterate/thaig2p.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai Grapheme-to-Phoneme (Thai G2P)

--- a/pythainlp/transliterate/thaig2p.py
+++ b/pythainlp/transliterate/thaig2p.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai Grapheme-to-Phoneme (Thai G2P)
 GitHub : https://github.com/wannaphong/thai-g2p

--- a/pythainlp/transliterate/tltk.py
+++ b/pythainlp/transliterate/tltk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 try:
     from tltk.nlp import g2p, th2ipa, th2roman

--- a/pythainlp/transliterate/tltk.py
+++ b/pythainlp/transliterate/tltk.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 try:
     from tltk.nlp import g2p, th2ipa, th2roman
 except ImportError:

--- a/pythainlp/transliterate/w2p.py
+++ b/pythainlp/transliterate/w2p.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai Word-to-Phoneme (Thai W2P)
 GitHub : https://github.com/wannaphong/Thai_W2P

--- a/pythainlp/transliterate/w2p.py
+++ b/pythainlp/transliterate/w2p.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai Word-to-Phoneme (Thai W2P)

--- a/pythainlp/transliterate/wunsen.py
+++ b/pythainlp/transliterate/wunsen.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Transliterating Japanese/Korean/Mandarin/Vietnamese romanization text

--- a/pythainlp/transliterate/wunsen.py
+++ b/pythainlp/transliterate/wunsen.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Transliterating Japanese/Korean/Mandarin/Vietnamese romanization text
 to Thai text

--- a/pythainlp/ulmfit/__init__.py
+++ b/pythainlp/ulmfit/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Universal Language Model Fine-tuning for Text Classification (ULMFiT).
 

--- a/pythainlp/ulmfit/__init__.py
+++ b/pythainlp/ulmfit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Universal Language Model Fine-tuning for Text Classification (ULMFiT).

--- a/pythainlp/ulmfit/core.py
+++ b/pythainlp/ulmfit/core.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Universal Language Model Fine-tuning for Text Classification (ULMFiT).
 """

--- a/pythainlp/ulmfit/core.py
+++ b/pythainlp/ulmfit/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Universal Language Model Fine-tuning for Text Classification (ULMFiT).

--- a/pythainlp/ulmfit/preprocess.py
+++ b/pythainlp/ulmfit/preprocess.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Preprocessing for ULMFiT
 """

--- a/pythainlp/ulmfit/preprocess.py
+++ b/pythainlp/ulmfit/preprocess.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Preprocessing for ULMFiT

--- a/pythainlp/ulmfit/tokenizer.py
+++ b/pythainlp/ulmfit/tokenizer.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Tokenzier classes for ULMFiT
 """

--- a/pythainlp/ulmfit/tokenizer.py
+++ b/pythainlp/ulmfit/tokenizer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Tokenzier classes for ULMFiT

--- a/pythainlp/util/__init__.py
+++ b/pythainlp/util/__init__.py
@@ -1,17 +1,6 @@
 ﻿# -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Utility functions, like date conversion and digit conversion
 """

--- a/pythainlp/util/__init__.py
+++ b/pythainlp/util/__init__.py
@@ -1,5 +1,5 @@
 ﻿# -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Utility functions, like date conversion and digit conversion

--- a/pythainlp/util/abbreviation.py
+++ b/pythainlp/util/abbreviation.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai abbreviation tools
 """

--- a/pythainlp/util/abbreviation.py
+++ b/pythainlp/util/abbreviation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai abbreviation tools

--- a/pythainlp/util/collate.py
+++ b/pythainlp/util/collate.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai collation (sorted according to Thai dictionary order)

--- a/pythainlp/util/collate.py
+++ b/pythainlp/util/collate.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai collation (sorted according to Thai dictionary order)
 Simple implementation using regular expressions

--- a/pythainlp/util/date.py
+++ b/pythainlp/util/date.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai date/time conversion.

--- a/pythainlp/util/date.py
+++ b/pythainlp/util/date.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai date/time conversion.
 

--- a/pythainlp/util/digitconv.py
+++ b/pythainlp/util/digitconv.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Convert digits

--- a/pythainlp/util/digitconv.py
+++ b/pythainlp/util/digitconv.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Convert digits
 """

--- a/pythainlp/util/emojiconv.py
+++ b/pythainlp/util/emojiconv.py
@@ -1,17 +1,6 @@
 # -*- coding_utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Convert emojis
 """

--- a/pythainlp/util/emojiconv.py
+++ b/pythainlp/util/emojiconv.py
@@ -1,5 +1,5 @@
 # -*- coding_utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Convert emojis

--- a/pythainlp/util/encoding.py
+++ b/pythainlp/util/encoding.py
@@ -1,5 +1,5 @@
 # -*- coding_utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 def tis620_to_utf8(text: str)->str:
     """

--- a/pythainlp/util/encoding.py
+++ b/pythainlp/util/encoding.py
@@ -1,17 +1,6 @@
 # -*- coding_utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 def tis620_to_utf8(text: str)->str:
     """
     Convert TIS-620 to UTF-8

--- a/pythainlp/util/keyboard.py
+++ b/pythainlp/util/keyboard.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Functions related to keyboard layout.

--- a/pythainlp/util/keyboard.py
+++ b/pythainlp/util/keyboard.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Functions related to keyboard layout.
 """

--- a/pythainlp/util/keywords.py
+++ b/pythainlp/util/keywords.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from collections import Counter
 from typing import Dict, List

--- a/pythainlp/util/keywords.py
+++ b/pythainlp/util/keywords.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from collections import Counter
 from typing import Dict, List
 

--- a/pythainlp/util/normalize.py
+++ b/pythainlp/util/normalize.py
@@ -1,17 +1,6 @@
 ﻿# -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Text normalization
 """

--- a/pythainlp/util/normalize.py
+++ b/pythainlp/util/normalize.py
@@ -1,5 +1,5 @@
 ﻿# -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Text normalization

--- a/pythainlp/util/numtoword.py
+++ b/pythainlp/util/numtoword.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Convert number value to Thai read out

--- a/pythainlp/util/numtoword.py
+++ b/pythainlp/util/numtoword.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Convert number value to Thai read out
 

--- a/pythainlp/util/phoneme.py
+++ b/pythainlp/util/phoneme.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Phonemes util
 """

--- a/pythainlp/util/phoneme.py
+++ b/pythainlp/util/phoneme.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Phonemes util

--- a/pythainlp/util/pronounce.py
+++ b/pythainlp/util/pronounce.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List
 

--- a/pythainlp/util/pronounce.py
+++ b/pythainlp/util/pronounce.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List
 
 from pythainlp.corpus import thai_words

--- a/pythainlp/util/remove_trailing_repeat_consonants.py
+++ b/pythainlp/util/remove_trailing_repeat_consonants.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Removement of repeated consonants at the end of words

--- a/pythainlp/util/remove_trailing_repeat_consonants.py
+++ b/pythainlp/util/remove_trailing_repeat_consonants.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Removement of repeated consonants at the end of words
 """

--- a/pythainlp/util/spell_words.py
+++ b/pythainlp/util/spell_words.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 import re
 from typing import List

--- a/pythainlp/util/spell_words.py
+++ b/pythainlp/util/spell_words.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 import re
 from typing import List
 from pythainlp import (

--- a/pythainlp/util/strftime.py
+++ b/pythainlp/util/strftime.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai date/time formatting.
 """

--- a/pythainlp/util/strftime.py
+++ b/pythainlp/util/strftime.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai date/time formatting.

--- a/pythainlp/util/syllable.py
+++ b/pythainlp/util/syllable.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Syllable tools

--- a/pythainlp/util/syllable.py
+++ b/pythainlp/util/syllable.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Syllable tools
 """

--- a/pythainlp/util/thai.py
+++ b/pythainlp/util/thai.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Check if it is Thai text
 """

--- a/pythainlp/util/thai.py
+++ b/pythainlp/util/thai.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Check if it is Thai text

--- a/pythainlp/util/thaiwordcheck.py
+++ b/pythainlp/util/thaiwordcheck.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Check if a word is a "native Thai word"

--- a/pythainlp/util/thaiwordcheck.py
+++ b/pythainlp/util/thaiwordcheck.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Check if a word is a "native Thai word"
 

--- a/pythainlp/util/time.py
+++ b/pythainlp/util/time.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Spell out time as Thai words.

--- a/pythainlp/util/time.py
+++ b/pythainlp/util/time.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Spell out time as Thai words.
 

--- a/pythainlp/util/trie.py
+++ b/pythainlp/util/trie.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Trie data structure.
 

--- a/pythainlp/util/trie.py
+++ b/pythainlp/util/trie.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Trie data structure.

--- a/pythainlp/util/wordtonum.py
+++ b/pythainlp/util/wordtonum.py
@@ -1,17 +1,6 @@
 ﻿# -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Convert number in words to a computable number value
 

--- a/pythainlp/util/wordtonum.py
+++ b/pythainlp/util/wordtonum.py
@@ -1,5 +1,5 @@
 ﻿# -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Convert number in words to a computable number value

--- a/pythainlp/wangchanberta/__init__.py
+++ b/pythainlp/wangchanberta/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 __all__ = [
     "ThaiNameTagger",
     "segment",

--- a/pythainlp/wangchanberta/__init__.py
+++ b/pythainlp/wangchanberta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 __all__ = [
     "ThaiNameTagger",

--- a/pythainlp/wangchanberta/core.py
+++ b/pythainlp/wangchanberta/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple, Union
 import re

--- a/pythainlp/wangchanberta/core.py
+++ b/pythainlp/wangchanberta/core.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple, Union
 import re
 import warnings

--- a/pythainlp/word_vector/__init__.py
+++ b/pythainlp/word_vector/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 thai2fit - Thai word vector.

--- a/pythainlp/word_vector/__init__.py
+++ b/pythainlp/word_vector/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 thai2fit - Thai word vector.
 

--- a/pythainlp/word_vector/core.py
+++ b/pythainlp/word_vector/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple
 

--- a/pythainlp/word_vector/core.py
+++ b/pythainlp/word_vector/core.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple
 
 from gensim.models import KeyedVectors

--- a/pythainlp/wsd/__init__.py
+++ b/pythainlp/wsd/__init__.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 """
 Thai Word Sense Disambiguation (WSD)
 """

--- a/pythainlp/wsd/__init__.py
+++ b/pythainlp/wsd/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 """
 Thai Word Sense Disambiguation (WSD)

--- a/pythainlp/wsd/core.py
+++ b/pythainlp/wsd/core.py
@@ -1,17 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple, Union
 
 from pythainlp.tokenize import Tokenizer

--- a/pythainlp/wsd/core.py
+++ b/pythainlp/wsd/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: Copyright (C) 2016-2023 PyThaiNLP Project.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
 from typing import List, Tuple, Union
 

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,6 @@
 ﻿# -*- coding: utf-8 -*-
-# Copyright (C) 2016-2023 PyThaiNLP Project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
+# SPDX-License-Identifier: Apache-2.0
 """
 Setup script for PyThaiNLP.
 


### PR DESCRIPTION
### What does this changes

According to issue #874 , in this PR, i already switch the license to SPDX already by replacing it with the new one as mentioned in that issue krub.  Tag @bact since i have made changes and you are an issue owner. You can take a review at it and inform me if i miss something in the source code krub.
 
Fix  #874 

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [ ] Passed code styles and structures
- [ ] Passed code linting checks and unit test
