### PR TITLE
Add pythainlp.corpus.find_synonyms

### DIFF
--- a/docs/api/corpus.rst
+++ b/docs/api/corpus.rst
@@ -12,6 +12,11 @@ countries
 .. autofunction:: countries
    :noindex:
 
+find_synonym
+~~~~~~~~~~~~
+.. autofunction:: find_synonym
+   :noindex:
+
 get_corpus
 ~~~~~~~~~~
 .. autofunction:: get_corpus

--- a/pythainlp/corpus/__init__.py
+++ b/pythainlp/corpus/__init__.py
@@ -14,6 +14,7 @@ __all__ = [
     "corpus_path",
     "countries",
     "download",
+    "find_synonyms",
     "get_corpus",
     "get_corpus_as_is",
     "get_corpus_db",
@@ -101,6 +102,7 @@ from pythainlp.corpus.core import (
 )  # these imports must come before other pythainlp.corpus.* imports
 from pythainlp.corpus.common import (
     countries,
+    find_synonyms,
     provinces,
     thai_dict,
     thai_family_names,

--- a/pythainlp/corpus/common.py
+++ b/pythainlp/corpus/common.py
@@ -354,13 +354,20 @@ def find_synonyms(word: str) -> List[str]:
         from pythainlp.corpus import find_synonyms
 
         print(find_synonyms("หมู"))
-        # output: ['จรุก', 'วราห์', 'วราหะ', 'ศูกร', 'สุกร']
+        # output: ['จรุก', 'วราหะ', 'วราห์', 'ศูกร', 'สุกร']
     """
     synonyms = thai_synonyms()  # get a dictionary of {word, synonym}
     list_synonym = []
 
-    for idx, words in enumerate(synonyms["word"]):
+    if word in synonyms["word"]: # find by word
+        list_synonym.extend(synonyms["synonym"][synonyms["word"].index(word)])
+
+    for idx, words in enumerate(synonyms["synonym"]): # find by synonym
         if word in words:
             list_synonym.extend(synonyms["synonym"][idx])
+            list_synonym.append(synonyms["word"][idx])
+
+    if word in list_synonym: # remove same word
+        list_synonym.remove(word)
 
     return sorted(list(set(list_synonym)))

--- a/pythainlp/corpus/common.py
+++ b/pythainlp/corpus/common.py
@@ -7,6 +7,7 @@ Common lists of words.
 
 __all__ = [
     "countries",
+    "find_synonyms",
     "provinces",
     "thai_family_names",
     "thai_female_names",
@@ -336,3 +337,26 @@ def thai_synonyms() -> dict:
 def thai_synonym() -> dict:
     warnings.warn("Deprecated: Use thai_synonyms() instead.", DeprecationWarning)
     return thai_synonyms()
+
+
+def find_synonyms(word) -> Union[List[str], None]:
+    """
+    Find synonyms
+
+    :param str word: Thai word
+    :return: List synonyms of word or None if it isn't exist.
+    :rtype: Union[List[str], None]
+
+    :Example:
+    ::
+
+        from pythainlp.corpus import find_synonyms
+
+        print(find_synonyms("หมู"))
+        # output: ['จรุก', 'วราห์', 'วราหะ', 'ศูกร', 'สุกร']
+    """
+    _temp = thai_synonyms()
+    if word in _temp["word"]:
+        _idx = _temp["word"].index(word)
+        return _temp["synonym"][_idx]
+    return None

--- a/pythainlp/corpus/common.py
+++ b/pythainlp/corpus/common.py
@@ -367,7 +367,9 @@ def find_synonyms(word: str) -> List[str]:
             list_synonym.extend(synonyms["synonym"][idx])
             list_synonym.append(synonyms["word"][idx])
 
+    list_synonym = sorted(list(set(list_synonym)))
+
     if word in list_synonym:  # remove same word
         list_synonym.remove(word)
 
-    return sorted(list(set(list_synonym)))
+    return list_synonym

--- a/pythainlp/corpus/common.py
+++ b/pythainlp/corpus/common.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # SPDX-FileCopyrightText: Copyright 2016-2023 PyThaiNLP Project
 # SPDX-License-Identifier: Apache-2.0
+
 """
 Common lists of words.
 """
@@ -339,12 +340,12 @@ def thai_synonym() -> dict:
     return thai_synonyms()
 
 
-def find_synonyms(word) -> List[str]:
+def find_synonyms(word: str) -> List[str]:
     """
     Find synonyms
 
     :param str word: Thai word
-    :return: List synonyms of word or None if it isn't exist.
+    :return: List of synonyms of the input word or an empty list if it isn't exist.
     :rtype: List[str]
 
     :Example:
@@ -355,8 +356,11 @@ def find_synonyms(word) -> List[str]:
         print(find_synonyms("หมู"))
         # output: ['จรุก', 'วราห์', 'วราหะ', 'ศูกร', 'สุกร']
     """
-    synonyms = thai_synonyms()
+    synonyms = thai_synonyms()  # get a dictionary of {word, synonym}
+
     if word in synonyms["word"]:
+        # returns the position of the first occurrence of the word
         idx = synonyms["word"].index(word)
         return synonyms["synonym"][idx]
+
     return []

--- a/pythainlp/corpus/common.py
+++ b/pythainlp/corpus/common.py
@@ -339,13 +339,13 @@ def thai_synonym() -> dict:
     return thai_synonyms()
 
 
-def find_synonyms(word) -> Union[List[str], None]:
+def find_synonyms(word) -> List[str]:
     """
     Find synonyms
 
     :param str word: Thai word
     :return: List synonyms of word or None if it isn't exist.
-    :rtype: Union[List[str], None]
+    :rtype: List[str]
 
     :Example:
     ::
@@ -359,4 +359,4 @@ def find_synonyms(word) -> Union[List[str], None]:
     if word in _temp["word"]:
         _idx = _temp["word"].index(word)
         return _temp["synonym"][_idx]
-    return None
+    return []

--- a/pythainlp/corpus/common.py
+++ b/pythainlp/corpus/common.py
@@ -359,15 +359,15 @@ def find_synonyms(word: str) -> List[str]:
     synonyms = thai_synonyms()  # get a dictionary of {word, synonym}
     list_synonym = []
 
-    if word in synonyms["word"]: # find by word
+    if word in synonyms["word"]:  # find by word
         list_synonym.extend(synonyms["synonym"][synonyms["word"].index(word)])
 
-    for idx, words in enumerate(synonyms["synonym"]): # find by synonym
+    for idx, words in enumerate(synonyms["synonym"]):  # find by synonym
         if word in words:
             list_synonym.extend(synonyms["synonym"][idx])
             list_synonym.append(synonyms["word"][idx])
 
-    if word in list_synonym: # remove same word
+    if word in list_synonym:  # remove same word
         list_synonym.remove(word)
 
     return sorted(list(set(list_synonym)))

--- a/pythainlp/corpus/common.py
+++ b/pythainlp/corpus/common.py
@@ -355,8 +355,8 @@ def find_synonyms(word) -> List[str]:
         print(find_synonyms("หมู"))
         # output: ['จรุก', 'วราห์', 'วราหะ', 'ศูกร', 'สุกร']
     """
-    _temp = thai_synonyms()
-    if word in _temp["word"]:
-        _idx = _temp["word"].index(word)
-        return _temp["synonym"][_idx]
+    synonyms = thai_synonyms()
+    if word in synonyms["word"]:
+        idx = synonyms["word"].index(word)
+        return synonyms["synonym"][idx]
     return []

--- a/pythainlp/corpus/common.py
+++ b/pythainlp/corpus/common.py
@@ -357,10 +357,10 @@ def find_synonyms(word: str) -> List[str]:
         # output: ['จรุก', 'วราห์', 'วราหะ', 'ศูกร', 'สุกร']
     """
     synonyms = thai_synonyms()  # get a dictionary of {word, synonym}
+    list_synonym = []
 
-    if word in synonyms["word"]:
-        # returns the position of the first occurrence of the word
-        idx = synonyms["word"].index(word)
-        return synonyms["synonym"][idx]
+    for idx, words in enumerate(synonyms["word"]):
+        if word in words:
+            list_synonym.extend(synonyms["synonym"][idx])
 
-    return []
+    return sorted(list(set(list_synonym)))

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -209,6 +209,6 @@ class TestCorpusPackage(unittest.TestCase):
     def test_find_synonyms(self):
         self.assertEqual(
             find_synonyms("หมู"),
-            ['จรุก', 'วราห์', 'วราหะ', 'ศูกร', 'สุกร']
+            ['จรุก', 'วราหะ', 'วราห์', 'ศูกร', 'สุกร']
         )
         self.assertEqual(find_synonyms("1"), [])

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -13,6 +13,7 @@ from pythainlp.corpus import (
     conceptnet,
     countries,
     download,
+    find_synonyms,
     get_corpus_db,
     get_corpus_db_detail,
     get_corpus_default_db,
@@ -204,3 +205,7 @@ class TestCorpusPackage(unittest.TestCase):
         p = get_corpus_path("test_zip")
         self.assertEqual(os.path.isdir(p), True)
         self.assertEqual(remove("test_zip"), True)
+
+    def test_find_synonyms(self):
+        self.assertIsInstance(find_synonyms("หมู"), list)
+        self.assertIsInstance(find_synonyms("1"), None)

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -207,5 +207,8 @@ class TestCorpusPackage(unittest.TestCase):
         self.assertEqual(remove("test_zip"), True)
 
     def test_find_synonyms(self):
-        self.assertIsInstance(find_synonyms("หมู"), list)
-        self.assertIsInstance(find_synonyms("1"), None)
+        self.assertEqual(
+            find_synonyms("หมู"),
+            ['จรุก', 'วราห์', 'วราหะ', 'ศูกร', 'สุกร']
+        )
+        self.assertEqual(find_synonyms("1"), [])


### PR DESCRIPTION
Add pythainlp.corpus.find_synonyms for find synonyms.

From Add thai_synonym #825

**Example**
```python
>>> from pythainlp.corpus import find_synonyms
>>> find_synonyms("หมู")
['จรุก', 'วราห์', 'วราหะ', 'ศูกร', 'สุกร']
```

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test
