### PR TITLE
crfcut: Ensure splitting of sentences using Terminal Punctuation

### DIFF
--- a/pythainlp/tokenize/crfcut.py
+++ b/pythainlp/tokenize/crfcut.py
@@ -198,12 +198,22 @@ def segment(text: str) -> List[str]:
     feat = extract_features(toks)
     labs = _tagger.tag(feat)
     labs[-1] = "E"  # make sure it cuts the last sentence
+  
+    #To ensure splitting of sentences using Terminal Punctuation
+    for idx, _ in enumerate(toks):
+      if(toks[idx].strip().endswith(('!', '.', '?'))):
+          labs[idx] = "E"
+      
+      #Spaces or empty strings would no longer be treated as end of the sentence.
+      elif(toks[idx].strip() == ""):
+          labs[idx] = "I"
 
     sentences = []
     sentence = ""
     for i, w in enumerate(toks):
         sentence = sentence + w
-        if labs[i] == "E":
+        #Constraining empty strings to get added, to avoid any sort of unusual behaviour due to empty strings.
+        if labs[i] == "E" and sentence != '':
             sentences.append(sentence)
             sentence = ""
 

--- a/pythainlp/tokenize/crfcut.py
+++ b/pythainlp/tokenize/crfcut.py
@@ -204,7 +204,7 @@ def segment(text: str) -> List[str]:
         if toks[idx].strip().endswith(("!", ".", "?")):
             labs[idx] = "E"
         # Spaces or empty strings would no longer be treated as end of sentence.
-        elif toks[idx].strip() == "":
+        elif (idx == 0 or labs[idx-1] == "E") and toks[idx].strip() == "":
             labs[idx] = "I"
 
     sentences = []

--- a/pythainlp/tokenize/crfcut.py
+++ b/pythainlp/tokenize/crfcut.py
@@ -201,11 +201,10 @@ def segment(text: str) -> List[str]:
 
     # To ensure splitting of sentences using Terminal Punctuation
     for idx, _ in enumerate(toks):
-        if toks[idx].strip().endswith(('!', '.', '?')):
+        if toks[idx].strip().endswith(("!", ".", "?")):
             labs[idx] = "E"
-
         # Spaces or empty strings would no longer be treated as end of sentence.
-        elif(toks[idx].strip() == ""):
+        elif toks[idx].strip() == "":
             labs[idx] = "I"
 
     sentences = []
@@ -213,7 +212,7 @@ def segment(text: str) -> List[str]:
     for i, w in enumerate(toks):
         sentence = sentence + w
         # Empty strings should not be part of output.
-        if labs[i] == "E" and sentence != '':
+        if labs[i] == "E" and sentence != "":
             sentences.append(sentence)
             sentence = ""
 

--- a/pythainlp/tokenize/crfcut.py
+++ b/pythainlp/tokenize/crfcut.py
@@ -201,7 +201,7 @@ def segment(text: str) -> List[str]:
 
     # To ensure splitting of sentences using Terminal Punctuation
     for idx, _ in enumerate(toks):
-        if(toks[idx].strip().endswith(('!', '.', '?'))):
+        if toks[idx].strip().endswith(('!', '.', '?')):
             labs[idx] = "E"
 
         # Spaces or empty strings would no longer be treated as end of sentence.

--- a/pythainlp/tokenize/crfcut.py
+++ b/pythainlp/tokenize/crfcut.py
@@ -198,21 +198,21 @@ def segment(text: str) -> List[str]:
     feat = extract_features(toks)
     labs = _tagger.tag(feat)
     labs[-1] = "E"  # make sure it cuts the last sentence
-  
-    #To ensure splitting of sentences using Terminal Punctuation
+
+    # To ensure splitting of sentences using Terminal Punctuation
     for idx, _ in enumerate(toks):
-      if(toks[idx].strip().endswith(('!', '.', '?'))):
-          labs[idx] = "E"
-      
-      #Spaces or empty strings would no longer be treated as end of the sentence.
-      elif(toks[idx].strip() == ""):
-          labs[idx] = "I"
+        if(toks[idx].strip().endswith(('!', '.', '?'))):
+            labs[idx] = "E"
+
+        # Spaces or empty strings would no longer be treated as end of sentence.
+        elif(toks[idx].strip() == ""):
+            labs[idx] = "I"
 
     sentences = []
     sentence = ""
     for i, w in enumerate(toks):
         sentence = sentence + w
-        #Constraining empty strings to get added, to avoid any sort of unusual behaviour due to empty strings.
+        # Empty strings should not be part of output.
         if labs[i] == "E" and sentence != '':
             sentences.append(sentence)
             sentence = ""


### PR DESCRIPTION
Crfcut creating issues for split using terminal punctuation commonly '.' (full stop) which should be treated as end of the sentence, Modified the function such that it should split using terminal punctuations and avoid any kind of empty strings.

### What does this changes

Brief summary of the changes

### What was wrong

Description of what was the root cause of the issue.

### How this fixes it

Description of how the changes fix the issue.

Fixes #904

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [ ] Passed code styles and structures
- [ ] Passed code linting checks and unit test
