### PR TITLE
Fix empty string ('') added (in some cases) when using word_tokenize with join_broken_num=True

### DIFF
--- a/pythainlp/tokenize/_utils.py
+++ b/pythainlp/tokenize/_utils.py
@@ -61,8 +61,8 @@ def rejoin_formatted_num(segments: List[str]) -> List[str]:
                 connected_token += segments[segment_idx]
                 pos += len(segments[segment_idx])
                 segment_idx += 1
-
-            tokens_joined.append(connected_token)
+            if connected_token :
+                tokens_joined.append(connected_token)
             match = next(matching_results, None)
         else:
             tokens_joined.append(token)

--- a/pythainlp/tokenize/_utils.py
+++ b/pythainlp/tokenize/_utils.py
@@ -61,7 +61,7 @@ def rejoin_formatted_num(segments: List[str]) -> List[str]:
                 connected_token += segments[segment_idx]
                 pos += len(segments[segment_idx])
                 segment_idx += 1
-            if connected_token :
+            if connected_token:
                 tokens_joined.append(connected_token)
             match = next(matching_results, None)
         else:


### PR DESCRIPTION
fix empty string bug

### What does this changes

pythainlp/tokenize/_utils.py : add the statement `if connected_token :` to check before appending `connected_token` to `tokens_joined`

### What was wrong

https://github.com/PyThaiNLP/pythainlp/issues/911

### How this fixes it

`tokens_joined` won't be appended by empty string anymore

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [x] Passed code styles and structures
- [ ] Passed code linting checks and unit test
