### PR TITLE
Add preprocess function to split whitespace before `romanize`

### DIFF
--- a/pythainlp/transliterate/core.py
+++ b/pythainlp/transliterate/core.py
@@ -84,7 +84,12 @@ def romanize(
         fallback = select_romanize_engine(fallback_engine)
         return romanize(text, fallback_func=fallback)
     else:
-        return select_romanize_engine(engine)(text)
+        rom_engine = select_romanize_engine(engine)
+        trans_word=[]
+        for word in text.split(' '):
+            trans_word.append(rom_engine(word))
+        new_word=''.join(trans_word)
+        return new_word
 
 
 def transliterate(

--- a/pythainlp/transliterate/core.py
+++ b/pythainlp/transliterate/core.py
@@ -85,10 +85,10 @@ def romanize(
         return romanize(text, fallback_func=fallback)
     else:
         rom_engine = select_romanize_engine(engine)
-        trans_word=[]
+        trans_word = []
         for word in text.split(' '):
             trans_word.append(rom_engine(word))
-        new_word=''.join(trans_word)
+        new_word = ''.join(trans_word)
         return new_word
 
 


### PR DESCRIPTION
### What does this PR changes

@wannaphong According to issue #922 there is room of improvement in transliterate function, where splitting whitespace yield much better performance. What do you think about it ? actually, we can improve this performance by adding tokenization module into the game so that the text can be splitted more logically too. Anyway, please let me know what do you think krub.

```python
from pythainlp.transliterate import romanize

A = "สวัสดี ครับ"
B = "คุณ ชื่อ อะไร ครับ"
A_B = "สวัสดี ครับ คุณ ชื่อ อะไร ครับ"
print(romanize(A, engine="thai2rom"))
print(romanize(B, engine="thai2rom"))
print(romanize(A_B, engine="thai2rom"))
for z in A_B.split(' '):
    roman = romanize(z, engine="thai2rom")
    print(roman, ' ', end="")

# output: 
# sawatdi khrap
# khun chue arai khrap
# sawatdi khrap khun chuen chuen chuen chuen chuen chuen chuen chuen chuen chuen chuen chuen chuen chu
# sawatdi  khrap  khun  chue  arai  khrap 

```

Now, i've fixed it, and got a preprocessing of the input text during the function execution
```python
from pythainlp.transliterate import romanize
A_B = "สวัสดี ครับ คุณ ชื่อ อะไร ครับ"
print(romanize(A_B, engine="thai2rom"))
# output: sawatdikhrapkhunchuearaikhrap

```
ps. just want to know that did PyThaiNLP joined Hacktoberfest 2024 thsi year ? please let me know

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [ ] Passed code styles and structures
- [ ] Passed code linting checks and unit test
