### PR TITLE
Fix collate() to consider tonemark in ordering

### DIFF
--- a/pythainlp/util/collate.py
+++ b/pythainlp/util/collate.py
@@ -15,9 +15,9 @@ _RE_LV_C = re.compile(r"([เ-ไ])([ก-ฮ])")
 def _thkey(word: str) -> str:
     cv = _RE_TONE.sub("", word)  # remove tone
     cv = _RE_LV_C.sub("\\2\\1", cv)  # switch lead vowel
-    
+
     tone_match = _RE_TONE.search(word)
-    tone = tone_match.group() if tone_match else "" 
+    tone = tone_match.group() if tone_match else ""
     return cv + tone
 
 

--- a/pythainlp/util/collate.py
+++ b/pythainlp/util/collate.py
@@ -15,7 +15,9 @@ _RE_LV_C = re.compile(r"([เ-ไ])([ก-ฮ])")
 def _thkey(word: str) -> str:
     cv = _RE_TONE.sub("", word)  # remove tone
     cv = _RE_LV_C.sub("\\2\\1", cv)  # switch lead vowel
-    tone = _RE_TONE.sub(" ", word)  # just tone
+    
+    tone_match = _RE_TONE.search(word)
+    tone = tone_match.group() if tone_match else "" 
     return cv + tone
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -79,6 +79,14 @@ class TestUtilPackage(unittest.TestCase):
             collate(["ไก่", "เป็ด", "หมู", "วัว"]),
             ["ไก่", "เป็ด", "วัว", "หมู"],
         )
+        self.assertEqual(
+            collate(["ก้วย", "ก๋วย", "กวย", "ก่วย", "ก๊วย"]),
+            collate(["ก๋วย", "ก่วย", "ก้วย", "ก๊วย", "กวย"]),
+        )  # should guarantee same order
+        self.assertEqual(
+            collate(["ก้วย", "ก๋วย", "ก่วย", "กวย", "ก้วย", "ก่วย", "ก๊วย"]),
+            ["กวย", "ก่วย", "ก่วย", "ก้วย", "ก้วย", "ก๊วย", "ก๋วย"],
+        )
 
     # ### pythainlp.util.numtoword
 


### PR DESCRIPTION
### What does this changes

Update Thai tone ordering sorted from #558 

### What was wrong

`pythainlp.util.collate()` results a wrong ordering,
from
```python
from pythainlp.util import collate

collate(["ก้วย", "ก๋วย", "ก่วย", "กวย", "ก้วย", "ก่วย", "ก๊วย"])
```
`collate` function expect.
```python
['กวย', 'ก่วย', 'ก่วย', 'ก้วย', 'ก้วย', 'ก๊วย', 'ก๋วย']
```
but before my pull request is
```python
['ก้วย', 'ก๋วย', 'ก่วย', 'ก้วย', 'ก่วย', 'ก๊วย', 'กวย']
```

### How this fixes it
Fixed it by use `search()` method from `Pattern` class  in `re` module. Then concat Thai tone with current lead vowel strings. at 
from
```python
def _thkey(word: str) -> str:
    cv = _RE_TONE.sub("", word)  # remove tone
    cv = _RE_LV_C.sub("\\2\\1", cv)  # switch lead vowel
    tone = _RE_TONE.sub(" ", word)  # just tone
    return cv + tone
```
to
```python
def _thkey(word: str) -> str:
    cv = _RE_TONE.sub("", word)  # remove tone
    cv = _RE_LV_C.sub("\\2\\1", cv)  # switch lead vowel

    tone_match = _RE_TONE.search(word)
    tone = tone_match.group() if tone_match else ""
    return cv + tone
```

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md) to this repository.

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test
P.S. some of unit test on `collate` function is pass but other unitest of normalize, `maiyamok` not pass