### PR TITLE
Move sent_tokenize with default crfcut to testx

### DIFF
--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -217,8 +217,6 @@ class TokenizeTestCase(unittest.TestCase):
             Tokenizer(engine="catcut888")
 
     def test_sent_tokenize(self):
-        self.assertEqual(sent_tokenize(None), [])
-        self.assertEqual(sent_tokenize(""), [])
         self.assertEqual(
             sent_tokenize("รักน้ำ  รักปลา  ", engine="whitespace"),
             ["รักน้ำ", "รักปลา", ""],

--- a/tests/testx_tokenize.py
+++ b/tests/testx_tokenize.py
@@ -89,6 +89,10 @@ class TokenizeTestCaseX(unittest.TestCase):
         )
 
     def testx_sent_tokenize(self):
+        # Use default engine (crfcut)
+        self.assertEqual(sent_tokenize(None), [])
+        self.assertEqual(sent_tokenize(""), [])
+
         self.assertEqual(
             sent_tokenize(SENT_1, engine="crfcut"),
             SENT_1_TOKS,


### PR DESCRIPTION
sent_tokenize() without engine argument use crfcut as default, move to extra tests (testx)