### PR TITLE
Fix nlpo3.load_dict() that never print error msg when not success

### DIFF
--- a/pythainlp/tokenize/nlpo3.py
+++ b/pythainlp/tokenize/nlpo3.py
@@ -10,30 +10,31 @@ from nlpo3 import segment as nlpo3_segment
 from pythainlp.corpus import path_pythainlp_corpus
 from pythainlp.corpus.common import _THAI_WORDS_FILENAME
 
-_NLPO3_DEFAULT_DICT_NAME = "_67a47bf9"
+_NLPO3_DEFAULT_DICT_NAME = "_73bcj049dzbu9t49b4va170k"  # supposed to be unique
 _NLPO3_DEFAULT_DICT = nlpo3_load_dict(
     path_pythainlp_corpus(_THAI_WORDS_FILENAME), _NLPO3_DEFAULT_DICT_NAME
-)
+)  # preload default dict, so it can be accessible by _NLPO3_DEFAULT_DICT_NAME
 
 
 def load_dict(file_path: str, dict_name: str) -> bool:
     """Load a dictionary file into an in-memory dictionary collection.
 
     The loaded dictionary will be accessible through the assigned dict_name.
-    *** This function does not override an existing dict name. ***
+    *** This function will not override an existing dict name. ***
 
     :param file_path: Path to a dictionary file
     :type file_path: str
     :param dict_name: A unique dictionary name, used for reference.
     :type dict_name: str
-    :return bool
+    :return success: True if loaded successfully, False otherwise.
+    :rtype: bool
 
     :See Also:
         * \
             https://github.com/PyThaiNLP/nlpo3
     """
     msg, success = nlpo3_load_dict(file_path=file_path, dict_name=dict_name)
-    if bool is False:
+    if not success:
         print(msg, file=stderr)
     return success
 


### PR DESCRIPTION
The check should be `if not success` not `if bool is False` which will always False.