### PR TITLE
PyThaiNLP v5.1.0-beta1

### DIFF
--- a/pythainlp/__init__.py
+++ b/pythainlp/__init__.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2016-2024 PyThaiNLP Project
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
-__version__ = "5.0.5-dev"
+__version__ = "5.1.0-beta1"
 
 thai_consonants = "กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรลวศษสหฬอฮ"  # 44 chars
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.6-dev
+current_version = 5.1.0-beta1
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ extras = {
 
 setup(
     name="pythainlp",
-    version="5.0.6-dev",
+    version="5.1.0-beta1",
     description="Thai Natural Language Processing library",
     long_description=LONG_DESC,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
PyThaiNLP v5.1.0-beta1

- First Beta release: 25 December 2024 - 26 December 2024

See #900