### PR TITLE
Fix inconsistency in newmm-safe engine by copilot

### DIFF
--- a/pythainlp/tokenize/newmm.py
+++ b/pythainlp/tokenize/newmm.py
@@ -182,7 +182,7 @@ def segment(
         # try to break by space first
         space_idx = sample.rfind(" ")
         if space_idx >= 0:
-            cut_pos = space_idx + 1
+            cut_pos = space_idx + 1 + _TEXT_SCAN_BEGIN
         else:
             tokens = list(_onecut(sample, custom_dict))
             token_max_idx = 0


### PR DESCRIPTION
Related to #755

Update the calculation of `cut_pos` in `newmm-safe` engine to ensure consistent tokenization results.

* Modify `pythainlp/tokenize/newmm.py` to update the calculation of `cut_pos` at line 193 to `cut_pos = space_idx + 1 + _TEXT_SCAN_BEGIN`.
