### PR TITLE
Refactor syllable.py to use set for thai_consonants_all

### DIFF
--- a/pythainlp/util/syllable.py
+++ b/pythainlp/util/syllable.py
@@ -21,7 +21,7 @@ spelling_class = {
     "กบ": list("บปภพฟ"),
 }
 
-thai_consonants_all = list(thai_consonants)
+thai_consonants_all = set(thai_consonants)
 thai_consonants_all.remove("อ")
 
 _temp = list("".join(["".join(v) for v in spelling_class.values()]))
@@ -87,7 +87,7 @@ def sound_syllable(syllable: str) -> str:
         return "dead"
 
     # get consonants
-    consonants = [i for i in syllable if i in list(thai_consonants_all)]
+    consonants = [i for i in syllable if i in thai_consonants_all]
     if (
         (len(consonants) == 0)
         and ("อ" in syllable)


### PR DESCRIPTION
### What does this changes
Switches `thai_consonants_all` from a `list` to a `set` in pythainlp/util/syllable.py and simplifies its use in sound_syllable.

###  What was wrong
Its not wrong, but the original code used `if i in list(thai_consonants_all)` for membership checks, which was less efficient due to list’s O(n) lookup time.

###  How this fixes it
Using a set for `thai_consonants_all` cleans up the code to `if i in thai_consonants_all`, leverages set’s O(1) lookups for speed, and maintains identical logic with no downsides.

### Your checklist for this pull request

<!--- Please review the guidelines for contributing to this repository at: -->
<!--- https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md -->

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test
