### PR TITLE
Add convert_currency

### DIFF
--- a/docs/api/ancient.rst
+++ b/docs/api/ancient.rst
@@ -7,3 +7,4 @@ Modules
 -------
 
 .. autofunction:: aksonhan_to_current
+.. autofunction:: convert_currency

--- a/pythainlp/ancient/__init__.py
+++ b/pythainlp/ancient/__init__.py
@@ -6,6 +6,7 @@
 Ancient versions of the Thai language
 """
 
-__all__ = ["aksonhan_to_current"]
+__all__ = ["aksonhan_to_current", "convert_currency"]
 
 from pythainlp.ancient.aksonhan import aksonhan_to_current
+from pythainlp.ancient.currency import convert_currency

--- a/pythainlp/ancient/currency.py
+++ b/pythainlp/ancient/currency.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# SPDX-FileCopyrightText: 2016-2025 PyThaiNLP Project
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+def convert_currency(value: float, from_unit: str) -> dict:
+    """
+    Convert ancient Thai currency to other units
+
+    :param float value: value
+    :param str from_unit: currency unit \
+        ('เบี้ย', 'อัฐ', 'ไพ', 'เฟื้อง', 'สลึง', 'บาท', 'ตำลึง', 'ชั่ง')
+    :return: Thai currency
+    :rtype: dict
+    """
+    conversion_factors_to_att = {
+        'เบี้ย': 1,
+        'อัฐ': 100,  # 1 อัฐ = 100 เบี้ย
+        'ไพ': 2 * 100,  # 1 ไพ = 2 อัฐ
+        'เฟื้อง': 4 * 2 * 100,  # 1 เฟื้อง = 4 ไพ
+        'สลึง': 2 * 4 * 2 * 100,  # 1 สลึง = 2 เฟื้อง
+        'บาท': 4 * 2 * 4 * 2 * 100,  # 1 บาท = 4 สลึง
+        'ตำลึง': 4 * 4 * 2 * 4 * 2 * 100,  # 1 ตำลึง = 4 บาท
+        'ชั่ง': 20 * 4 * 4 * 2 * 4 * 2 * 100,  # 1 ชั่ง = 20 ตำลึง
+    }
+
+    if from_unit not in conversion_factors_to_att:
+        raise NotImplementedError(
+            f"Currency unit '{from_unit}' is not support."
+        )
+
+    # start from 'อัฐ'
+    value_in_att = value * conversion_factors_to_att[from_unit]
+
+    # Calculate values ​​in other units
+    results = {}
+    for unit, factor in conversion_factors_to_att.items():
+        results[unit] = value_in_att / factor
+
+    return results

--- a/pythainlp/ancient/currency.py
+++ b/pythainlp/ancient/currency.py
@@ -7,11 +7,41 @@ def convert_currency(value: float, from_unit: str) -> dict:
     """
     Convert ancient Thai currency to other units
 
+    * เบี้ย (Bia)
+    * อัฐ (At)
+    * ไพ (Pi)
+    * เฟื้อง (Feuang)
+    * สลึง (Saleung)
+    * บาท (Bath)
+    * ตำลึง (Tamleung)
+    * ชั่ง (Chang)
+
+    See more:
+        `Thai money <https://en.wikipedia.org/wiki/History_of_Thai_money>`_.
+
     :param float value: value
     :param str from_unit: currency unit \
         ('เบี้ย', 'อัฐ', 'ไพ', 'เฟื้อง', 'สลึง', 'บาท', 'ตำลึง', 'ชั่ง')
     :return: Thai currency
     :rtype: dict
+
+    :Example:
+    ::
+
+        from pythainlp.ancient import convert_currency
+
+        print(convert_currency(8, "บาท"))
+        # output:
+        # {
+        #  'เบี้ย': 51200.0,
+        #  'อัฐ': 512.0,
+        #  'ไพ': 256.0,
+        #  'เฟื้อง': 64.0,
+        #  'สลึง': 32.0,
+        #  'บาท': 8.0,
+        #  'ตำลึง': 2.0,
+        #  'ชั่ง': 0.1
+        # }
     """
     conversion_factors_to_att = {
         'เบี้ย': 1,

--- a/tests/core/test_ancient.py
+++ b/tests/core/test_ancient.py
@@ -5,7 +5,7 @@
 
 import unittest
 
-from pythainlp.ancient import aksonhan_to_current
+from pythainlp.ancient import aksonhan_to_current, convert_currency
 
 
 class AncientTestCase(unittest.TestCase):
@@ -23,3 +23,25 @@ class AncientTestCase(unittest.TestCase):
         self.assertEqual(aksonhan_to_current("หลงง"), "หลัง")
         self.assertEqual(aksonhan_to_current("บงงคบบ"), "บังคับ")
         self.assertEqual(aksonhan_to_current("สรรเพชญ"), "สรรเพชญ")
+
+    def test_convert_currency(self):
+        self.assertEqual(
+            convert_currency(80, "บาท")["ตำลึง"],
+            20.0
+        )
+        self.assertEqual(
+            convert_currency(80, "บาท")["ชั่ง"],
+            1.0
+        )
+        self.assertEqual(
+            convert_currency(80, "บาท")["บาท"],
+            80.0
+        )
+        self.assertEqual(
+            convert_currency(1,"ชั่ง")["บาท"],
+            80.0
+        )
+        self.assertEqual(
+            convert_currency(1,"ชั่ง")["ชั่ง"],
+            1.0
+        )


### PR DESCRIPTION
Fix #1113

```
100 เบี้ย = 1 อัฐ
2 อัฐ = 1 ไพ
4 ไพ = 1 เฟื้อง
2 เฟื้อง = 1 สลึง
4 สลึง = 1 บาท
4 บาท = 1 ตำลึง
20 ตำลึง = 1 ชั่ง
```


### Your checklist for this pull request

<!--- Please review the guidelines for contributing to this repository at: -->
<!--- https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md -->

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test