### PR TITLE
Remove spylls

### DIFF
--- a/docker_requirements.txt
+++ b/docker_requirements.txt
@@ -28,7 +28,6 @@ sentence-transformers==2.7.0
 sentencepiece==0.2.0
 spacy_thai==0.7.8
 spacy==3.5.*
-spylls==0.1.7
 ssg==0.0.8
 symspellpy==6.9.0
 tensorflow==2.18.1

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,6 @@ extras = {
         "sentence-transformers>=2.2.2",
         "spacy>=3.0",
         "spacy_thai>=0.7.1",
-        "spylls>=0.1.5",
         "ssg>=0.0.8",
         "symspellpy>=6.7.6",
         "thai_nner",


### PR DESCRIPTION
We haven't used spells for a long time. I searched the code that uses spylls, but I didn't find it. It looks like we forgot to remove `spylls`.