### PR TITLE
Comment out non-exists URL test case

### DIFF
--- a/tests/core/test_corpus.py
+++ b/tests/core/test_corpus.py
@@ -78,10 +78,10 @@ class CorpusTestCase(unittest.TestCase):
         self.assertIsNone(get_corpus_default_db("3XKg0013", "1.2.345"))
 
         # BEGIN - Test non-exists
-        self.assertIsInstance(
-            get_corpus_db("https://example.com/XXXXXX0lkjasd/SXfmskdjKKXXX"),
-            Response,
-        )  # URL does not exist, should get 404 response
+        # self.assertIsInstance(
+        #     get_corpus_db("https://example.com/XXXXXX0lkjasd/SXfmskdjKKXXX"),
+        #     Response,
+        # )  # URL does not exist, should get 404 response
         self.assertIsNone(get_corpus_db("XXXlkja3sfdXX"))  # Invalid URL
         self.assertEqual(
             get_corpus_db_detail("XXXmx3KSXX"), {}


### PR DESCRIPTION
Comment out test for non-existent URL response.

The download test on non-existing example.com/xxx URL creates issues in test workflow often, esp on Mac instances.

