### PR TITLE
Fix base dependencies

### DIFF
--- a/pythainlp/cli/benchmark.py
+++ b/pythainlp/cli/benchmark.py
@@ -91,7 +91,7 @@ class WordTokenizationBenchmark:
             from pythainlp.benchmarks import word_tokenization
         except ImportError:
             raise ImportError(
-                "Please install the extra dependencies `benchmarks` to use the command by `pip install pythainlp[benchmarks]`"
+                "Please install the extra dependencies `benchmarks` to use this command by running `pip install pythainlp[benchmarks]`"
             )
 
         df_raw = word_tokenization.benchmark(expected, actual)

--- a/pythainlp/cli/benchmark.py
+++ b/pythainlp/cli/benchmark.py
@@ -8,10 +8,8 @@ import argparse
 import json
 import os
 
-import yaml
 
 from pythainlp import cli
-from pythainlp.benchmarks import word_tokenization
 from pythainlp.tools import safe_print
 
 
@@ -87,6 +85,14 @@ class WordTokenizationBenchmark:
             "Benchmarking %s against %s with %d samples in total"
             % (args.input_file, args.test_file, len(actual))
         )
+
+        try:
+            import yaml
+            from pythainlp.benchmarks import word_tokenization
+        except ImportError:
+            raise ImportError(
+                "Please install the extra dependencies `benchmarks` to use the command by `pip install pythainlp[benchmarks]`"
+            )
 
         df_raw = word_tokenization.benchmark(expected, actual)
 

--- a/pythainlp/tools/misspell.py
+++ b/pythainlp/tools/misspell.py
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from typing import List
 
-import numpy as np
+import math
+import random
 
 THAI_CHARACTERS_WITHOUT_SHIFT = [
     "ผปแอิืทมใฝ",
@@ -126,10 +127,8 @@ def misspell(sentence: str, ratio: float = 0.05):
         # output:
         ภาษาไทยปรากฏครั้งแรกในกุทธศักราช 1727
     """
-    num_misspells = np.floor(len(sentence) * ratio).astype(int)
-    positions = np.random.choice(
-        len(sentence), size=num_misspells, replace=False
-    )
+    num_misspells = math.floor(len(sentence) * ratio)
+    positions = random.sample(range(len(sentence)), k=num_misspells)
 
     # convert strings to array of characters
     misspelled = list(sentence)
@@ -138,7 +137,7 @@ def misspell(sentence: str, ratio: float = 0.05):
         if potential_candidates is None:
             continue
 
-        candidate = np.random.choice(potential_candidates)
+        candidate = random.choice(potential_candidates)
 
         misspelled[pos] = candidate
 

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,6 @@ See https://github.com/PyThaiNLP/pythainlp for installation options.
 requirements = [
     "backports.zoneinfo; python_version<'3.9'",
     "requests>=2.31",
-    PYYAML,
-    PANDAS,
-    NUMPY,
     "tzdata; sys_platform == 'win32'",
 ]
 


### PR DESCRIPTION
### What does this changes

Remove `pandas`, `numpy` and `pyyaml` from base dependencies

### What was wrong

As described in issue #1184 

### How this fixes it

After investigating, these three libraries are used in two modules, `benchmark` and `misspell`. In `misspell`, we can totally remove `numpy` out since we can achieve the same functionality by use built-in python module `math` and `random` (might be quicker too, since we remove `numpy` overhead). In `benchmark`, we can use lazy imports so that running help in parser does not raise import errors. The modules are only imported at execution time, which improves flexibility and avoids failures during help or argument parsing. I also added the warning that the user should install `pythainlp[benchmarks]` if they want to use the `thainlp benchmark`

Fixes
- Remove base dependencies
- Make `misspell` module, use built-in python library instead of `numpy`
- Make `benchmark` module lazy import and warning to install extra dependency.

### Your checklist for this pull request

<!--- Please review the guidelines for contributing to this repository at: -->
<!--- https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md -->

- [ ] Passed code styles and structures
- [ ] Passed code linting checks and unit test
