### PR TITLE
Reduce peak memory on import by 62x

### DIFF
--- a/docs/api/spell.rst
+++ b/docs/api/spell.rst
@@ -48,9 +48,9 @@ The `NorvigSpellChecker` class is a fundamental component of the `pythainlp.spel
 DEFAULT_SPELL_CHECKER
 ~~~~~~~~~~~~~~~~~~~~~
 .. autodata:: DEFAULT_SPELL_CHECKER
-   :annotation: = Default instance of the standard NorvigSpellChecker, using word list data from the Thai National Corpus: http://www.arts.chula.ac.th/ling/tnc/
+   :annotation: = Default reference of the standard NorvigSpellChecker, using word list data from the Thai National Corpus: http://www.arts.chula.ac.th/ling/tnc/
 
-The `DEFAULT_SPELL_CHECKER` is an instance of the `NorvigSpellChecker` class with default settings. It is pre-configured to use word list data from the Thai National Corpus, making it a reliable choice for general spell-checking tasks.
+The `DEFAULT_SPELL_CHECKER` is an reference to the `NorvigSpellChecker` class with default settings. It is pre-configured to use word list data from the Thai National Corpus, making it a reliable choice for general spell-checking tasks.
 
 References
 ----------

--- a/pythainlp/augment/word2vec/thai2fit.py
+++ b/pythainlp/augment/word2vec/thai2fit.py
@@ -6,7 +6,7 @@ from typing import List, Tuple
 
 from pythainlp.augment.word2vec.core import Word2VecAug
 from pythainlp.corpus import get_corpus_path
-from pythainlp.tokenize import THAI2FIT_TOKENIZER
+from pythainlp.tokenize import thai2fit_tokenizer
 
 
 class Thai2fitAug:
@@ -26,7 +26,8 @@ class Thai2fitAug:
         :param str text: Thai text
         :rtype: List[str]
         """
-        return THAI2FIT_TOKENIZER.word_tokenize(text)
+        tok = thai2fit_tokenizer()
+        return tok.word_tokenize(text)
 
     def load_w2v(self):
         """

--- a/pythainlp/spell/__init__.py
+++ b/pythainlp/spell/__init__.py
@@ -18,7 +18,7 @@ __all__ = [
 
 from pythainlp.spell.pn import NorvigSpellChecker
 
-DEFAULT_SPELL_CHECKER = NorvigSpellChecker()
+DEFAULT_SPELL_CHECKER = NorvigSpellChecker
 
 # these imports are placed here to avoid circular imports
 from pythainlp.spell.core import correct, correct_sent, spell, spell_sent

--- a/pythainlp/spell/core.py
+++ b/pythainlp/spell/core.py
@@ -6,11 +6,16 @@
 Spell checking functions
 """
 
+from functools import lru_cache
 import itertools
 from typing import List
 
 from pythainlp.spell import DEFAULT_SPELL_CHECKER
 
+@lru_cache
+def default_spell_checker():
+    """Lazy load default spell checker with cache"""
+    return DEFAULT_SPELL_CHECKER()
 
 def spell(word: str, engine: str = "pn") -> List[str]:
     """
@@ -72,7 +77,7 @@ def spell(word: str, engine: str = "pn") -> List[str]:
 
         text_correct = SPELL_CHECKER(word)
     else:
-        text_correct = DEFAULT_SPELL_CHECKER.spell(word)
+        text_correct = default_spell_checker().spell(word)
 
     return text_correct
 
@@ -125,7 +130,7 @@ def correct(word: str, engine: str = "pn") -> str:
         text_correct = SPELL_CHECKER(word)
 
     else:
-        text_correct = DEFAULT_SPELL_CHECKER.correct(word)
+        text_correct = default_spell_checker().correct(word)
 
     return text_correct
 

--- a/pythainlp/tokenize/__init__.py
+++ b/pythainlp/tokenize/__init__.py
@@ -7,7 +7,7 @@ Tokenizers at different levels of linguistic analysis.
 """
 
 __all__ = [
-    "THAI2FIT_TOKENIZER",
+    "thai2fit_tokenizer",
     "Tokenizer",
     "Trie",
     "paragraph_tokenize",
@@ -41,9 +41,4 @@ from pythainlp.tokenize.core import (
     word_tokenize,
     display_cell_tokenize,
 )
-
-from pythainlp.corpus import get_corpus as _get_corpus
-
-THAI2FIT_TOKENIZER = Tokenizer(
-    custom_dict=_get_corpus("words_th_thai2fit_201810.txt"), engine="mm"
-)
+from pythainlp.tokenize.thai2fit import thai2fit_tokenizer

--- a/pythainlp/tokenize/__init__.py
+++ b/pythainlp/tokenize/__init__.py
@@ -19,6 +19,7 @@ __all__ = [
     "display_cell_tokenize",
 ]
 
+from functools import lru_cache
 from pythainlp.corpus import thai_syllables, thai_words
 from pythainlp.util.trie import Trie
 
@@ -27,9 +28,15 @@ DEFAULT_SENT_TOKENIZE_ENGINE = "crfcut"
 DEFAULT_SUBWORD_TOKENIZE_ENGINE = "tcc"
 DEFAULT_SYLLABLE_TOKENIZE_ENGINE = "han_solo"
 
-DEFAULT_WORD_DICT_TRIE = Trie(thai_words())
-DEFAULT_SYLLABLE_DICT_TRIE = Trie(thai_syllables())
-DEFAULT_DICT_TRIE = DEFAULT_WORD_DICT_TRIE
+@lru_cache
+def word_dict_trie():
+    """Lazy load default word dict trie with cache"""
+    return Trie(thai_words())
+
+@lru_cache
+def syllable_dict_trie():
+    """Lazy load default syllable dict trie with cache"""
+    return Trie(thai_syllables())
 
 from pythainlp.tokenize.core import (
     Tokenizer,

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -97,7 +97,7 @@ def word_detokenize(
 
 def word_tokenize(
     text: str,
-    custom_dict: Trie = Trie([]),
+    custom_dict: Trie | None = None,
     engine: str = DEFAULT_WORD_TOKENIZE_ENGINE,
     keep_whitespace: bool = True,
     join_broken_num: bool = True,
@@ -222,6 +222,9 @@ def word_tokenize(
         return []
 
     segments = []
+
+    if custom_dict is None:
+        custom_dict = Trie([])
 
     if custom_dict and engine in (
         "attacut",
@@ -877,6 +880,7 @@ class Tokenizer:
         :param bool keep_whitespace: True to keep whitespace, a common mark
                                      for end of phrase in Thai
         """
+        print("HEHE")
         self.__trie_dict = Trie([])
         if custom_dict:
             self.__trie_dict = dict_trie(custom_dict)

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -8,7 +8,7 @@ Generic functions of tokenizers
 
 import copy
 import re
-from typing import Iterable, List, Union
+from typing import Iterable, List, Optional, Union
 
 from pythainlp.tokenize import (
     DEFAULT_SENT_TOKENIZE_ENGINE,
@@ -97,7 +97,7 @@ def word_detokenize(
 
 def word_tokenize(
     text: str,
-    custom_dict: Trie | None = None,
+    custom_dict: Optional[Trie] = None,
     engine: str = DEFAULT_WORD_TOKENIZE_ENGINE,
     keep_whitespace: bool = True,
     join_broken_num: bool = True,

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -13,9 +13,9 @@ from typing import Iterable, List, Union
 from pythainlp.tokenize import (
     DEFAULT_SENT_TOKENIZE_ENGINE,
     DEFAULT_SUBWORD_TOKENIZE_ENGINE,
-    DEFAULT_SYLLABLE_DICT_TRIE,
+    syllable_dict_trie,
     DEFAULT_SYLLABLE_TOKENIZE_ENGINE,
-    DEFAULT_WORD_DICT_TRIE,
+    word_dict_trie,
     DEFAULT_WORD_TOKENIZE_ENGINE,
 )
 from pythainlp.tokenize._utils import (
@@ -693,7 +693,7 @@ def subword_tokenize(
         for word in words:
             segments.extend(
                 word_tokenize(
-                    text=word, custom_dict=DEFAULT_SYLLABLE_DICT_TRIE
+                    text=word, custom_dict=syllable_dict_trie()
                 )
             )
     elif engine == "ssg":
@@ -885,7 +885,7 @@ class Tokenizer:
         if custom_dict:
             self.__trie_dict = dict_trie(custom_dict)
         else:
-            self.__trie_dict = DEFAULT_WORD_DICT_TRIE
+            self.__trie_dict = word_dict_trie()
         self.__engine = engine
         if self.__engine not in ["newmm", "mm", "longest", "deepcut"]:
             raise NotImplementedError(

--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -880,7 +880,6 @@ class Tokenizer:
         :param bool keep_whitespace: True to keep whitespace, a common mark
                                      for end of phrase in Thai
         """
-        print("HEHE")
         self.__trie_dict = Trie([])
         if custom_dict:
             self.__trie_dict = dict_trie(custom_dict)

--- a/pythainlp/tokenize/etcc.py
+++ b/pythainlp/tokenize/etcc.py
@@ -19,6 +19,7 @@ Para Limmaneepraserth. "Thai word segmentation using combination of forward
 and backward longest matching techniques." In International Symposium on
 Communications and Information Technology (ISCIT), pp. 37-40. 2001.
 """
+from functools import lru_cache
 import re
 from typing import List
 
@@ -26,7 +27,11 @@ from pythainlp import thai_follow_vowels
 from pythainlp.corpus import get_corpus
 from pythainlp.tokenize import Tokenizer
 
-_cut_etcc = Tokenizer(get_corpus("etcc.txt"), engine="longest")
+@lru_cache
+def _cut_etcc():
+    """Lazy load ETCC tokenizer with cache"""
+    return Tokenizer(get_corpus("etcc.txt"), engine="longest")
+
 _PAT_ENDING_CHAR = f"[{thai_follow_vowels}ๆฯ]"
 _RE_ENDING_CHAR = re.compile(_PAT_ENDING_CHAR)
 
@@ -64,4 +69,4 @@ def segment(text: str) -> List[str]:
     if not text or not isinstance(text, str):
         return []
 
-    return _cut_subword(_cut_etcc.word_tokenize(text))
+    return _cut_subword(_cut_etcc().word_tokenize(text))

--- a/pythainlp/tokenize/longest.py
+++ b/pythainlp/tokenize/longest.py
@@ -12,10 +12,10 @@ on the codes from Patorn Utenpattanun.
 
 """
 import re
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 from pythainlp import thai_tonemarks
-from pythainlp.tokenize import DEFAULT_WORD_DICT_TRIE
+from pythainlp.tokenize import word_dict_trie
 from pythainlp.util import Trie
 
 _FRONT_DEP_CHAR = [
@@ -152,7 +152,7 @@ class LongestMatchTokenizer:
 _tokenizers: Dict[int, LongestMatchTokenizer] = {}
 
 
-def segment(text: str, custom_dict: Trie = DEFAULT_WORD_DICT_TRIE) -> List[str]:
+def segment(text: str, custom_dict: Optional[Trie] = None) -> List[str]:
     """
     Dictionary-based longest matching word segmentation.
 
@@ -164,7 +164,7 @@ def segment(text: str, custom_dict: Trie = DEFAULT_WORD_DICT_TRIE) -> List[str]:
         return []
 
     if not custom_dict:
-        custom_dict = DEFAULT_WORD_DICT_TRIE
+        custom_dict = word_dict_trie()
 
     global _tokenizers
     custom_dict_ref_id = id(custom_dict)

--- a/pythainlp/tokenize/multi_cut.py
+++ b/pythainlp/tokenize/multi_cut.py
@@ -15,9 +15,9 @@ Original codes from Korakot Chaovavanich.
 
 import re
 from collections import defaultdict
-from typing import Iterator, List
+from typing import Iterator, List, Optional
 
-from pythainlp.tokenize import DEFAULT_WORD_DICT_TRIE
+from pythainlp.tokenize import word_dict_trie
 from pythainlp.util import Trie
 
 
@@ -48,12 +48,11 @@ _PAT_NONTHAI = re.compile(_RE_NONTHAI)
 
 
 def _multicut(
-    text: str, custom_dict: Trie = DEFAULT_WORD_DICT_TRIE
+    text: str, custom_dict: Optional[Trie] = None
 ) -> Iterator[LatticeString]:
     """Return LatticeString"""
     if not custom_dict:
-        custom_dict = DEFAULT_WORD_DICT_TRIE
-
+        custom_dict = word_dict_trie()
     len_text = len(text)
     words_at = defaultdict(list)  # main data structure
 
@@ -123,39 +122,45 @@ def _combine(ww: List[LatticeString]) -> Iterator[str]:
 
 
 def segment(
-    text: str, custom_dict: Trie = DEFAULT_WORD_DICT_TRIE
+    text: str, custom_dict: Optional[Trie] = None
 ) -> List[str]:
     """Dictionary-based maximum matching word segmentation.
 
     :param text: text to be tokenized
     :type text: str
     :param custom_dict: tokenization dictionary,\
-        defaults to DEFAULT_WORD_DICT_TRIE
+        defaults to word_dict_trie()
     :type custom_dict: Trie, optional
     :return: list of segmented tokens
     :rtype: List[str]
     """
     if not text or not isinstance(text, str):
         return []
+    
+    if not custom_dict:
+        custom_dict = word_dict_trie()
 
     return list(_multicut(text, custom_dict=custom_dict))
 
 
 def find_all_segment(
-    text: str, custom_dict: Trie = DEFAULT_WORD_DICT_TRIE
+    text: str, custom_dict: Optional[Trie] = None
 ) -> List[str]:
     """Get all possible segment variations.
 
     :param text: input string to be tokenized
     :type text: str
     :param custom_dict: tokenization dictionary,\
-        defaults to DEFAULT_WORD_DICT_TRIE
+        defaults to word_dict_trie()
     :type custom_dict: Trie, optional
     :return: list of segment variations
     :rtype: List[str]
     """
     if not text or not isinstance(text, str):
         return []
+    
+    if not custom_dict:
+        custom_dict = word_dict_trie()
 
     ww = list(_multicut(text, custom_dict=custom_dict))
 

--- a/pythainlp/tokenize/multi_cut.py
+++ b/pythainlp/tokenize/multi_cut.py
@@ -136,7 +136,7 @@ def segment(
     """
     if not text or not isinstance(text, str):
         return []
-    
+
     if not custom_dict:
         custom_dict = word_dict_trie()
 
@@ -158,7 +158,7 @@ def find_all_segment(
     """
     if not text or not isinstance(text, str):
         return []
-    
+
     if not custom_dict:
         custom_dict = word_dict_trie()
 

--- a/pythainlp/tokenize/multi_cut.py
+++ b/pythainlp/tokenize/multi_cut.py
@@ -129,7 +129,7 @@ def segment(
     :param text: text to be tokenized
     :type text: str
     :param custom_dict: tokenization dictionary,\
-        defaults to word_dict_trie()
+        defaults to a Trie generated from pythainlp.corpus.thai_words
     :type custom_dict: Trie, optional
     :return: list of segmented tokens
     :rtype: List[str]

--- a/pythainlp/tokenize/newmm.py
+++ b/pythainlp/tokenize/newmm.py
@@ -18,9 +18,9 @@ with heuristic graph size limit added to avoid exponential waiting time.
 import re
 from collections import defaultdict
 from heapq import heappop, heappush
-from typing import Generator, List
+from typing import Generator, List, Optional
 
-from pythainlp.tokenize import DEFAULT_WORD_DICT_TRIE
+from pythainlp.tokenize import word_dict_trie
 from pythainlp.tokenize.tcc_p import tcc_pos
 from pythainlp.util import Trie
 
@@ -140,7 +140,7 @@ def _onecut(text: str, custom_dict: Trie) -> Generator[str, None, None]:
 
 def segment(
     text: str,
-    custom_dict: Trie = DEFAULT_WORD_DICT_TRIE,
+    custom_dict: Optional[Trie] = None,
     safe_mode: bool = False,
 ) -> List[str]:
     """Maximal-matching word segmentation constrained by Thai Character Cluster.
@@ -153,7 +153,7 @@ def segment(
     :param text: text to be tokenized
     :type text: str
     :param custom_dict: tokenization dictionary,\
-        defaults to DEFAULT_WORD_DICT_TRIE
+        defaults to word_dict_trie()
     :type custom_dict: Trie, optional
     :param safe_mode: reduce chance for long processing time for long text\
         with many ambiguous breaking points, defaults to False
@@ -165,7 +165,7 @@ def segment(
         return []
 
     if not custom_dict:
-        custom_dict = DEFAULT_WORD_DICT_TRIE
+        custom_dict = word_dict_trie()
 
     if not safe_mode or len(text) < _TEXT_SCAN_END:
         return list(_onecut(text, custom_dict))

--- a/pythainlp/tokenize/thai2fit.py
+++ b/pythainlp/tokenize/thai2fit.py
@@ -1,0 +1,10 @@
+from functools import lru_cache
+from pythainlp.corpus import get_corpus
+from pythainlp.tokenize import Tokenizer
+
+@lru_cache
+def thai2fit_tokenizer():
+    """Lazy load Thai2Fit tokenizer with cache"""
+    return Tokenizer(
+        custom_dict=get_corpus("words_th_thai2fit_201810.txt"), engine="mm"
+    )

--- a/pythainlp/tokenize/thai2fit.py
+++ b/pythainlp/tokenize/thai2fit.py
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -*-
+# SPDX-FileCopyrightText: 2016-2026 PyThaiNLP Project
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
 from functools import lru_cache
 from pythainlp.corpus import get_corpus
 from pythainlp.tokenize import Tokenizer

--- a/pythainlp/tokenize/thai2fit.py
+++ b/pythainlp/tokenize/thai2fit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: 2016-2026 PyThaiNLP Project
+# SPDX-FileCopyrightText: 2026 PyThaiNLP Project
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
 

--- a/pythainlp/ulmfit/core.py
+++ b/pythainlp/ulmfit/core.py
@@ -12,7 +12,7 @@ import numpy as np
 import torch
 
 from pythainlp.corpus import get_corpus_path
-from pythainlp.tokenize import THAI2FIT_TOKENIZER
+from pythainlp.tokenize import thai2fit_tokenizer
 from pythainlp.ulmfit.preprocess import (
     fix_html,
     lowercase_all,
@@ -67,7 +67,7 @@ post_rules_th_sparse = post_rules_th[1:] + [
 def process_thai(
     text: str,
     pre_rules: Collection = pre_rules_th_sparse,
-    tok_func: Callable = THAI2FIT_TOKENIZER.word_tokenize,
+    tok_func: Callable | None = None,
     post_rules: Collection = post_rules_th_sparse,
 ) -> Collection[str]:
     """
@@ -132,6 +132,9 @@ def process_thai(
     """
     res = text
 
+    if tok_func is None:
+        tok_func = thai2fit_tokenizer().word_tokenize
+
     for rule in pre_rules:
         res = rule(res)
     res = tok_func(res)
@@ -183,7 +186,7 @@ def document_vector(text: str, learn, data, agg: str = "mean"):
 
     """
 
-    s = THAI2FIT_TOKENIZER.word_tokenize(text)
+    s = thai2fit_tokenizer().word_tokenize(text)
     t = torch.tensor(data.vocab.numericalize(s), requires_grad=False).to(
         device
     )

--- a/pythainlp/ulmfit/core.py
+++ b/pythainlp/ulmfit/core.py
@@ -6,7 +6,7 @@
 Universal Language Model Fine-tuning for Text Classification (ULMFiT).
 """
 import collections
-from typing import Callable, Collection
+from typing import Callable, Collection, Optional
 
 import numpy as np
 import torch
@@ -67,7 +67,7 @@ post_rules_th_sparse = post_rules_th[1:] + [
 def process_thai(
     text: str,
     pre_rules: Collection = pre_rules_th_sparse,
-    tok_func: Callable | None = None,
+    tok_func: Optional[Callable] = None,
     post_rules: Collection = post_rules_th_sparse,
 ) -> Collection[str]:
     """

--- a/pythainlp/ulmfit/tokenizer.py
+++ b/pythainlp/ulmfit/tokenizer.py
@@ -8,7 +8,7 @@ Tokenzier classes for ULMFiT
 
 from typing import Collection, List
 
-from pythainlp.tokenize import THAI2FIT_TOKENIZER
+from pythainlp.tokenize import thai2fit_tokenizer
 
 
 class BaseTokenizer:
@@ -65,7 +65,7 @@ class ThaiTokenizer(BaseTokenizer):
              ' ', 'ภาวนามยปัญญา']
 
         """
-        return THAI2FIT_TOKENIZER.word_tokenize(text)
+        return thai2fit_tokenizer().word_tokenize(text)
 
     def add_special_cases(self, toks):
         pass

--- a/pythainlp/util/phoneme.py
+++ b/pythainlp/util/phoneme.py
@@ -5,6 +5,7 @@
 """
 Phonemes util
 """
+from functools import lru_cache
 import unicodedata
 
 from pythainlp.tokenize import Tokenizer
@@ -192,8 +193,12 @@ dict_ipa_rtgs = {
 }
 
 dict_ipa_rtgs_final = {"w": "o"}
-trie = Trie(list(dict_ipa_rtgs.keys()) + list(dict_ipa_rtgs_final.keys()))
-ipa_cut = Tokenizer(custom_dict=trie, engine="newmm")
+
+@lru_cache
+def _ipa_cut():
+    """Lazy load IPA tokenizer with cache"""
+    trie = Trie(list(dict_ipa_rtgs.keys()) + list(dict_ipa_rtgs_final.keys()))
+    return Tokenizer(custom_dict=trie, engine="newmm")
 
 
 def ipa_to_rtgs(ipa: str) -> str:
@@ -216,6 +221,7 @@ def ipa_to_rtgs(ipa: str) -> str:
 
     """
     rtgs_parts = []
+    ipa_cut = _ipa_cut()
 
     ipa_parts = ipa_cut.word_tokenize(ipa)
     for i, ipa_part in enumerate(ipa_parts):

--- a/pythainlp/util/spell_words.py
+++ b/pythainlp/util/spell_words.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2016-2026 PyThaiNLP Project
 # SPDX-FileType: SOURCE
 # SPDX-License-Identifier: Apache-2.0
+from functools import lru_cache
 import re
 from typing import List
 
@@ -48,7 +49,10 @@ for i in thai_above_vowels:
 for i in thai_below_vowels:
     dict_vowel[i] = "อ" + i
 
-_cut = Tokenizer(list(dict_vowel.keys()) + list(thai_consonants), engine="mm")
+@lru_cache
+def _cut():
+    """Lazy load vowel tokenizer with cache"""
+    return Tokenizer(list(dict_vowel.keys()) + list(thai_consonants), engine="mm")
 
 
 def _clean(w):
@@ -93,7 +97,7 @@ def spell_syllable(text: str) -> List[str]:
         print(spell_syllable("แมว"))
         # output: ['มอ', 'วอ', 'แอ', 'แมว']
     """
-    tokens = _cut.word_tokenize(_clean(text))
+    tokens = _cut().word_tokenize(_clean(text))
 
     c_only = [tok + "อ" for tok in tokens if tok in set(thai_consonants)]
     v_only = [dict_vowel[tok] for tok in tokens if tok in set(dict_vowel)]

--- a/pythainlp/util/time.py
+++ b/pythainlp/util/time.py
@@ -8,6 +8,7 @@ Spell out time as Thai words.
 Convert time string or time object to Thai words.
 """
 from datetime import datetime, time
+from functools import lru_cache
 from typing import Union
 
 from pythainlp.tokenize import Tokenizer
@@ -43,9 +44,13 @@ _DICT_THAI_TIME = {
     "นาฬิกา": 0,
     "ครึ่ง": 30,
 }
-_THAI_TIME_CUT = Tokenizer(
-    custom_dict=list(_DICT_THAI_TIME.keys()), engine="newmm"
-)
+
+@lru_cache
+def _thai_time_cut():
+    """Lazy load Thai time tokenizer with cache"""
+    return Tokenizer(
+        custom_dict=list(_DICT_THAI_TIME.keys()), engine="newmm"
+    )
 _THAI_TIME_AFFIX = [
     "โมงเช้า",
     "บ่ายโมง",
@@ -266,10 +271,10 @@ def thaiword_to_time(text: str, padding: bool = True) -> str:
     _LIST_THAI_TIME = _time.split("|")
     del _time
 
-    hour = _THAI_TIME_CUT.word_tokenize(_LIST_THAI_TIME[0])
+    hour = _thai_time_cut().word_tokenize(_LIST_THAI_TIME[0])
     minute = _LIST_THAI_TIME[1]
     if len(minute) > 1:
-        minute = _THAI_TIME_CUT.word_tokenize(minute)
+        minute = _thai_time_cut().word_tokenize(minute)
     else:
         minute = 0
     text = ""

--- a/pythainlp/util/wordtonum.py
+++ b/pythainlp/util/wordtonum.py
@@ -8,6 +8,7 @@ Convert number in words to a computable number value
 First version of the code adapted from Korakot Chaovavanich's notebook
 https://colab.research.google.com/drive/148WNIeclf0kOU6QxKd6pcfwpSs8l-VKD#scrollTo=EuVDd0nNuI8Q
 """
+from functools import lru_cache
 import re
 from typing import List
 
@@ -47,7 +48,10 @@ _powers_of_10 = {
 _valid_tokens = (
     set(_digits.keys()) | set(_powers_of_10.keys()) | {"ล้าน", "ลบ"}
 )
-_tokenizer = Tokenizer(custom_dict=_valid_tokens)
+@lru_cache
+def _tokenizer():
+    """Lazy load Thai numeral tokenizer with cache"""
+    return Tokenizer(custom_dict=_valid_tokens)
 
 
 def _check_is_thainum(word: str):
@@ -96,7 +100,7 @@ def thaiword_to_num(word: str) -> int:
     if not _re_thai_numerals.fullmatch(word):
         raise ValueError("The input string is not a valid Thai numeral")
 
-    tokens = _tokenizer.word_tokenize(word)
+    tokens = _tokenizer().word_tokenize(word)
     accumulated = 0
     next_digit = 1
 

--- a/pythainlp/util/wordtonum.py
+++ b/pythainlp/util/wordtonum.py
@@ -68,7 +68,10 @@ _dict_words = [i for i in list(thai_words()) if not _check_is_thainum(i)[0]]
 _dict_words += list(_digits.keys())
 _dict_words += ["สิบ", "ร้อย", "พัน", "หมื่น", "แสน", "ล้าน", "จุด"]
 
-_tokenizer_thaiwords = Tokenizer(_dict_words)
+@lru_cache
+def _tokenizer_thaiwords():
+    """Lazy load Thai words tokenizer with cache"""
+    return Tokenizer(_dict_words)
 
 
 def thaiword_to_num(word: str) -> int:

--- a/pythainlp/util/wordtonum.py
+++ b/pythainlp/util/wordtonum.py
@@ -191,7 +191,7 @@ def text_to_num(text: str) -> List[str]:
         # output: ['10021889', 'บาท']
 
     """
-    _temp = _tokenizer_thaiwords.word_tokenize(text)
+    _temp = _tokenizer_thaiwords().word_tokenize(text)
     thainum = []
     last_index = -1
     list_word_new = []

--- a/pythainlp/util/wordtonum.py
+++ b/pythainlp/util/wordtonum.py
@@ -64,13 +64,12 @@ def _check_is_thainum(word: str):
     return (False, None)
 
 
-_dict_words = [i for i in list(thai_words()) if not _check_is_thainum(i)[0]]
-_dict_words += list(_digits.keys())
-_dict_words += ["สิบ", "ร้อย", "พัน", "หมื่น", "แสน", "ล้าน", "จุด"]
-
 @lru_cache
 def _tokenizer_thaiwords():
     """Lazy load Thai words tokenizer with cache"""
+    _dict_words = [i for i in list(thai_words()) if not _check_is_thainum(i)[0]]
+    _dict_words += list(_digits.keys())
+    _dict_words += ["สิบ", "ร้อย", "พัน", "หมื่น", "แสน", "ล้าน", "จุด"]
     return Tokenizer(_dict_words)
 
 

--- a/pythainlp/word_vector/core.py
+++ b/pythainlp/word_vector/core.py
@@ -9,7 +9,7 @@ from gensim.models.keyedvectors import Word2VecKeyedVectors
 from numpy import ndarray, zeros
 
 from pythainlp.corpus import get_corpus_path
-from pythainlp.tokenize import THAI2FIT_TOKENIZER, word_tokenize
+from pythainlp.tokenize import thai2fit_tokenizer, word_tokenize
 
 WV_DIM = 300  # word vector dimension
 
@@ -61,7 +61,7 @@ class WordVector:
         self.WV_DIM = self.model.vector_size
 
         if self.model_name == "thai2fit_wv":
-            self.tokenize = THAI2FIT_TOKENIZER.word_tokenize
+            self.tokenize = thai2fit_tokenizer().word_tokenize
         else:
             self.tokenize = word_tokenize
 

--- a/tests/core/test_tokenize.py
+++ b/tests/core/test_tokenize.py
@@ -6,7 +6,7 @@
 import unittest
 
 from pythainlp.tokenize import (
-    DEFAULT_WORD_DICT_TRIE,
+    word_dict_trie,
     Tokenizer,
     etcc,
     longest,
@@ -261,7 +261,7 @@ class DetokenizeTestCase(unittest.TestCase):
 
 class TokenizeTestCase(unittest.TestCase):
     def test_Tokenizer(self):
-        _tokenizer = Tokenizer(DEFAULT_WORD_DICT_TRIE)
+        _tokenizer = Tokenizer(word_dict_trie())
         self.assertEqual(_tokenizer.word_tokenize(""), [])
         _tokenizer.set_tokenize_engine("longest")
         self.assertEqual(_tokenizer.word_tokenize(None), [])

--- a/tests/extra/testx_tokenize.py
+++ b/tests/extra/testx_tokenize.py
@@ -8,7 +8,7 @@
 import unittest
 
 from pythainlp.tokenize import (
-    DEFAULT_WORD_DICT_TRIE,
+    word_dict_trie,
     attacut,
     deepcut,
     nercut,
@@ -275,12 +275,12 @@ class WordTokenizeDeepcutTestCase(unittest.TestCase):
     def test_deepcut(self):
         self.assertEqual(deepcut.segment(None), [])
         self.assertEqual(deepcut.segment(""), [])
-        self.assertIsNotNone(deepcut.segment("ทดสอบ", DEFAULT_WORD_DICT_TRIE))
+        self.assertIsNotNone(deepcut.segment("ทดสอบ", word_dict_trie()))
         self.assertIsNotNone(deepcut.segment("ทดสอบ", ["ทด", "สอบ"]))
         self.assertIsNotNone(word_tokenize("ทดสอบ", engine="deepcut"))
         self.assertIsNotNone(
             word_tokenize(
-                "ทดสอบ", engine="deepcut", custom_dict=DEFAULT_WORD_DICT_TRIE
+                "ทดสอบ", engine="deepcut", custom_dict=word_dict_trie()
             )
         )
 


### PR DESCRIPTION
### What does this changes

Refactor by moving expensive loading variable into LRU cached function

### What was wrong

Most of the variables, tokenizer and tries, are initialized in the module scope, so when we do `import pythainlp`, this will unnecessarily load everything into the RAM. This also affect the import time too.

### How this fixes it

I move everything inside the function to prevent sudden execution (lazy) and wrap it with `functools.lru_cache` to cache the result for future access.

This is the minimal script to test the behavior
```py
# test.py
import time
import tracemalloc

tracemalloc.start()
start = time.perf_counter()

import pythainlp

end = time.perf_counter()

# Capture snapshot AFTER imports
snapshot = tracemalloc.take_snapshot()

current, peak = tracemalloc.get_traced_memory()
tracemalloc.stop()

print(f"Version: {pythainlp.__version__}")

# Top memory users by file
top_stats = snapshot.statistics("filename")

print("\nTop 10 memory allocations by file:")
for stat in top_stats[:10]:
    print(f"{stat.traceback[0].filename}: {stat.size / 1e6:.3f} MB")

print(f"\nCurrent memory: {current / 1e6:.3f} MB")
print(f"Peak memory: {peak / 1e6:.3f} MB")
print(f"Import time: {end - start:.4f}s")
```

### Branch `dev`
```
Version: 5.2.0

Top 10 memory allocations by file:
/home/nim/Project/pythainlp/pythainlp/util/trie.py: 186.240 MB
/home/nim/Project/pythainlp/pythainlp/corpus/core.py: 11.781 MB
/home/nim/Project/pythainlp/pythainlp/corpus/tnc.py: 3.074 MB
<frozen importlib._bootstrap_external>: 1.900 MB
/usr/lib/python3.12/collections/__init__.py: 0.961 MB
/home/nim/Project/pythainlp/pythainlp/util/wordtonum.py: 0.506 MB
<frozen importlib._bootstrap>: 0.304 MB
/usr/lib/python3.12/typing.py: 0.184 MB
/home/nim/Project/pythainlp/pythainlp/util/emojiconv.py: 0.137 MB
<frozen abc>: 0.075 MB

Current memory: 205.733 MB
Peak memory: 222.194 MB
Import time: 2.6567s
```

### This PR
```
Version: 5.2.0

Top 10 memory allocations by file:
<frozen importlib._bootstrap_external>: 1.906 MB
<frozen importlib._bootstrap>: 0.305 MB
/usr/lib/python3.12/typing.py: 0.185 MB
/home/nim/Project/pythainlp/pythainlp/util/emojiconv.py: 0.137 MB
/usr/lib/python3.12/re/_compiler.py: 0.137 MB
/home/nim/Project/pythainlp/pythainlp/corpus/core.py: 0.110 MB
<frozen abc>: 0.074 MB
/usr/lib/python3.12/ast.py: 0.065 MB
/usr/lib/python3.12/sysconfig.py: 0.036 MB
/usr/lib/python3.12/re/_parser.py: 0.035 MB

Current memory: 3.402 MB
Peak memory: 3.559 MB
Import time: 0.1471s
```
Import time is ~18x faster and peak RAM is reduced by ~62x

### Your checklist for this pull request

<!--- Please review the guidelines for contributing to this repository at: -->
<!--- https://github.com/PyThaiNLP/pythainlp/blob/dev/CONTRIBUTING.md -->

- [ ] Passed code styles and structures
- [ ] Passed code linting checks and unit test
