### PR TITLE
Run unittest only when there is a code change

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -10,14 +10,10 @@ on:
       - "bin/**"
       - "build_tools/**"
       - "pythainlp/**"
-      - "requirements/**"
       - "tests/**"
       - "Makefile"
       - "MANIFEST.in"
       - "pyproject.toml"
-      - "requirements.txt"
-      - "setup.cfg"
-      - "setup.py"
       - "tox.ini"
   pull_request:
     branches:
@@ -27,14 +23,10 @@ on:
       - "bin/**"
       - "build_tools/**"
       - "pythainlp/**"
-      - "requirements/**"
       - "tests/**"
       - "Makefile"
       - "MANIFEST.in"
       - "pyproject.toml"
-      - "requirements.txt"
-      - "setup.cfg"
-      - "setup.py"
       - "tox.ini"
 
 jobs:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -5,15 +5,37 @@ name: Unit test
 
 on:
   push:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
+    paths:
+      - ".github/workflows/**"
+      - "bin/**"
+      - "build_tools/**"
+      - "pythainlp/**"
+      - "requirements/**"
+      - "tests/**"
+      - "Makefile"
+      - "MANIFEST.in"
+      - "pyproject.toml"
+      - "requirements.txt"
+      - "setup.cfg"
+      - "setup.py"
+      - "tox.ini"
   pull_request:
     branches:
       - dev
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
+    paths:
+      - ".github/workflows/**"
+      - "bin/**"
+      - "build_tools/**"
+      - "pythainlp/**"
+      - "requirements/**"
+      - "tests/**"
+      - "Makefile"
+      - "MANIFEST.in"
+      - "pyproject.toml"
+      - "requirements.txt"
+      - "setup.cfg"
+      - "setup.py"
+      - "tox.ini"
 
 jobs:
   unittest:


### PR DESCRIPTION
The unittest workflow is very expensive.

Try to limit the triggers.
Only run the workflow when there is a change in Python code or in relevant configuration file.
