### PR TITLE
Fix pypi-test workflow

### DIFF
--- a/.github/workflows/pypi-test.yml
+++ b/.github/workflows/pypi-test.yml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2016-2026 PyThaiNLP Project
 # SPDX-License-Identifier: CC0-1.0
 
+# Check that the package can be installed from PyPI and run tests
+
 name: PyPI Unit test
 
 on:
@@ -30,17 +32,20 @@ jobs:
         python -m nltk.downloader omw-1.4
     - name: Test
       run: |
-        mkdir pythainlp_test
+        set -euo pipefail
+        mkdir -p pythainlp_test
         cd pythainlp_test
+        # Download sdist from PyPI
         pip download --no-binary=:all: --no-dependencies pythainlp
-        file="find . -name *.tar.gz"
-        file=$(eval "$file")
-        tar -xvzf $file --one-top-level
-        second="/"
-        path=${file//.tar.gz/$second}
-        cd $path
-        ls
-        cd tests
-        mkdir tests
-        mv data tests/
-        python -m unittest discover
+        archive=$(ls -1 *.tar.gz | head -n1)
+        echo "Found archive: $archive"
+        # Determine top-level folder inside archive, extract and cd into it
+        topdir=$(tar -tf "$archive" | head -n1 | cut -f1 -d"/")
+        tar -xzf "$archive"
+        cd "$topdir"
+        ls -la
+        # If test data is at package root and a tests dir exists, move it into tests
+        if [ -d data ] && [ -d tests ]; then
+          mv data tests/
+        fi
+        python -m unittest discover -v

--- a/.github/workflows/pypi-test.yml
+++ b/.github/workflows/pypi-test.yml
@@ -36,7 +36,7 @@ jobs:
         set -euo pipefail
         mkdir -p pythainlp_test
         cd pythainlp_test
-        # Download sdist from PyPI
+        # Download sdist from PyPI (the binary distribution does not contain tests)
         pip download --no-binary=:all: --no-dependencies pythainlp
         archive=$(ls -1 *.tar.gz | head -n1)
         echo "Found archive: $archive"

--- a/.github/workflows/pypi-test.yml
+++ b/.github/workflows/pypi-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Ideally be the minimum supported version, as in requires-python in pyproject.toml
+        # Ideally, this is the minimum supported version, as in requires-python in pyproject.toml
         python-version: ["3.9"]
 
     steps:

--- a/.github/workflows/pypi-test.yml
+++ b/.github/workflows/pypi-test.yml
@@ -3,7 +3,7 @@
 
 # Check that the package can be installed from PyPI and run tests
 
-name: PyPI Unit test
+name: Test package installed from PyPI
 
 on:
   schedule:
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"]
+        # Ideally be the minimum supported version, as in requires-python in pyproject.toml
+        python-version: ["3.9"]
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
It was failed for a year. Try to fix it.
The workflow supposed to install pythainlp package from PyPI (via pip) and run tests.