### PR TITLE
Remove act binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.ruff_cache/
 cover/
 tests/ptagger_temp*
 ptagger_temp*


### PR DESCRIPTION
Users can install it themselves. See https://github.com/nektos/act

It's quite big as well (12.8 MB).