### PR TITLE
Migrate build backend to hatchling

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,11 +30,7 @@ jobs:
       with:
         python-version: "3.12"
     - name: Install build tools and doc build tools
-      run: |
-        pip install --upgrade "pip<24.1" "setuptools>=69.0.0,<=73.0.1"
-      # pip<24.1 because https://github.com/omry/omegaconf/pull/1195
-      # setuptools>=65.0.2 because https://github.com/pypa/setuptools/commit/d03da04e024ad4289342077eef6de40013630a44#diff-9ea6e1e3dde6d4a7e08c7c88eceed69ca745d0d2c779f8f85219b22266efff7fR1
-      # setuptools<=73.0.1 because https://github.com/pypa/setuptools/issues/4620
+      run: pip install --upgrade pip
     - name: Install PyThaiNLP
       run: pip install ".[docs]"
     - name: Build sphinx documentation

--- a/.github/workflows/pypi-test.yml
+++ b/.github/workflows/pypi-test.yml
@@ -33,7 +33,7 @@ jobs:
       env:
         SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL: True
       run: |
-        python -m pip install --upgrade "pip<24.1" setuptools
+        python -m pip install --upgrade pip
         python -m pip install ".[compact]"
         python -m nltk.downloader omw-1.4
 

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -21,7 +21,6 @@ on:
       - "pythainlp/**"
       - "tests/**"
       - "Makefile"
-      - "MANIFEST.in"
       - "pyproject.toml"
   pull_request:
     branches:
@@ -33,7 +32,6 @@ on:
       - "pythainlp/**"
       - "tests/**"
       - "Makefile"
-      - "MANIFEST.in"
       - "pyproject.toml"
 
 # Avoid duplicate runs for the same source branch and repository.
@@ -94,11 +92,8 @@ jobs:
 
       - name: Install build tools
         run: |
-          pip install --upgrade "pip<24.1" "setuptools>=69.0.0,<=73.0.1"
+          pip install --upgrade pip
           pip install coverage coveralls
-        # pip<24.1 because https://github.com/omry/omegaconf/pull/1195
-        # setuptools>=65.0.2 because https://github.com/pypa/setuptools/commit/d03da04e024ad4289342077eef6de40013630a44#diff-9ea6e1e3dde6d4a7e08c7c88eceed69ca745d0d2c779f8f85219b22266efff7fR1
-        # setuptools<=73.0.1 because https://github.com/pypa/setuptools/issues/4620
 
       - name: Install ICU (macOS)
         if: startsWith(matrix.os, 'macos-')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The minimum requirement is now Python 3.9.
   when the var is set; auto-downloads otherwise (#1306)
 - Callers raise `FileNotFoundError` with download instructions when
   a corpus path cannot be resolved (#1306)
+- Migrate build backend to `hatchling` (#1311)
 
 ### Deprecated
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,0 @@
-include CONTRIBUTING.md
-include LICENSE
-include README.md
-include README_TH.md
-
-recursive-include tests *
-recursive-exclude * __pycache__
-recursive-exclude * *.py[co]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
-requires = ["setuptools>=69.0.0", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "pythainlp"
@@ -297,14 +297,16 @@ issues = "https://github.com/PyThaiNLP/pythainlp/issues"
 [project.scripts]
 thainlp = "pythainlp.__main__:main"
 
-[tool.setuptools]
-include-package-data = true
+[tool.hatch.build.targets.wheel]
+packages = ["pythainlp"]
 
-[tool.setuptools.packages.find]
-exclude = ["tests", "tests.*"]
-
-[tool.setuptools.package-data]
-pythainlp = ["corpus/*"]
+[tool.hatch.build.targets.sdist]
+include = [
+    "pythainlp/",
+    "tests/",
+    "LICENSE",
+    "README.md",
+]
 
 # Bumpversion configuration
 [tool.bumpversion]


### PR DESCRIPTION
### What do these changes do

Migrate build backend to [hatchling](https://hatch.pypa.io/1.16/config/build/).

Simplify configurations, remove the need of MANIFEST.in.

Hacthling also excludes `__pycache__` and `*.py[co]` by default.


- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test
