### PR TITLE
Raise errors when get unsupported value / instance not ready

### DIFF
--- a/pythainlp/tokenize/budoux.py
+++ b/pythainlp/tokenize/budoux.py
@@ -56,6 +56,9 @@ def segment(text: str) -> list[str]:
             _parser = _init_parser()
         parser = _parser
 
+    if parser is None:
+        raise RuntimeError("Failed to initialize BudouX parser")
+
     result = cast("list[str]", parser.parse(text))
 
     return result

--- a/pythainlp/transliterate/thai2rom.py
+++ b/pythainlp/transliterate/thai2rom.py
@@ -245,6 +245,10 @@ class Attn(nn.Module):
                 attn_energies,
                 self.other.unsqueeze(0).expand(*hidden.size()).transpose(1, 2),
             ).squeeze(2)
+        else:
+            raise ValueError(
+                f"Unsupported attention method: {self.method!r}"
+            )
 
         attn_energies = attn_energies.masked_fill(mask == 0, -1e10)
 

--- a/pythainlp/transliterate/thaig2p.py
+++ b/pythainlp/transliterate/thaig2p.py
@@ -267,6 +267,10 @@ class Attn(nn.Module):
                 attn_energies,
                 self.other.unsqueeze(0).expand(*hidden.size()).transpose(1, 2),
             ).squeeze(2)
+        else:
+            raise ValueError(
+                f"Unsupported attention method: {self.method!r}"
+            )
 
         attn_energies = attn_energies.masked_fill(mask == 0, -1e10)
 

--- a/pythainlp/util/thai_lunar_date.py
+++ b/pythainlp/util/thai_lunar_date.py
@@ -407,8 +407,14 @@ def to_lunar_date(input_date: date) -> str:
         days_in_month = _DAYS_355
     elif last_day == 384:
         days_in_month = _DAYS_384
+    else:
+        raise ValueError(
+            f"Unexpected last_day value: {last_day!r}. "
+            "Expected 354, 355, or 384."
+        )
 
     days_of_year = day_from_one
+    th_m = 0
     for j, days in enumerate(days_in_month, start=1):
         th_m = j
         if 0 < days_of_year <= days:


### PR DESCRIPTION
### What do these changes do

Let the library raises errors when
- lunar calendar gets unsupported last day value
- tokenizer or parser instance is not initialized properly

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test
