### PR TITLE
fix: catch TypeError instead of ValueError in sent_tokenize

### DIFF
--- a/pythainlp/tokenize/core.py
+++ b/pythainlp/tokenize/core.py
@@ -488,7 +488,7 @@ def sent_tokenize(
     if isinstance(text, list):
         try:
             original_text = "".join(text)
-        except ValueError:
+        except TypeError:
             return []
     else:
         original_text = str(text)

--- a/tests/core/test_tokenize.py
+++ b/tests/core/test_tokenize.py
@@ -333,6 +333,16 @@ class TokenizeTestCase(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             sent_tokenize("ฉันไป กิน", engine="XX")  # engine does not exist
+        # Reproduce: list with non-string items should return []
+        # instead of raising TypeError (str.join raises TypeError, not ValueError)
+        self.assertEqual(
+            sent_tokenize(["สวัสดี", 123], engine="whitespace+newline"),
+            [],
+        )
+        self.assertEqual(
+            sent_tokenize(["สวัสดี", None], engine="whitespace+newline"),
+            [],
+        )
 
     def test_subword_tokenize(self):
         self.assertEqual(subword_tokenize(None), [])  # type: ignore[arg-type]

--- a/tests/core/test_tokenize.py
+++ b/tests/core/test_tokenize.py
@@ -336,7 +336,7 @@ class TokenizeTestCase(unittest.TestCase):
         # Reproduce: list with non-string items should return []
         # instead of raising TypeError (str.join raises TypeError, not ValueError)
         self.assertEqual(
-            sent_tokenize(["สวัสดี", 123], engine="whitespace+newline"),
+            sent_tokenize(["สวัสดี", 123], engine="whitespace+newline"),  # type: ignore
             [],
         )
         self.assertEqual(

--- a/tests/core/test_tokenize.py
+++ b/tests/core/test_tokenize.py
@@ -340,7 +340,7 @@ class TokenizeTestCase(unittest.TestCase):
             [],
         )
         self.assertEqual(
-            sent_tokenize(["สวัสดี", None], engine="whitespace+newline"),
+            sent_tokenize(["สวัสดี", None], engine="whitespace+newline"),  # type: ignore
             [],
         )
 


### PR DESCRIPTION
### What do these changes do

Fix `sent_tokenize` raising uncaught `TypeError` when list input contains non-string items — the code catches `ValueError` but `str.join()` raises `TypeError`

Fixes #1373

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test