### PR TITLE
fix: use full version string in _check_version for <= and < operators

### DIFF
--- a/pythainlp/corpus/core.py
+++ b/pythainlp/corpus/core.py
@@ -632,10 +632,10 @@ def _check_version(cause: str) -> bool:
         check = _version2int(temp_parts[0]) < v < _version2int(temp_parts[1])
     elif cause.startswith("<="):
         temp = cause.replace("<=", "")
-        check = v <= _version2int(temp[0])
+        check = v <= _version2int(temp)
     elif cause.startswith("<"):
         temp = cause.replace("<", "")
-        check = v < _version2int(temp[0])
+        check = v < _version2int(temp)
 
     return check
 

--- a/tests/core/test_corpus.py
+++ b/tests/core/test_corpus.py
@@ -628,8 +628,8 @@ class DefensiveLoadingTestCase(unittest.TestCase):
         # only gets the first character of the version string instead
         # of the full version, causing incorrect comparisons.
         self.assertTrue(_check_version("*"))
-        self.assertTrue(_check_version("<=9.9.9"))
-        self.assertTrue(_check_version("<9.9.9"))
+        self.assertTrue(_check_version("<=9999.9.9"))
+        self.assertTrue(_check_version("<9999.9.9"))
         self.assertFalse(_check_version("<=0.0.1"))
         self.assertFalse(_check_version("<0.0.1"))
         # version2int consistency

--- a/tests/core/test_corpus.py
+++ b/tests/core/test_corpus.py
@@ -6,6 +6,7 @@ import os
 import unittest
 from unittest.mock import mock_open, patch
 
+from pythainlp.corpus.core import _check_version, _version2int
 from pythainlp.corpus import (
     countries,
     download,
@@ -621,3 +622,16 @@ class DefensiveLoadingTestCase(unittest.TestCase):
                         self.assertEqual(
                             result["synonym"], [["cat", "kitty"], ["dog"]]
                         )
+
+    def test_check_version(self):
+        # Reproduce: _check_version with <= and < used temp[0] which
+        # only gets the first character of the version string instead
+        # of the full version, causing incorrect comparisons.
+        self.assertTrue(_check_version("*"))
+        self.assertTrue(_check_version("<=9.9.9"))
+        self.assertTrue(_check_version("<9.9.9"))
+        self.assertFalse(_check_version("<=0.0.1"))
+        self.assertFalse(_check_version("<0.0.1"))
+        # version2int consistency
+        self.assertNotEqual(_version2int("5.3.3"), _version2int("5"))
+        self.assertEqual(_version2int("2.0"), _version2int("2.0.0"))

--- a/tests/core/test_corpus.py
+++ b/tests/core/test_corpus.py
@@ -6,7 +6,6 @@ import os
 import unittest
 from unittest.mock import mock_open, patch
 
-from pythainlp.corpus.core import _check_version, _version2int
 from pythainlp.corpus import (
     countries,
     download,
@@ -32,6 +31,7 @@ from pythainlp.corpus import (
     tnc,
     ttc,
 )
+from pythainlp.corpus.core import _check_version, _version2int
 from pythainlp.corpus.util import revise_newmm_default_wordset
 
 

--- a/tests/core/test_corpus.py
+++ b/tests/core/test_corpus.py
@@ -630,6 +630,8 @@ class DefensiveLoadingTestCase(unittest.TestCase):
         self.assertTrue(_check_version("*"))
         self.assertTrue(_check_version("<=9999.9.9"))
         self.assertTrue(_check_version("<9999.9.9"))
+        self.assertTrue(_check_version(">=0.0.1"))
+        self.assertTrue(_check_version(">0.0.1"))
         self.assertFalse(_check_version("<=0.0.1"))
         self.assertFalse(_check_version("<0.0.1"))
         # version2int consistency


### PR DESCRIPTION
### What do these changes do

Fix `_check_version` using `temp[0]` (first character) instead of `temp` (full version string) for `<=` and `<` operators

Fixes #1389

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test