### PR TITLE
fix: remove unconditional overwrite that disables teacher forcing in Seq2Seq

### DIFF
--- a/pythainlp/transliterate/thai2rom.py
+++ b/pythainlp/transliterate/thai2rom.py
@@ -423,8 +423,6 @@ class Seq2Seq(nn.Module):  # type: ignore[misc]
             else:
                 decoder_input = topi.detach()
 
-            decoder_input = topi.detach()
-
             if inference and decoder_input == end_token:
                 return outputs[:di]
 


### PR DESCRIPTION
### What do these changes do

Remove unconditional `decoder_input = topi.detach()` that overwrites the teacher forcing if-else block

Fixes #1390

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test