### PR TITLE
fix: guard han_solo list_cut[-1] and narrow longest.py exception catch

### DIFF
--- a/pythainlp/tokenize/han_solo.py
+++ b/pythainlp/tokenize/han_solo.py
@@ -162,7 +162,7 @@ def segment(text: str) -> list[str]:
     y_pred = tagger.tag(x)
     list_cut = []
     for j, k in zip(list(text), y_pred):
-        if k == "1":
+        if k == "1" or not list_cut:
             list_cut.append(j)
         else:
             list_cut[-1] += j

--- a/pythainlp/tokenize/han_solo.py
+++ b/pythainlp/tokenize/han_solo.py
@@ -160,7 +160,7 @@ def segment(text: str) -> list[str]:
     tagger = _get_tagger()
     x = _to_feature.featurize(text)["X"]
     y_pred = tagger.tag(x)
-    list_cut = []
+    list_cut: list[str] = []
     for j, k in zip(list(text), y_pred):
         if k == "1" or not list_cut:
             list_cut.append(j)

--- a/pythainlp/tokenize/longest.py
+++ b/pythainlp/tokenize/longest.py
@@ -105,7 +105,7 @@ class LongestMatchTokenizer:
                     return text[0 : len_word_valid + 1]
                 else:
                     return word_valid
-            except BaseException:
+            except IndexError:
                 return word_valid
         else:
             return ""


### PR DESCRIPTION
### What do these changes do

- Guard `list_cut[-1]` in han_solo when list is empty
- Narrow `except BaseException` to `except IndexError` in longest

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test