### PR TITLE
fix: metasound truncation order, add 4 missing consonants per paper

### DIFF
--- a/pythainlp/soundex/metasound.py
+++ b/pythainlp/soundex/metasound.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 _CONS_THANTHAKHAT: str = "กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรลวศษสหฬอฮ์"
 _THANTHAKHAT: str = "์"  # \u0e4c
 _C1: str = "กขฃคฆฅ"  # sound K -> coded letter 1
-_C2: str = "จฉชฌซฐทฒดฎตสศษ"  # D -> 2
+_C2: str = "จฉชฌซฐฏทฑฒถธดฎตสศษ"  # D -> 2
 _C3: str = "ฟฝพผภบป"  # B -> 3
 _C4: str = "ง"  # NG -> 4
 _C5: str = "ลฬรนณฦญ"  # N -> 5
@@ -78,7 +78,8 @@ def metasound(text: str, length: int = 4) -> str:
             chars[i] = " "
         i += 1
 
-    # retain first consonant, encode the rest
+    # filter out spaces left by karan removal, then truncate
+    chars = [c for c in chars if c != " "]
     chars = chars[:length]
     i = 1
     while i < len(chars):

--- a/pythainlp/soundex/prayut_and_somchaip.py
+++ b/pythainlp/soundex/prayut_and_somchaip.py
@@ -18,7 +18,7 @@ from pythainlp import thai_characters
 
 _C0: str = "AEIOUHWYอ"
 _C1: str = "BFPVบฝฟปผพภว"
-_C2: str = "CGJKQSXZขฃคฅฆฉขฌกจซศษส"
+_C2: str = "CGJKQSXZขฃคฅฆฉฌกจซศษส"
 _C3: str = "DTฎดฏตฐฑฒถทธ"
 _C4: str = "Lลฬ"
 _C5: str = "MNมณน"

--- a/tests/core/test_soundex.py
+++ b/tests/core/test_soundex.py
@@ -169,3 +169,18 @@ class SoundexTestCase(unittest.TestCase):
             short_code, long_code
         )
         self.assertAlmostEqual(similarity_diff_len, 5 / 11, places=4)
+
+    def test_metasound_karan_truncation(self):
+        # B1: karan spaces should be filtered before truncation
+        # "สรรค์พล" has karan in middle — พ must not be lost
+        self.assertEqual(metasound("สรรค์พล", 4), "ส553")
+        self.assertEqual(metasound("รักษ์นา", 4), "ร150")
+        # No karan — should be unaffected
+        self.assertEqual(metasound("บูรณการ", 4), "บ551")
+
+    def test_metasound_consonant_classification(self):
+        # B2: ถ,ธ,ฏ,ฑ should be class 2 (same sound as ท,ด)
+        self.assertEqual(metasound("กถ", 2), "ก2")
+        self.assertEqual(metasound("กธ", 2), "ก2")
+        self.assertEqual(metasound("กฏ", 2), "ก2")
+        self.assertEqual(metasound("กฑ", 2), "ก2")


### PR DESCRIPTION
### What do these changes do

Fix metasound:
- Filter karan spaces before truncating to requested length
- Add ฏ, ฑ, ถ, ธ to `_C2` per the original paper (Snae & Brückner, 2009, Table p.507)
- Remove duplicate ข in prayut_and_somchaip

Fixes #1383

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test