### PR TITLE
fix: apply เอ็ด rule for ones=1 in hundreds and above

### DIFF
--- a/pythainlp/util/numtoword.py
+++ b/pythainlp/util/numtoword.py
@@ -121,6 +121,10 @@ def num_to_thaiword(number: Optional[int]) -> str:
     for search, replac in _EXCEPTIONS.items():
         output = output.replace(search, replac)
 
+    # เอ็ด rule: trailing หนึ่ง in ones place (after any place marker)
+    if number != 1 and number != -1 and output.endswith("หนึ่ง"):
+        output = output[: -len("หนึ่ง")] + "เอ็ด"
+
     if number_temp < 0:
         output = "ลบ" + output
 

--- a/tests/core/test_util.py
+++ b/tests/core/test_util.py
@@ -141,6 +141,10 @@ class UtilTestCase(unittest.TestCase):
         self.assertEqual(num_to_thaiword(0), "ศูนย์")
         self.assertEqual(num_to_thaiword(112), "หนึ่งร้อยสิบสอง")
         self.assertEqual(num_to_thaiword(-273), "ลบสองร้อยเจ็ดสิบสาม")
+        # เอ็ด rule: ones=1 must use เอ็ด when number > 1
+        self.assertEqual(num_to_thaiword(101), "หนึ่งร้อยเอ็ด")
+        self.assertEqual(num_to_thaiword(1001), "หนึ่งพันเอ็ด")
+        self.assertEqual(num_to_thaiword(1000001), "หนึ่งล้านเอ็ด")
 
         self.assertEqual(thaiword_to_num("ศูนย์"), 0)
         self.assertEqual(thaiword_to_num("แปด"), 8)

--- a/tests/core/test_util.py
+++ b/tests/core/test_util.py
@@ -143,6 +143,7 @@ class UtilTestCase(unittest.TestCase):
         self.assertEqual(num_to_thaiword(-273), "ลบสองร้อยเจ็ดสิบสาม")
         # เอ็ด rule: ones=1 must use เอ็ด when number > 1
         self.assertEqual(num_to_thaiword(1), "หนึ่ง")
+        self.assertEqual(num_to_thaiword(-1), "ลบหนึ่ง")
         self.assertEqual(num_to_thaiword(101), "หนึ่งร้อยเอ็ด")
         self.assertEqual(num_to_thaiword(1001), "หนึ่งพันเอ็ด")
         self.assertEqual(num_to_thaiword(1000001), "หนึ่งล้านเอ็ด")

--- a/tests/core/test_util.py
+++ b/tests/core/test_util.py
@@ -142,6 +142,7 @@ class UtilTestCase(unittest.TestCase):
         self.assertEqual(num_to_thaiword(112), "หนึ่งร้อยสิบสอง")
         self.assertEqual(num_to_thaiword(-273), "ลบสองร้อยเจ็ดสิบสาม")
         # เอ็ด rule: ones=1 must use เอ็ด when number > 1
+        self.assertEqual(num_to_thaiword(1), "หนึ่ง")
         self.assertEqual(num_to_thaiword(101), "หนึ่งร้อยเอ็ด")
         self.assertEqual(num_to_thaiword(1001), "หนึ่งพันเอ็ด")
         self.assertEqual(num_to_thaiword(1000001), "หนึ่งล้านเอ็ด")


### PR DESCRIPTION
### What do these changes do

Fix `num_to_thaiword(101)` returning หนึ่งร้อยหนึ่ง instead of หนึ่งร้อยเอ็ด

Fixes #1385

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test