### PR TITLE
fix: build WSD Trie after populating dictionary, not before

### DIFF
--- a/pythainlp/wsd/core.py
+++ b/pythainlp/wsd/core.py
@@ -12,16 +12,16 @@ from pythainlp.util.trie import Trie
 _wsd_dict: dict[str, Union[list[str], list[list[str]]]] = thai_wsd_dict()
 _mean_all: dict[str, list[str]] = {}
 
-_all_word: set[str] = cast("set[str]", set(_mean_all.keys()))
-_TRIE: Trie = Trie(_all_word)
-_word_cut: Tokenizer = Tokenizer(custom_dict=_TRIE)
-
 words: list[str] = cast("list[str]", _wsd_dict["word"])
 meanings: list[list[str]] = cast("list[list[str]]", _wsd_dict["meaning"])
 i_word: str
 i_meanings: list[str]
 for i_word, i_meanings in zip(words, meanings):
     _mean_all[i_word] = i_meanings
+
+_all_word: set[str] = cast("set[str]", set(_mean_all.keys()))
+_TRIE: Trie = Trie(_all_word)
+_word_cut: Tokenizer = Tokenizer(custom_dict=_TRIE)
 
 _MODEL_CACHE: dict[str, _SentenceTransformersModel] = {}
 


### PR DESCRIPTION
### What do these changes do

Fix WSD Trie being built from empty dictionary — move construction after the population loop

Fixes #1387

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test