### PR TITLE
Add ValueError tests for nighit (PR 1377)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to
 - Full release notes: <https://github.com/PyThaiNLP/pythainlp/releases>
 - Commit history: <https://github.com/PyThaiNLP/pythainlp/compare/v5.3.3...v5.3.4>
 
+## [Unreleased]
+
+## Changed
+
+- Improve guardrails in `check_sara()` and `nighit()`
+
 ## [5.3.4] - 2026-04-02
 
 ### Fixed

--- a/pythainlp/khavee/core.py
+++ b/pythainlp/khavee/core.py
@@ -217,7 +217,7 @@ class KhaveeVerifier:
             sara.append("เอือ")
 
         if not sara:
-            return "Can't find Sara in this word"
+            return ""
 
         return sara[0]
 

--- a/tests/core/test_khavee.py
+++ b/tests/core/test_khavee.py
@@ -258,3 +258,9 @@ class KhaveeCheckSaraEdgeCasesTestCase(unittest.TestCase):
 
     def test_returns_string(self):
         self.assertIsInstance(self.kv.check_sara("เริง"), str)
+
+    def test_empty_string_returns_empty(self):
+        self.assertEqual(self.kv.check_sara(""), "")
+
+    def test_empty_string_after_removing_karun_returns_empty(self):
+        self.assertEqual(self.kv.check_sara("ก์"), "")

--- a/tests/core/test_khavee.py
+++ b/tests/core/test_khavee.py
@@ -264,3 +264,8 @@ class KhaveeCheckSaraEdgeCasesTestCase(unittest.TestCase):
 
     def test_empty_string_after_removing_karun_returns_empty(self):
         self.assertEqual(self.kv.check_sara("ก์"), "")
+
+    def test_empty_string_after_removing_tone_marks_returns_empty(self):
+        self.assertEqual(
+            self.kv.check_sara("\u0e48"), ""
+        )  # The string contains only Thai Mai Ek tone mark

--- a/tests/core/test_morpheme.py
+++ b/tests/core/test_morpheme.py
@@ -10,15 +10,26 @@ from pythainlp.morpheme import is_native_thai, nighit
 class MorphemeTestCase(unittest.TestCase):
     def test_nighit(self):
         self.assertEqual(nighit("สํ", "คีต"), "สังคีต")
+        self.assertEqual(
+            nighit("สํ", "คีต "), "สังคีต"
+        )  # w2 has trailing space, should still work
+        self.assertEqual(
+            nighit("สํ ", "คีต"), "สังคีต"
+        )  # w1 has trailing space, should still work
         self.assertEqual(nighit("สํ", "จร"), "สัญจร")
         self.assertEqual(nighit("สํ", "ฐาน"), "สัณฐาน")
         self.assertEqual(nighit("สํ", "นิษฐาน"), "สันนิษฐาน")
         self.assertEqual(nighit("สํ", "ปทา"), "สัมปทา")
         self.assertEqual(nighit("สํ", "โยค"), "สังโยค")
+        self.assertEqual(nighit("", "คีต"), "คีต")  # w1 is empty, should return w2
+        self.assertEqual(nighit("สํ", ""), "สํ")  # w2 is empty, should return w1
+
         with self.assertRaises(NotImplementedError):
             nighit("abc", "คีต")  # w1 does not end with ํ and len > 2
         with self.assertRaises(NotImplementedError):
             nighit("สํ", "มาร")  # consonant ม is not in any supported group
+        with self.assertRaises(ValueError):
+            nighit("สํ", "123")  # w2 does not contain any Thai consonant
 
     def test_is_native_thai(self):
         self.assertFalse(is_native_thai(None))  # type: ignore[arg-type]


### PR DESCRIPTION
PR #1377 adds guardrails to nighit().
This PR add tests to those guardrails.

(Need to merge #1377 first)

- [x] Passed code styles and structures
- [ ] Passed code linting checks and unit test
