### PR TITLE
fix: remove duplicate .replace mid-tone in _clean_ipa

### DIFF
--- a/pythainlp/soundex/sound.py
+++ b/pythainlp/soundex/sound.py
@@ -28,7 +28,6 @@ def _clean_ipa(ipa: str) -> str:
         .replace("˨˩", "")
         .replace("˦˥", "")
         .replace("˧", "")
-        .replace("˧", "")
         .replace(" .", ".")
         .replace(". ", ".")
         .strip()


### PR DESCRIPTION
## What do these changes do?

Remove a duplicate `.replace("ˈ", "")` call in the `_clean_ipa()` function in `pythainlp/soundex/sound.py`. Line 31 is an exact duplicate of line 30 and is dead code.

## What was wrong?

The function had two identical consecutive `.replace("ˈ", "")` calls:
```python
.replace("ˈ", "")  # line 30 - removes mid tone
.replace("ˈ", "")  # line 31 - DUPLICATE, dead code
```

After line 30 removes all mid-tone characters, line 31 has no effect. This was likely introduced via copy-paste.

## How this fixes it

Removes the duplicate line, reducing dead code as per the project's CONTRIBUTING.md guidelines.

## Checklist
- [x] Code follows the project style guidelines
- [x] No dead code
- [x] No behavior change (functionality is identical)