### PR TITLE
fix(transliterate): romanize royin words containing ฤ

### DIFF
--- a/pythainlp/transliterate/royin.py
+++ b/pythainlp/transliterate/royin.py
@@ -274,7 +274,10 @@ def _romanize(word: str) -> str:
         return ""
 
     word = _replace_vowels(_normalize(word))
-    consonants = _RE_CONSONANT.findall(word)
+    # Use the same membership test as _replace_consonants(), which treats
+    # every key of _CONSONANTS as a consonant. _RE_CONSONANT only matches
+    # thai_consonants, so it misses ฤ and the two lists fall out of sync.
+    consonants = [c for c in word if c in _CONSONANTS]
 
     # 2-character word, all consonants
     if len(word) == 2 and len(consonants) == 2:

--- a/tests/core/test_transliterate.py
+++ b/tests/core/test_transliterate.py
@@ -38,6 +38,13 @@ BASIC_TESTS = {
     "ชารินทร์": "charin",
 }
 
+# words containing ฤ (U+0E24 THAI CHARACTER RU), see issue #1444
+RU_TESTS = {
+    "ฤก": "rueok",
+    "ฤดู": "rueadu",
+    "ฤทธิ์": "rueot",
+}
+
 # these are set of two-syllable words,
 # to test if the transliteration/romanization is consistent, say
 # romanize(1+2) = romanize(1) + romanize(2)
@@ -58,6 +65,12 @@ class TransliterateTestCase(unittest.TestCase):
 
     def test_romanize_royin_basic(self):
         for word, expect in BASIC_TESTS.items():
+            self.assertEqual(romanize(word, engine="royin"), expect)  # type: ignore[arg-type]
+
+    def test_romanize_royin_ru(self):
+        # ฤ (U+0E24) is a key of _CONSONANTS but is not in thai_consonants,
+        # so it used to desynchronise the consonant list and raise IndexError.
+        for word, expect in RU_TESTS.items():
             self.assertEqual(romanize(word, engine="royin"), expect)  # type: ignore[arg-type]
 
     def test_romanize_royin_consistency(self):

--- a/tests/core/test_transliterate.py
+++ b/tests/core/test_transliterate.py
@@ -69,7 +69,7 @@ class TransliterateTestCase(unittest.TestCase):
 
     def test_romanize_royin_ru(self):
         # ฤ (U+0E24) is a key of _CONSONANTS but is not in thai_consonants,
-        # so it used to desynchronise the consonant list and raise IndexError.
+        # so it used to desynchronize the consonant list and raise IndexError.
         for word, expect in RU_TESTS.items():
             self.assertEqual(romanize(word, engine="royin"), expect)  # type: ignore[arg-type]
 


### PR DESCRIPTION
### What do these changes do

Make `romanize(..., engine="royin")` handle words containing ฤ (U+0E24) instead of raising `IndexError`, and add a regression test for them.

### What was wrong

`_romanize()` built its consonant list with `_RE_CONSONANT`, which is compiled from `thai_consonants` and therefore does not match ฤ. `_replace_consonants()`, however, treats every key of `_CONSONANTS` — which does include ฤ — as a consonant and advances its index for each one. On a word containing ฤ the index ran past the end of the list, so `romanize("ฤดู", engine="royin")` raised `IndexError: string index out of range`.

### How this fixes it

The consonant list is now built with the same membership test the loop uses (`c in _CONSONANTS`), keeping the two in sync and letting ฤ romanize through its existing `_CONSONANTS` entry. ฤก→rueok, ฤดู→rueadu, ฤทธิ์→rueot; words without ฤ are byte-identical to before, including ฤ words that did not crash (พฤษภาคม, อังกฤษ, พฤหัสบดี, นฤมล, ทฤษฎี).

Fixes #1444

### Your checklist for this pull request

- [x] Passed code styles and structures
- [x] Passed code linting checks and unit test

`test_romanize_royin_ru` was added to `tests/core/test_transliterate.py` beside the existing royin tests; it fails without the source fix (the reported `IndexError`) and passes with it. `tests/core/test_transliterate.py` passes in full, and `ruff check` is clean on both changed files.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
